### PR TITLE
Making docs link to application-commands instead of slash-commands

### DIFF
--- a/discord_slash/model.py
+++ b/discord_slash/model.py
@@ -447,7 +447,7 @@ class CogComponentCallbackObject(ComponentCallbackObject):
 
 class SlashCommandOptionType(IntEnum):
     """
-    Equivalent of `ApplicationCommandOptionType <https://discord.com/developers/docs/interactions/slash-commands#applicationcommandoptiontype>`_  in the Discord API.
+    Equivalent of `ApplicationCommandOptionType <https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-type>`_  in the Discord API.
     """
 
     SUB_COMMAND = 1
@@ -667,7 +667,7 @@ class GuildPermissionsData:
 
 class SlashCommandPermissionType(IntEnum):
     """
-    Equivalent of `ApplicationCommandPermissionType <https://discord.com/developers/docs/interactions/slash-commands#applicationcommandpermissiontype>`_  in the Discord API.
+    Equivalent of `ApplicationCommandPermissionType <https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-application-command-permission-type>`_  in the Discord API.
     """
 
     ROLE = 1

--- a/discord_slash/model.py
+++ b/discord_slash/model.py
@@ -447,7 +447,7 @@ class CogComponentCallbackObject(ComponentCallbackObject):
 
 class SlashCommandOptionType(IntEnum):
     """
-    Equivalent of `ApplicationCommandOptionType <https://discord.com/developers/docs/interactions/slash-commands#applicationcommandoptiontype>`_  in the Discord API.
+    Equivalent of `ApplicationCommandOptionType <https://discord.com/developers/docs/interactions/application-commands#applicationcommandoptiontype>`_  in the Discord API.
     """
 
     SUB_COMMAND = 1
@@ -667,7 +667,7 @@ class GuildPermissionsData:
 
 class SlashCommandPermissionType(IntEnum):
     """
-    Equivalent of `ApplicationCommandPermissionType <https://discord.com/developers/docs/interactions/slash-commands#applicationcommandpermissiontype>`_  in the Discord API.
+    Equivalent of `ApplicationCommandPermissionType <https://discord.com/developers/docs/interactions/application-commands#applicationcommandpermissiontype>`_  in the Discord API.
     """
 
     ROLE = 1

--- a/discord_slash/utils/manage_commands.py
+++ b/discord_slash/utils/manage_commands.py
@@ -131,7 +131,7 @@ async def get_all_guild_commands_permissions(bot_id, bot_token, guild_id):
     :param bot_id: User ID of the bot.
     :param bot_token: Token of the bot.
     :param guild_id: ID of the guild to get permissions.
-    :return: JSON Response of the request. A list of <https://discord.com/developers/docs/interactions/slash-commands#get-application-command-permissions>.
+    :return: JSON Response of the request. A list of <https://discord.com/developers/docs/interactions/application-commands#get-application-command-permissions>.
     :raises: :class:`.error.RequestFailure` - Requesting to Discord API has failed.
     """
     url = f"https://discord.com/api/v8/applications/{bot_id}/guilds/{guild_id}/commands/permissions"
@@ -154,7 +154,7 @@ async def get_guild_command_permissions(bot_id, bot_token, guild_id, command_id)
     :param bot_token: Token of the bot.
     :param guild_id: ID of the guild to update permissions on.
     :param command_id: ID for the command to update permissions on.
-    :return: JSON Response of the request. A list of <https://discord.com/developers/docs/interactions/slash-commands#edit-application-command-permissions>
+    :return: JSON Response of the request. A list of <https://discord.com/developers/docs/interactions/application-commands#edit-application-command-permissions>
     :raises: :class:`.error.RequestFailure` - Requesting to Discord API has failed.
     """
     url = f"https://discord.com/api/v8/applications/{bot_id}/guilds/{guild_id}/commands/{command_id}/permissions"
@@ -178,7 +178,7 @@ async def update_single_command_permissions(bot_id, bot_token, guild_id, command
     :param guild_id: ID of the guild to update permissions on.
     :param command_id: ID for the command to update permissions on.
     :param permissions: List of permissions for the command.
-    :return: JSON Response of the request. A list of <https://discord.com/developers/docs/interactions/slash-commands#edit-application-command-permissions>
+    :return: JSON Response of the request. A list of <https://discord.com/developers/docs/interactions/application-commands#edit-application-command-permissions>
     :raises: :class:`.error.RequestFailure` - Requesting to Discord API has failed.
     """
     url = f"https://discord.com/api/v8/applications/{bot_id}/guilds/{guild_id}/commands/{command_id}/permissions"
@@ -205,7 +205,7 @@ async def update_guild_commands_permissions(bot_id, bot_token, guild_id, cmd_per
     :param bot_token: Token of the bot.
     :param guild_id: ID of the guild to update permissions.
     :param cmd_permissions: List of dict with permissions for each commands.
-    :return: JSON Response of the request. A list of <https://discord.com/developers/docs/interactions/slash-commands#batch-edit-application-command-permissions>.
+    :return: JSON Response of the request. A list of <https://discord.com/developers/docs/interactions/application-commands#batch-edit-application-command-permissions>.
     :raises: :class:`.error.RequestFailure` - Requesting to Discord API has failed.
     """
     url = f"https://discord.com/api/v8/applications/{bot_id}/guilds/{guild_id}/commands/permissions"
@@ -246,7 +246,7 @@ def create_option(
         You must set the the relevant argument's function to a default argument, eg ``argname = None``.
 
     .. note::
-        ``choices`` must either be a list of `option type dicts <https://discord.com/developers/docs/interactions/slash-commands#applicationcommandoptionchoice>`_
+        ``choices`` must either be a list of `option type dicts <https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-choice-structure>`_
         or a list of single string values.
     """
     if not isinstance(option_type, int) or isinstance(

--- a/discord_slash/utils/manage_commands.py
+++ b/discord_slash/utils/manage_commands.py
@@ -131,7 +131,7 @@ async def get_all_guild_commands_permissions(bot_id, bot_token, guild_id):
     :param bot_id: User ID of the bot.
     :param bot_token: Token of the bot.
     :param guild_id: ID of the guild to get permissions.
-    :return: JSON Response of the request. A list of <https://discord.com/developers/docs/interactions/slash-commands#get-application-command-permissions>.
+    :return: JSON Response of the request. A list of <https://discord.com/developers/docs/interactions/application-commands#get-application-command-permissions>.
     :raises: :class:`.error.RequestFailure` - Requesting to Discord API has failed.
     """
     url = f"https://discord.com/api/v8/applications/{bot_id}/guilds/{guild_id}/commands/permissions"
@@ -154,7 +154,7 @@ async def get_guild_command_permissions(bot_id, bot_token, guild_id, command_id)
     :param bot_token: Token of the bot.
     :param guild_id: ID of the guild to update permissions on.
     :param command_id: ID for the command to update permissions on.
-    :return: JSON Response of the request. A list of <https://discord.com/developers/docs/interactions/slash-commands#edit-application-command-permissions>
+    :return: JSON Response of the request. A list of <https://discord.com/developers/docs/interactions/application-commands#edit-application-command-permissions>
     :raises: :class:`.error.RequestFailure` - Requesting to Discord API has failed.
     """
     url = f"https://discord.com/api/v8/applications/{bot_id}/guilds/{guild_id}/commands/{command_id}/permissions"
@@ -178,7 +178,7 @@ async def update_single_command_permissions(bot_id, bot_token, guild_id, command
     :param guild_id: ID of the guild to update permissions on.
     :param command_id: ID for the command to update permissions on.
     :param permissions: List of permissions for the command.
-    :return: JSON Response of the request. A list of <https://discord.com/developers/docs/interactions/slash-commands#edit-application-command-permissions>
+    :return: JSON Response of the request. A list of <https://discord.com/developers/docs/interactions/application-commands#edit-application-command-permissions>
     :raises: :class:`.error.RequestFailure` - Requesting to Discord API has failed.
     """
     url = f"https://discord.com/api/v8/applications/{bot_id}/guilds/{guild_id}/commands/{command_id}/permissions"
@@ -205,7 +205,7 @@ async def update_guild_commands_permissions(bot_id, bot_token, guild_id, cmd_per
     :param bot_token: Token of the bot.
     :param guild_id: ID of the guild to update permissions.
     :param cmd_permissions: List of dict with permissions for each commands.
-    :return: JSON Response of the request. A list of <https://discord.com/developers/docs/interactions/slash-commands#batch-edit-application-command-permissions>.
+    :return: JSON Response of the request. A list of <https://discord.com/developers/docs/interactions/application-commands#batch-edit-application-command-permissions>.
     :raises: :class:`.error.RequestFailure` - Requesting to Discord API has failed.
     """
     url = f"https://discord.com/api/v8/applications/{bot_id}/guilds/{guild_id}/commands/permissions"
@@ -246,7 +246,7 @@ def create_option(
         You must set the the relevant argument's function to a default argument, eg ``argname = None``.
 
     .. note::
-        ``choices`` must either be a list of `option type dicts <https://discord.com/developers/docs/interactions/slash-commands#applicationcommandoptionchoice>`_
+        ``choices`` must either be a list of `option type dicts <https://discord.com/developers/docs/interactions/application-commands#applicationcommandoptionchoice>`_
         or a list of single string values.
     """
     if not isinstance(option_type, int) or isinstance(

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -445,8 +445,8 @@ As a side-note, as of version 3.0, message/menu commands (context menus) are han
 .. _components: components.html
 .. _errors: discord_slash.error.html
 .. _listeners: events.html
-.. _ApplicationCommandOptionType: https://discord.com/developers/docs/interactions/slash-commands#applicationcommandoptiontype
-.. _ApplicationCommandOptionChoice: https://discord.com/developers/docs/interactions/slash-commands#applicationcommandoptionchoice
-.. _ApplicationCommandOption: https://discord.com/developers/docs/interactions/slash-commands#applicationcommandoption
-.. _ApplicationCommandPermissionType: https://discord.com/developers/docs/interactions/slash-commands#applicationcommandpermissions
+.. _ApplicationCommandOptionType: https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-type
+.. _ApplicationCommandOptionChoice: https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-choice-structure
+.. _ApplicationCommandOption: https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure
+.. _ApplicationCommandPermissionType: https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-application-command-permission-type
 .. _ApplicationCommandType: https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-types


### PR DESCRIPTION

## About this pull request

Description of the pr

Replaced links i could find that redirected to https://discord.com/developers/docs/interactions/slash-commands which has been moved over to https://discord.com/developers/docs/interactions/application-commands

## Changes

What changes were made?

Replaced 4 links

## Checklist

- [ ] I've run the `pre_push.py` script to format and lint code.
- [ ] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [ ] This adds something new.
- [ ] There is/are breaking change(s).
- [x] (If required) Relevant documentation has been updated/added.
- [x] This is not a code change. (README, docs, etc.)
