### PR TITLE
Fix sync_commands with options, choices = []

### DIFF
--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -433,9 +433,8 @@ class SlashCommand:
         for guild in cmds["guild"]:
             cmds_formatted[guild] = cmds["guild"][guild]
 
-        for scope in cmds_formatted:
+        for scope, new_cmds in cmds_formatted.items():
             permissions = {}
-            new_cmds = cmds_formatted[scope]
             existing_cmds = await self.req.get_all_commands(guild_id=scope)
             existing_by_name = {}
             to_send = []

--- a/discord_slash/model.py
+++ b/discord_slash/model.py
@@ -51,7 +51,7 @@ class OptionData:
             for choice in choices:
                 self.choices.append(ChoiceData(**choice))
         else:
-            self.choices = None
+            self.choices = []
 
         if self.type in (1, 2):
             self.options = []
@@ -101,7 +101,7 @@ class CommandData:
             for option in options:
                 self.options.append(OptionData(**option))
         else:
-            self.options = None
+            self.options = []
 
     def __eq__(self, other):
         if isinstance(other, CommandData):


### PR DESCRIPTION
## About this pull request

Fixes a bug where sync_commands would detect changes since one of the following comparisons would occur and fail:
* `options = []` on the local compared to `options = None` from remote
* `choices = []` on the local compared to `choices = None` from remote

## Changes

Instead of `self.choices = None`, if choices is unspecified, `self.choices = []` is used

## Checklist

- [x] I've run the `pre_push.py` script to format and lint code.
- [x] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
- [ ] This adds something new.
- [ ] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
