### PR TITLE
Weakly typed CommandData and PermissionData comparison.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
     <a href="https://pypi.org/project/discord-py-interactions/">
-        <img src="https://raw.githubusercontent.com/muqshots/discord-py-interactions/master/.github/banner_transparent.png" alt="discord-py-interactions" height="128">
+        <img src="https://raw.githubusercontent.com/goverfl0w/discord-interactions/stable/.github/banner_transparent.png" alt="discord-py-interactions" height="128">
     </a>
     <h2>Your ultimate Discord interactions library for <a href="https://github.com/Rapptz/discord.py">discord.py</a>.</h2>
 </div>

--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -332,7 +332,7 @@ class SlashCommand:
                         "type": selected._type,
                     }
                     if command_dict["type"] != 1:
-                        command_dict.pop("description")
+                        command_dict["description"] = ""
                     if y in selected.permissions:
                         command_dict["permissions"][y] = selected.permissions[y]
                     wait[y][x] = copy.deepcopy(command_dict)
@@ -348,7 +348,7 @@ class SlashCommand:
                     "type": selected._type,
                 }
                 if command_dict["type"] != 1:
-                    command_dict.pop("description")
+                    command_dict["description"] = ""
                 wait["global"][x] = copy.deepcopy(command_dict)
 
         # Separated normal command add and subcommand add not to

--- a/discord_slash/cog_ext.py
+++ b/discord_slash/cog_ext.py
@@ -212,7 +212,7 @@ def cog_context_menu(*, name: str, guild_ids: list = None, target: int = 1):
             )
 
         _cmd = {
-            "default_permission": None,
+            "default_permission": True,
             "has_permissions": None,
             "name": name,
             "type": target,

--- a/discord_slash/model.py
+++ b/discord_slash/model.py
@@ -629,8 +629,8 @@ class PermissionData:
     def __eq__(self, other):
         if isinstance(other, PermissionData):
             return (
-                self.id == other.id
-                and self.type == other.id
+                str(self.id) == str(other.id)
+                and self.type == other.type
                 and self.permission == other.permission
             )
         else:
@@ -658,7 +658,7 @@ class GuildPermissionsData:
         if isinstance(other, GuildPermissionsData):
             return (
                 self.id == other.id
-                and self.guild_id == other.guild_id
+                and str(self.guild_id) == str(other.guild_id)
                 and self.permissions == other.permissions
             )
         else:

--- a/discord_slash/model.py
+++ b/discord_slash/model.py
@@ -108,7 +108,7 @@ class CommandData:
             return (
                 self.name == other.name
                 and self.description == other.description
-                and self.options == other.options
+                and (self.options == other.options or not self.options and not other.options)
                 and self.default_permission == other.default_permission
             )
         else:


### PR DESCRIPTION
## About this pull request

Fixes a bug where sync_commands would detect changes in both permissions and commands due to inconsistent types across the library.

## Changes

Changes were made as to `CommadData.__eq__` and `PermissionData.__eq__` method, making it more weakly typed, eg: str guild_id will be equal to int guild_id. These changes are **nonbreaking**.

Another change was that even though context commands do not have a description, poping them will result in having the description set to None. However, Discord API returns the description as an empty string, hence setting it to an empty string as a solution over poping it/setting it to `NoneType`.

There was also a typo, (I assume) in `PermissionData.__eq__` where the library tries to compare a permission type to permission id.

Lastly, I also slid in the readme update for the png.

## Checklist

- [x] I've run the `pre_push.py` script to format and lint code.
- [x] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [ ] This adds something new.
- [ ] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
