### PR TITLE
accept str custom_id in component callbacks

### DIFF
--- a/interactions/client.py
+++ b/interactions/client.py
@@ -399,8 +399,10 @@ class Client:
         """
 
         def decorator(coro: Coroutine) -> Any:
-            payload: Component = _component(component)
-            return self.event(coro, name=payload.custom_id)
+            payload: str = (
+                _component(component).custom_id if isinstance(component, Component) else component
+            )
+            return self.event(coro, name=payload)
 
         return decorator
 


### PR DESCRIPTION
## About this Pull Request

This pull request accepts str custom_id in component callbacks, which effectively lets you pass a custom_id instead of a component in the component callback decorator.
See #380, I made this so it targets `unstable` and also I messed up #380.
this PR does not add anything new, only modifies a couple of lines to accept custom_id in component callbacks.

## Checklist

- [x] I've run the `pre_push.py` script to format and lint the change(s) made.
- [x] I've checked to make sure this pull request runs on Python `3.6.X`.
- [ ] This fixes/solves something from the project's [Issues](https://github.com/goverfl0w/discord-interactions/issues).
    - Issue (if referenceable):
- [ ] This adds something new.
    - [ ] This is not a code change.
    - [ ] (If required) Relevant documentation has been updated/added.
    - [ ] There is/are (a) breaking change(s).
