### PR TITLE
[v4] Switch from pre_push to pre-commit

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,3 @@
 [flake8]
-ignore = E203 E501 W503 W504
+ignore = E203 E501 E402 W503 W504
+max-line-length = 100

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/pre-commit/mirrors-isort
+    rev: v5.4.2
+    hooks:
+      - id: isort
+  - repo: https://github.com/psf/black
+    rev: 20.8b1
+    hooks:
+      - id: black
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.9
+    hooks:
+    - id: flake8

--- a/pre_push.py
+++ b/pre_push.py
@@ -33,18 +33,12 @@ def do_process(args, shell=False):
 
 
 def run_static():
-    """Runs static tests.
+    """Runs a documentation static test.
 
-    Returns a statuscode of 0 if everything ran correctly. Otherwise, it will return
-    statuscode 1
-
+    Returns a statuscode of 0 if everything ran correctly.
+    Otherwise, it will return statuscode 1.
     """
     success = True
-    # Formatters
-    success &= do_process(["black", "."])
-    success &= do_process(["isort", "."])
-    # Linters
-    success &= do_process(["flake8", "--exclude=.eggs,build,docs,.venv*,env*"])
 
     tmp_dir = mkdtemp()
     try:


### PR DESCRIPTION
## About this pull request

This PR effectively changes how PR'ing works by migrating from `pre_push.py` to `pre-commit`, in this case, a CI-driven tool that checks the lib on any PR/commit. This effectively saves everyone a lot of time, notably when `pre_push` accidentally somehow reformats the virtual environment.

## Changes

- Added E402 in `.flake8` because of `conf.py`
- Deleted black, isort, flake8 checks on pre_push, but recreated in the new config file.
    - This was tested locally, and all checks have been passed with flying colours.

## Checklist

- [X] I've run the `pre_push.py` script to format and lint code.
- [ ] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [X] This adds something new.
- [X] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
