### PR TITLE
Set `origin_message` for component interactions on ephemeral messages

### DIFF
--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -482,8 +482,7 @@ class SlashCommand:
                         for num in cmd_nums:
                             error_command = to_send[int(num)]
                             error_string = error_string.replace(
-                                f"In {num}",
-                                f"'{error_command.get('name')}'",
+                                f"In {num}", f"'{error_command.get('name')}'"
                             )
 
                         ex.args = (error_string,)
@@ -1142,10 +1141,7 @@ class SlashCommand:
         callback_obj.keys.add((message_id, custom_id))
 
     def get_component_callback(
-        self,
-        message_id: int = None,
-        custom_id: str = None,
-        component_type: int = None,
+        self, message_id: int = None, custom_id: str = None, component_type: int = None
     ):
         """
         Returns component callback (or None if not found) for specific combination of message_id, custom_id, component_type.

--- a/discord_slash/cog_ext.py
+++ b/discord_slash/cog_ext.py
@@ -282,10 +282,7 @@ def cog_component(
             raise IncorrectFormat("You must specify messages or components (or both)")
 
         return CogComponentCallbackObject(
-            callback,
-            message_ids=message_ids,
-            custom_ids=custom_ids,
-            component_type=component_type,
+            callback, message_ids=message_ids, custom_ids=custom_ids, component_type=component_type
         )
 
     return wrapper

--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -681,9 +681,7 @@ class MenuContext(InteractionContext):
                     _neudict = self._resolved["members"][_auth]
                     _neudict["user"] = self._resolved["users"][_auth]
                     self.target_author = discord.Member(
-                        data=_neudict,
-                        state=self.bot._connection,
-                        guild=self.guild,
+                        data=_neudict, state=self.bot._connection, guild=self.guild
                     )
                 else:
                     _auth = [auth for auth in self._resolved["users"]][0]

--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -431,8 +431,8 @@ class ComponentContext(InteractionContext):
 
     :ivar custom_id: The custom ID of the component (has alias component_id).
     :ivar component_type: The type of the component.
-    :ivar component: Component data retrieved from the message. Not available if the origin message was ephemeral.
-    :ivar origin_message: The origin message of the component. Not available if the origin message was ephemeral.
+    :ivar component: Component data retrieved from the message.
+    :ivar origin_message: The origin message of the component.
     :ivar origin_message_id: The ID of the origin message.
     :ivar selected_options: The options selected (only for selects)
     """
@@ -454,7 +454,7 @@ class ComponentContext(InteractionContext):
 
         self._deferred_edit_origin = False
 
-        if self.origin_message_id and (_json["message"]["flags"] & 64) != 64:
+        if self.origin_message_id:
             self.origin_message = ComponentMessage(
                 state=self.bot._connection, channel=self.channel, data=_json["message"]
             )

--- a/discord_slash/model.py
+++ b/discord_slash/model.py
@@ -404,13 +404,7 @@ class ComponentCallbackObject(CallbackObject):
     :ivar component_type: Type of the component. See `:class.utils.manage_components.ComponentsType`
     """
 
-    def __init__(
-        self,
-        func,
-        message_ids,
-        custom_ids,
-        component_type,
-    ):
+    def __init__(self, func, message_ids, custom_ids, component_type):
         if component_type not in (2, 3, None):
             raise error.IncorrectFormat(f"Invalid component type `{component_type}`")
 

--- a/discord_slash/utils/manage_components.py
+++ b/discord_slash/utils/manage_components.py
@@ -140,10 +140,7 @@ def create_button(
 
     emoji = emoji_to_dict(emoji)
 
-    data = {
-        "type": ComponentType.button,
-        "style": style,
-    }
+    data = {"type": ComponentType.button, "style": style}
 
     if label:
         data["label"] = label

--- a/setup.py
+++ b/setup.py
@@ -12,10 +12,7 @@ with open("README.md", "r", encoding="UTF-8") as f:
 with open(path.join(HERE, PACKAGE_NAME, "const.py"), encoding="utf-8") as fp:
     VERSION = re.search('__version__ = "([^"]+)"', fp.read()).group(1)
 
-extras = {
-    "lint": ["black", "flake8", "isort"],
-    "readthedocs": ["sphinx", "karma-sphinx-theme"],
-}
+extras = {"lint": ["black", "flake8", "isort"], "readthedocs": ["sphinx", "karma-sphinx-theme"]}
 extras["lint"] += extras["readthedocs"]
 extras["dev"] = extras["lint"] + extras["readthedocs"]
 


### PR DESCRIPTION
## About this pull request

Discord made an API change some time ago to send ephemeral message payloads with interactions. [Link to the announcement in the Discord Developers server.](https://discord.com/channels/613425648685547541/697138785317814292/875828152763547649) The library currently checks whether a component interaction's message is ephemeral, and skips setting the `origin_message` of the interaction if it is. I have removed this check so that the `origin_message` will be set.

## Changes

In `context.py` line 457: removed the flag check that skipped setting the `origin_message` if the message is ephemeral.

## Checklist

- [x] I've run the `pre_push.py` script to format and lint code.
- [x] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/goverfl0w/discord-interactions/issues).
    - Issue:
- [ ] This adds something new.
- [ ] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added. *(Docstrings have been updated, but I could not get Sphinx to run successfully)*
- [ ] This is not a code change. (README, docs, etc.)
