### PR TITLE
Add missing slot for options attribute

### DIFF
--- a/interactions/models/component.py
+++ b/interactions/models/component.py
@@ -42,6 +42,7 @@ class SelectMenu(DictSerializerMixin):
         "_json",
         "type",
         "custom_id",
+        "options",
         "placeholder",
         "min_values",
         "max_values",


### PR DESCRIPTION
- Tried using the library (unstable branch) and run into this error.
- Single line change made through the github website, didn't run any tests.
- Feel free to close PR if making this change in one of your own existing branches is easier.