### PR TITLE
Fix invalid code in documentation for cog support

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,14 @@ This example serves as an alternative method for using slash commands in a cog i
 
 ```py
 # bot.py
-from discord import Client, Intents, Embed
-from discord_slash import SlashCommand, SlashContext
+from discord import Intents
+from discord.ext.commands import Bot
+from discord_slash import SlashCommand
 
-bot = Client(intents=Intents.default())
+# Note that command_prefix is a required but essentially unused paramater.
+# Setting help_command=False ensures that discord.py does not create a !help command.
+# Enabling self_bot ensures that the bot does not try and parse messages that start with "!".
+bot = Bot(command_prefix="!", self_bot=True, help_command=False, intents=Intents.default())
 slash = SlashCommand(bot)
 
 bot.load_extension("cog")
@@ -83,18 +87,19 @@ bot.run("discord_token")
 
 # cog.py
 from discord import Embed
+from discord.ext.commands import Bot, Cog
 from discord_slash import cog_ext, SlashContext
 
-class Slash(commands.Cog):
-    def __init__(self, bot):
+class Slash(Cog):
+    def __init__(self, bot: Bot):
         self.bot = bot
 
     @cog_ext.cog_slash(name="test")
     async def _test(self, ctx: SlashContext):
         embed = Embed(title="Embed Test")
         await ctx.send(embed=embed)
-    
-def setup(bot):
+
+def setup(bot: Bot):
     bot.add_cog(Slash(bot))
 ```
 


### PR DESCRIPTION
## About this pull request
There is some invalid code in the `README.md` file. For example the `Client` object does not have a `load_extension()` method on it. I believe this was intended to be a `Bot` instead.

## Changes
Simply updating the example code so that it can actually run.

## Checklist
- [x] This is not a code change. (README, docs, etc.)
