### PR TITLE
Ephemeral send

### DIFF
--- a/interactions/context.py
+++ b/interactions/context.py
@@ -56,6 +56,7 @@ class InteractionContext(Context):
         components: Optional[Union[Component, List[Component]]] = None,
         sticker_ids: Optional[Union[str, List[str]]] = None,
         type: Optional[int] = None,
+        ephemeral: Optional[bool] = False,
     ) -> Message:
         """
         A **very** primitive form of the send model to get the uttermost
@@ -87,6 +88,7 @@ class InteractionContext(Context):
             message_reference=_message_reference,
             components=_components,
             sticker_ids=_sticker_ids,
+            flags=64 if ephemeral else 0,
         )
         self.message = payload
 


### PR DESCRIPTION
## About this pull request

Adds the "ephemeral" keyword to allow ephemeral messages

## Changes

Added the ability to set flags to 64, creating ephemeral responses

## Checklist

- [x ] I've run the `pre_push.py` script to format and lint code.
- [x ] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/goverfl0w/discord-interactions/issues).
    - Issue:
- [x ] This adds something new.
- [ ] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
