### PR TITLE
Fix global commands getting overridden.

### DIFF
--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -428,10 +428,15 @@ class SlashCommand:
         permissions_map = {}
         cmds = await self.to_dict()
         self.logger.info("Syncing commands...")
-        # if debug_guild is set, global commands get re-routed to the guild to update quickly
-        cmds_formatted = {self.debug_guild: cmds["global"]}
+        cmds_formatted = {}
         for guild in cmds["guild"]:
             cmds_formatted[guild] = cmds["guild"][guild]
+
+        # if debug_guild is set, global commands get re-routed to the guild to update quickly
+        if self.debug_guild is not None and self.debug_guild in cmds_formatted:
+            cmds_formatted[self.debug_guild].extend(cmds["global"])
+        else:
+            cmds_formatted[self.debug_guild] = cmds["global"]
 
         for scope in cmds_formatted:
             permissions = {}


### PR DESCRIPTION
## About this pull request

Fix an edge case where some commands can specifically only be run on one guild, and also happens to be the debug_guild. This resulted in the global commands being overridden.

## Changes

Bugfix to sync method.

## Checklist

- [x] I've run the `pre_push.py` script to format and lint code.
- [x] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/goverfl0w/discord-interactions/issues).
    - Issue:
- [ ] This adds something new.
- [ ] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
