### PR TITLE
docs: Fix broken header image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
     <a href="https://pypi.org/project/discord-py-interactions/">
-        <img src="https://raw.githubusercontent.com/muqshots/discord-py-interactions/master/.github/banner_transparent.png" alt="discord-py-interactions" height="128">
+        <img src=".github/banner_transparent.png" alt="discord-py-interactions" height="128">
     </a>
     <h2>Your ultimate Discord interactions library for <a href="https://github.com/Rapptz/discord.py">discord.py</a>.</h2>
 </div>


### PR DESCRIPTION
## About this pull request

Replaced broken header link with a working relative link

## Changes

### Before

![image](https://user-images.githubusercontent.com/20955511/135934959-77a6a542-f953-4e65-b852-a8ec9767f3ca.png)

### After

![image](https://user-images.githubusercontent.com/20955511/135935015-61779c63-30bc-4d18-968f-edd91a8b6822.png)


## Checklist

- [x] This is not a code change. (README, docs, etc.)
