### PR TITLE
Fix typo in commands.py

### DIFF
--- a/interactions/models/command.py
+++ b/interactions/models/command.py
@@ -59,7 +59,7 @@ class Option(object):
 
 class Permission(object):
     """
-    A class object representing the permission of an applicatioon command.
+    A class object representing the permission of an application command.
 
     :ivar int id: The ID of the permission.
     :ivar interactions.enums.PermissionType type: The type of permission.


### PR DESCRIPTION
## Changes

A typo was fixed.

## Checklist

- [ ] I've run the `pre_push.py` script to format and lint code.
- [ ] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [ ] This adds something new.
- [ ] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added.
- [x] This is not a code change. (README, docs, etc.)
