### PR TITLE
Aliases!

### DIFF
--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -826,6 +826,7 @@ class SlashCommand:
         name: str = None,
         description: str = None,
         guild_ids: typing.List[int] = None,
+        aliases: typing.List[str] = None,
         options: typing.List[dict] = None,
         default_permission: bool = True,
         permissions: dict = None,
@@ -878,6 +879,8 @@ class SlashCommand:
         :type description: str
         :param guild_ids: List of Guild ID of where the command will be used. Default ``None``, which will be global command.
         :type guild_ids: List[int]
+        :param aliases: Slash Commands that will return the same result. As this is not officially supported by the Discord API, it will count up on the Slash Command number, getting you closer to the 100 global/guild Command limit. It isn't recommended to use this.
+        :type aliases: List[str]
         :param options: Options of the slash command. This will affect ``auto_convert`` and command data at Discord API. Default ``None``.
         :type options: List[dict]
         :param default_permission: Sets if users have permission to run slash command by default, when no permissions are set. Default ``True``.
@@ -905,6 +908,18 @@ class SlashCommand:
                 permissions,
                 connector,
             )
+            if aliases is not None:
+                for alias in aliases:
+                    self.add_slash_command(
+                        cmd,
+                        alias,
+                        description,
+                        guild_ids,
+                        options,
+                        default_permission,
+                        permissions,
+                        connector,
+                    )
 
             return obj
 

--- a/discord_slash/cog_ext.py
+++ b/discord_slash/cog_ext.py
@@ -14,6 +14,7 @@ def cog_slash(
     name: str = None,
     description: str = None,
     guild_ids: typing.List[int] = None,
+    aliases: typing.List[str] = None,
     options: typing.List[dict] = None,
     default_permission: bool = True,
     permissions: typing.Dict[int, list] = None,
@@ -41,6 +42,8 @@ def cog_slash(
     :type description: str
     :param guild_ids: List of Guild ID of where the command will be used. Default ``None``, which will be global command.
     :type guild_ids: List[int]
+    :param aliases: Slash Commands that will return the same result. As this is not officially supported by the Discord API, it will count up on the Slash Command number, getting you closer to the 100 global/guild Command limit. It isn't recommended to use this.
+    :type aliases: List[str]
     :param options: Options of the slash command. This will affect ``auto_convert`` and command data at Discord API. Default ``None``.
     :type options: List[dict]
     :param default_permission: Sets if users have permission to run slash command by default, when no permissions are set. Default ``True``.
@@ -79,6 +82,11 @@ def cog_slash(
             "connector": connector,
             "has_subcommands": False,
         }
+
+        if aliases is not None:
+            for alias in aliases:
+                CogBaseCommandObject(alias, _cmd)
+
         return CogBaseCommandObject(name or cmd.__name__, _cmd)
 
     return wrapper


### PR DESCRIPTION
## About this pull request

This pull request adds a Slash Command aliases argument to the decorators. Decided not to mess with subcommands (what would aliases for subcommands even be useful for?).

In the argument description, it warns the user that it will count up their command limit.

## Changes

- Added argument to `@slash.slash` and `@cog_ext.cog_slash` decorators for command aliases.

## Checklist

- [X] I've run the `pre_push.py` script to format and lint code.
- [ ] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [X] This adds something new.
- [ ] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
