### PR TITLE
Updated context.send to add flags

### DIFF
--- a/interactions/context.py
+++ b/interactions/context.py
@@ -56,6 +56,7 @@ class InteractionContext(Context):
         components: Optional[Union[Component, List[Component]]] = None,
         sticker_ids: Optional[Union[str, List[str]]] = None,
         type: Optional[int] = None,
+        flags: Optional[int] = None,
     ) -> Message:
         """
         A **very** primitive form of the send model to get the uttermost
@@ -74,6 +75,7 @@ class InteractionContext(Context):
         )
         _sticker_ids: list = [] if sticker_ids is None else [sticker for sticker in sticker_ids]
         _type: int = 4 if type is None else type
+        _flags: int = 0 if flags is None else flags
 
         if sticker_ids and len(sticker_ids) > 3:
             raise Exception("Message can only have up to 3 stickers.")
@@ -87,6 +89,7 @@ class InteractionContext(Context):
             message_reference=_message_reference,
             components=_components,
             sticker_ids=_sticker_ids,
+            flags:_flags
         )
         self.message = payload
 


### PR DESCRIPTION
Responding to interactions should allow to set "flags" so users can decide whether its an ephemeral message or not.

More information: https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-interaction-callback-data-flags

## About this pull request

Description of the pr

## Changes

What changes were made?

## Checklist

- [ ] I've run the `pre_push.py` script to format and lint code.
- [ ] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/goverfl0w/discord-interactions/issues).
    - Issue:
- [ ] This adds something new.
- [ ] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
