### PR TITLE
[v4] Include Channel and Guild Type codes

### DIFF
--- a/dis_interact/types/enums.py
+++ b/dis_interact/types/enums.py
@@ -134,6 +134,65 @@ class Message(IntEnum):
     GUILD_INVITE_REMINDER = 22
 
 
+class Intents(IntEnum):
+    """
+    Intent flags defined by the Discord API.
+    """
+
+    # Base intents, exactly from the API
+    GUILDS = 1 << 0
+    GUILD_MEMBERS = 1 << 1
+    GUILD_BANS = 1 << 2
+    GUILD_EMOJIS_AND_STICKERS = 1 << 3
+    GUILD_INTEGRATIONS = 1 << 4
+    GUILD_WEBHOOKS = 1 << 5
+    GUILD_INVITES = 1 << 6
+    GUILD_VOICE_STATES = 1 << 7
+    GUILD_PRESENCES = 1 << 8
+    GUILD_MESSAGES = 1 << 9
+    GUILD_MESSAGE_REACTIONS = 1 << 10
+    GUILD_MESSAGE_TYPING = 1 << 11
+    DIRECT_MESSAGES = 1 << 12
+    DIRECT_MESSAGE_REACTIONS = 1 << 13
+    DIRECT_MESSAGE_TYPING = 1 << 14
+
+    # Shortcuts/grouping/aliases
+    DEFAULT = (
+            GUILDS
+            | GUILD_BANS
+            | GUILD_EMOJIS_AND_STICKERS
+            | GUILD_INTEGRATIONS
+            | GUILD_WEBHOOKS
+            | GUILD_INVITES
+            | GUILD_VOICE_STATES
+            | GUILD_MESSAGES
+            | GUILD_MESSAGE_REACTIONS
+            | GUILD_MESSAGE_TYPING
+            | DIRECT_MESSAGES
+            | DIRECT_MESSAGE_REACTIONS
+            | DIRECT_MESSAGE_TYPING
+    )
+
+    MESSAGES = GUILD_MESSAGES | DIRECT_MESSAGES
+    REACTIONS = GUILD_MESSAGE_REACTIONS | DIRECT_MESSAGE_REACTIONS
+    TYPING = GUILD_MESSAGE_TYPING | DIRECT_MESSAGE_TYPING
+
+    PRIVILEGED = GUILD_PRESENCES | GUILD_MEMBERS
+
+    NONE = 0  # No intents
+    ALL = DEFAULT | PRIVILEGED  # All intents are the regular + "requested" intents.
+
+    @classmethod
+    def all(cls) -> int:
+        """Returns all of the intents."""
+        return cls.ALL
+
+    @classmethod
+    def default(cls) -> int:
+        """Returns the default intents."""
+        return cls.DEFAULT
+
+
 class Options(IntEnum):
     """
     Enumerable object of literal integers holding equivocal values of a slash command's option(s).

--- a/dis_interact/types/enums.py
+++ b/dis_interact/types/enums.py
@@ -82,6 +82,58 @@ class HTTPResponse(IntEnum):
     GATEWAY_UNAVAILABLE = 502
 
 
+class Channel(IntEnum):
+    """
+    Types of channels.
+
+    ..note::
+        While all of them are listed, not all of them would be used at this lib's scope.
+    """
+
+    GUILD_TEXT = 0
+    DM = 1
+    GUILD_VOICE = 2
+    GROUP_DM = 3
+    GUILD_CATEGORY = 4
+    GUILD_NEWS = 5
+    GUILD_STORE = 6
+    GUILD_NEWS_THREAD = 10
+    GUILD_PUBLIC_THREAD = 11
+    GUILD_PRIVATE_THREAD = 12
+    GUILD_STAGE_VOICE = 13
+
+
+class Message(IntEnum):
+    """Type of messages.
+
+    ..note::
+        While all of them are listed, not all of them would be used at this lib's scope.
+    """
+
+    DEFAULT = 0
+    RECIPIENT_ADD = 1
+    RECIPIENT_REMOVE = 2
+    CALL = 3
+    CHANNEL_NAME_CHANGE = 4
+    CHANNEL_ICON_CHANGE = 5
+    CHANNEL_PINNED_MESSAGE = 6
+    GUILD_MEMBER_JOIN = 7
+    USER_PREMIUM_GUILD_SUBSCRIPTION = 8
+    USER_PREMIUM_GUILD_SUBSCRIPTION_TIER_1 = 9
+    USER_PREMIUM_GUILD_SUBSCRIPTION_TIER_2 = 10
+    USER_PREMIUM_GUILD_SUBSCRIPTION_TIER_3 = 11
+    CHANNEL_FOLLOW_ADD = 12
+    GUILD_DISCOVERY_DISQUALIFIED = 14
+    GUILD_DISCOVERY_REQUALIFIED = 15
+    GUILD_DISCOVERY_GRACE_PERIOD_INITIAL_WARNING = 16
+    GUILD_DISCOVERY_GRACE_PERIOD_FINAL_WARNING = 17
+    THREAD_CREATED = 18
+    REPLY = 19
+    APPLICATION_COMMAND = 20
+    THREAD_STARTER_MESSAGE = 21
+    GUILD_INVITE_REMINDER = 22
+
+
 class Options(IntEnum):
     """
     Enumerable object of literal integers holding equivocal values of a slash command's option(s).
@@ -138,7 +190,7 @@ class Options(IntEnum):
                     # proven in 3.7.8+, 3.8.6+, 3.9+ definitively
                     return cls.MENTIONABLE
         if not hasattr(typing, "_GenericAlias"):  # py 3.6
-            if isinstance(t, typing._Union):  # noqa
+            if isinstance(_type, typing._Union):  # noqa
                 return cls.MENTIONABLE
 
         if issubclass(_type, float):  # Python floats are essentially doubles, compared to languages when it's separate.


### PR DESCRIPTION
## About this pull request

As the v4 route goes down we may need to include types of channels/guild objects as representative of the API.
This also includes Intents as of c846d6f, and their own respective methods

## Changes

This PR:
- Includes all Guild and Channel types (We won't use all of them per this lib's scope, but it's easier to read and interpret what's being received.
- Fixes typo of typechecking for Union, again
- Implement intents Enum

## Checklist

- [ ] I've run the `pre_push.py` script to format and lint code.
- [ ] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [ ] This adds something new.
- [ ] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
