### PR TITLE
fixed commands in the debug_guild not registering

### DIFF
--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -431,7 +431,11 @@ class SlashCommand:
         # if debug_guild is set, global commands get re-routed to the guild to update quickly
         cmds_formatted = {self.debug_guild: cmds["global"]}
         for guild in cmds["guild"]:
-            cmds_formatted[guild] = cmds["guild"][guild]
+            # check whether there already are commands for that guild (coming from the debug_guild) instead of overriding them
+            try:
+                cmds_formatted[guild].append(cmds["guild"][guild][0])
+            except KeyError:
+                cmds_formatted[guild] = cmds["guild"][guild]
 
         for scope in cmds_formatted:
             permissions = {}

--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -433,7 +433,8 @@ class SlashCommand:
         for guild in cmds["guild"]:
             # check whether there already are commands for that guild (coming from the debug_guild) instead of overriding them
             try:
-                cmds_formatted[guild].append(cmds["guild"][guild][0])
+                for cmd in cmds["guild"][guild]:
+                    cmds_formatted[guild].append(cmd)
             except KeyError:
                 cmds_formatted[guild] = cmds["guild"][guild]
 


### PR DESCRIPTION
## About this pull request

Global commands weren't registering at all when a `debug_guild` was specified and you had commands having the same guild id in their `guild_ids` attribute because the list of global commands re-routed to this guild was overridden by the normal guild commands you specified for that guild.

## Changes

I changed the code in `client.py` to check whether there are commands in the list coming from the debug_guild re-route and append the normal guild commands to them.

## Checklist

- [x] I've run the `pre_push.py` script to format and lint code.
- [ ] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/goverfl0w/discord-interactions/issues).
    - Issue:
- [ ] This adds something new.
- [ ] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
