### PR TITLE
Add MENTIONABLE and FLOAT option type in docs.

### DIFF
--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -130,6 +130,10 @@ terms on what this means with a table below showing all of these values:
 +-------------------+-----------+
 | ROLE              | 8         |
 +-------------------+-----------+
+| MENTIONABLE       | 9         |
++-------------------+-----------+
+| FLOAT             | 10        |
++-------------------+-----------+
 
 The purpose of having the ``ApplicationCommandOptionType`` value passed into our option JSON structure
 is so that we can help the Discord UI understand what kind of value we're inputting here. For instance,


### PR DESCRIPTION
## About this pull request

As stated in the title ^

## Changes

Added missing option type in docs. 

## Checklist

- [ ] I've run the `pre_push.py` script to format and lint code.
- [ ] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/goverfl0w/discord-interactions/issues).
    - Issue:
- [ ] This adds something new.
- [ ] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added.
- [x] This is not a code change. (README, docs, etc.)
