### PR TITLE
fix: component sending/editing with context

### DIFF
--- a/interactions/context.py
+++ b/interactions/context.py
@@ -193,7 +193,7 @@ class CommandContext(Context):
         if (
             isinstance(components, list)
             and components
-            and (isinstance(action_row, ActionRow) for action_row in components)
+            and all(isinstance(action_row, ActionRow) for action_row in components)
         ):
             _components = [
                 {
@@ -317,7 +317,7 @@ class CommandContext(Context):
         if (
             isinstance(components, list)
             and components
-            and (isinstance(action_row, ActionRow) for action_row in components)
+            and all(isinstance(action_row, ActionRow) for action_row in components)
         ):
             _components = [
                 {

--- a/interactions/context.py
+++ b/interactions/context.py
@@ -270,8 +270,6 @@ class CommandContext(Context):
                 for component in components.components
             ]
         elif isinstance(components, (Button, SelectMenu)):
-            if isinstance(components, SelectMenu):
-                components._json["options"] = [option._json for option in components.options]
             _components[0]["components"] = (
                 [components._json]
                 if components._json.get("custom_id") or components._json.get("url")
@@ -457,8 +455,6 @@ class CommandContext(Context):
                 for component in components.components
             ]
         elif isinstance(components, (Button, SelectMenu)):
-            if isinstance(components, SelectMenu):
-                components._json["options"] = [option._json for option in components.options]
             _components[0]["components"] = (
                 [components._json]
                 if components._json.get("custom_id") or components._json.get("url")

--- a/interactions/context.py
+++ b/interactions/context.py
@@ -211,6 +211,8 @@ class CommandContext(Context):
                 for component in components.components
             ]
         elif isinstance(components, (Button, SelectMenu)):
+            if isinstance(components, SelectMenu):
+                components._json["options"] = [option._json for option in components.options]
             _components[0]["components"] = (
                 [components._json] if components._json.get("custom_id") else []
             )

--- a/interactions/context.py
+++ b/interactions/context.py
@@ -251,6 +251,8 @@ class CommandContext(Context):
             _components[0]["components"] = (
                 [components._json] if components._json.get("custom_id") else []
             )
+        elif components is None:
+            _components = None
         else:
             _components = []
 

--- a/interactions/context.py
+++ b/interactions/context.py
@@ -188,7 +188,7 @@ class CommandContext(Context):
             else ([embed._json for embed in embeds] if isinstance(embeds, list) else [embeds._json])
         )
         _allowed_mentions: dict = {} if allowed_mentions is None else allowed_mentions
-        _components: list = [{"type": 1, "components": []}]
+        _components: List[dict] = [{"type": 1, "components": []}]
 
         if (
             isinstance(components, list)
@@ -205,6 +205,20 @@ class CommandContext(Context):
                 }
                 for action_row in components
             ]
+        elif (
+            isinstance(components, list)
+            and components
+            and all(isinstance(component, (Button, SelectMenu)) for component in components)
+        ):
+            _components = [
+                {
+                    "type": 1,
+                    "components": [
+                        (component._json if component._json.get("custom_id") else [])
+                        for component in components
+                    ],
+                }
+            ]
         elif isinstance(components, ActionRow):
             _components[0]["components"] = [
                 (component._json if component._json.get("custom_id") else [])
@@ -217,7 +231,7 @@ class CommandContext(Context):
                 [components._json] if components._json.get("custom_id") else []
             )
         else:
-            _components = [components] if components._json.get("custom_id") else []
+            _components = []
 
         _ephemeral: int = (1 << 6) if ephemeral else 0
 
@@ -328,6 +342,20 @@ class CommandContext(Context):
                     ],
                 }
                 for action_row in components
+            ]
+        elif (
+            isinstance(components, list)
+            and components
+            and all(isinstance(component, (Button, SelectMenu)) for component in components)
+        ):
+            _components = [
+                {
+                    "type": 1,
+                    "components": [
+                        (component._json if component._json.get("custom_id") else [])
+                        for component in components
+                    ],
+                }
             ]
         elif isinstance(components, ActionRow):
             _components[0]["components"] = [

--- a/interactions/context.py
+++ b/interactions/context.py
@@ -199,7 +199,7 @@ class CommandContext(Context):
                 {
                     "type": 1,
                     "components": [
-                        (component._json if components._json.get("custom_id") else [])
+                        (component._json if component._json.get("custom_id") else [])
                         for component in action_row.components
                     ],
                 }
@@ -207,7 +207,7 @@ class CommandContext(Context):
             ]
         elif isinstance(components, ActionRow):
             _components[0]["components"] = [
-                (component._json if components._json.get("custom_id") else [])
+                (component._json if component._json.get("custom_id") else [])
                 for component in components.components
             ]
         elif isinstance(components, (Button, SelectMenu)):
@@ -323,7 +323,7 @@ class CommandContext(Context):
                 {
                     "type": 1,
                     "components": [
-                        (component._json if components._json.get("custom_id") else [])
+                        (component._json if component._json.get("custom_id") else [])
                         for component in action_row.components
                     ],
                 }
@@ -331,7 +331,7 @@ class CommandContext(Context):
             ]
         elif isinstance(components, ActionRow):
             _components[0]["components"] = [
-                (component._json if components._json.get("custom_id") else [])
+                (component._json if component._json.get("custom_id") else [])
                 for component in components.components
             ]
         elif isinstance(components, (Button, SelectMenu)):

--- a/interactions/context.py
+++ b/interactions/context.py
@@ -410,6 +410,8 @@ class CommandContext(Context):
             _components[0]["components"] = (
                 [components._json] if components._json.get("custom_id") else []
             )
+        elif components is None:
+            print(_message_reference)
         else:
             _components = []
 

--- a/interactions/context.py
+++ b/interactions/context.py
@@ -157,7 +157,7 @@ class CommandContext(Context):
         embeds: Optional[Union[Embed, List[Embed]]] = None,
         allowed_mentions: Optional[MessageInteraction] = None,
         components: Optional[
-            Union[Union[ActionRow, Button, SelectMenu], List[Union[ActionRow, Button, SelectMenu]]]
+            Union[ActionRow, Button, SelectMenu, List[Union[ActionRow, Button, SelectMenu]]]
         ] = None,
         ephemeral: Optional[bool] = False,
     ) -> Message:
@@ -174,7 +174,7 @@ class CommandContext(Context):
         :param allowed_mentions?: The message interactions/mention limits that the message can refer to.
         :type allowed_mentions: Optional[MessageInteraction]
         :param components?: A component, or list of components for the message.
-        :type components: Optional[Union[Union[ActionRow, Button, SelectMenu], List[Union[ActionRow, Button, SelectMenu]]]]
+        :type components: Optional[Union[ActionRow, Button, SelectMenu, List[Union[ActionRow, Button, SelectMenu]]]]
         :param ephemeral?: Whether the response is hidden or not.
         :type ephemeral: Optional[bool]
         :return: The sent message as an object.
@@ -355,7 +355,7 @@ class CommandContext(Context):
         allowed_mentions: Optional[MessageInteraction] = None,
         message_reference: Optional[MessageReference] = None,
         components: Optional[
-            Union[Union[ActionRow, Button, SelectMenu], List[Union[ActionRow, Button, SelectMenu]]]
+            Union[ActionRow, Button, SelectMenu, List[Union[ActionRow, Button, SelectMenu]]]
         ] = None,
     ) -> Message:
         """

--- a/interactions/context.py
+++ b/interactions/context.py
@@ -333,6 +333,8 @@ class CommandContext(Context):
                 for component in components.components
             ]
         elif isinstance(components, (Button, SelectMenu)):
+            if isinstance(components, SelectMenu):
+                components._json["options"] = [option._json for option in components.options]
             _components[0]["components"] = (
                 [components._json] if components._json.get("custom_id") else []
             )

--- a/interactions/context.py
+++ b/interactions/context.py
@@ -10,7 +10,7 @@ from .api.models.user import User
 from .base import CustomFormatter, Data
 from .enums import InteractionCallbackType, InteractionType
 from .models.command import Choice
-from .models.component import ActionRow, Button, Component, Modal, SelectMenu
+from .models.component import ActionRow, Button, Modal, SelectMenu
 from .models.misc import InteractionData
 
 basicConfig(level=Data.LOGGER)
@@ -226,11 +226,13 @@ class CommandContext(Context):
         elif (
             isinstance(components, list)
             and components
-            and all(isinstance(action_row, list) for action_row in components)
+            and all(isinstance(action_row, (list, ActionRow)) for action_row in components)
         ):
             _components = []
             for action_row in components:
-                for component in action_row:
+                for component in (
+                    action_row if isinstance(action_row, list) else action_row.components
+                ):
                     if isinstance(component, SelectMenu):
                         component._json["options"] = [option._json for option in component.options]
                 _components.append(
@@ -238,7 +240,11 @@ class CommandContext(Context):
                         "type": 1,
                         "components": [
                             (component._json if component._json.get("custom_id") else [])
-                            for component in action_row
+                            for component in (
+                                action_row
+                                if isinstance(action_row, list)
+                                else action_row.components
+                            )
                         ],
                     }
                 )
@@ -389,11 +395,13 @@ class CommandContext(Context):
         elif (
             isinstance(components, list)
             and components
-            and all(isinstance(action_row, list) for action_row in components)
+            and all(isinstance(action_row, (list, ActionRow)) for action_row in components)
         ):
             _components = []
             for action_row in components:
-                for component in action_row:
+                for component in (
+                    action_row if isinstance(action_row, list) else action_row.components
+                ):
                     if isinstance(component, SelectMenu):
                         component._json["options"] = [option._json for option in component.options]
                 _components.append(
@@ -401,7 +409,11 @@ class CommandContext(Context):
                         "type": 1,
                         "components": [
                             (component._json if component._json.get("custom_id") else [])
-                            for component in action_row
+                            for component in (
+                                action_row
+                                if isinstance(action_row, list)
+                                else action_row.components
+                            )
                         ],
                     }
                 )

--- a/interactions/context.py
+++ b/interactions/context.py
@@ -221,6 +221,25 @@ class CommandContext(Context):
                     ],
                 }
             ]
+        elif (
+            isinstance(components, list)
+            and components
+            and all(isinstance(action_row, list) for action_row in components)
+        ):
+            _components = []
+            for action_row in components:
+                for component in action_row:
+                    if isinstance(component, SelectMenu):
+                        component._json["options"] = [option._json for option in component.options]
+                _components.append(
+                    {
+                        "type": 1,
+                        "components": [
+                            (component._json if component._json.get("custom_id") else [])
+                            for component in action_row
+                        ],
+                    }
+                )
         elif isinstance(components, ActionRow):
             _components[0]["components"] = [
                 (component._json if component._json.get("custom_id") else [])
@@ -361,6 +380,25 @@ class CommandContext(Context):
                     ],
                 }
             ]
+        elif (
+            isinstance(components, list)
+            and components
+            and all(isinstance(action_row, list) for action_row in components)
+        ):
+            _components = []
+            for action_row in components:
+                for component in action_row:
+                    if isinstance(component, SelectMenu):
+                        component._json["options"] = [option._json for option in component.options]
+                _components.append(
+                    {
+                        "type": 1,
+                        "components": [
+                            (component._json if component._json.get("custom_id") else [])
+                            for component in action_row
+                        ],
+                    }
+                )
         elif isinstance(components, ActionRow):
             _components[0]["components"] = [
                 (component._json if component._json.get("custom_id") else [])

--- a/interactions/context.py
+++ b/interactions/context.py
@@ -174,7 +174,7 @@ class CommandContext(Context):
         :param allowed_mentions?: The message interactions/mention limits that the message can refer to.
         :type allowed_mentions: Optional[MessageInteraction]
         :param components?: A component, or list of components for the message.
-        :type components: Optional[Union[Component, List[Component]]]
+        :type components: Optional[Union[Union[ActionRow, Button, SelectMenu], List[Union[ActionRow, Button, SelectMenu]]]]
         :param ephemeral?: Whether the response is hidden or not.
         :type ephemeral: Optional[bool]
         :return: The sent message as an object.

--- a/interactions/context.py
+++ b/interactions/context.py
@@ -156,7 +156,9 @@ class CommandContext(Context):
         # attachments: Optional[List[Any]] = None,  # TODO: post-v4: Replace with own file type.
         embeds: Optional[Union[Embed, List[Embed]]] = None,
         allowed_mentions: Optional[MessageInteraction] = None,
-        components: Optional[Union[Component, List[Component]]] = None,
+        components: Optional[
+            Union[Union[ActionRow, Button, SelectMenu], List[Union[ActionRow, Button, SelectMenu]]]
+        ] = None,
         ephemeral: Optional[bool] = False,
     ) -> Message:
         """
@@ -328,7 +330,9 @@ class CommandContext(Context):
         embeds: Optional[Union[Embed, List[Embed]]] = None,
         allowed_mentions: Optional[MessageInteraction] = None,
         message_reference: Optional[MessageReference] = None,
-        components: Optional[Union[ActionRow, Button, SelectMenu]] = None,
+        components: Optional[
+            Union[Union[ActionRow, Button, SelectMenu], List[Union[ActionRow, Button, SelectMenu]]]
+        ] = None,
     ) -> Message:
         """
         This allows the invocation state described in the "context"

--- a/interactions/context.py
+++ b/interactions/context.py
@@ -201,7 +201,11 @@ class CommandContext(Context):
                 {
                     "type": 1,
                     "components": [
-                        (component._json if component._json.get("custom_id") else [])
+                        (
+                            component._json
+                            if component._json.get("custom_id") or component._json.get("url")
+                            else []
+                        )
                         for component in action_row.components
                     ],
                 }
@@ -218,7 +222,11 @@ class CommandContext(Context):
                 {
                     "type": 1,
                     "components": [
-                        (component._json if component._json.get("custom_id") else [])
+                        (
+                            component._json
+                            if component._json.get("custom_id") or component._json.get("url")
+                            else []
+                        )
                         for component in components
                     ],
                 }
@@ -239,7 +247,11 @@ class CommandContext(Context):
                     {
                         "type": 1,
                         "components": [
-                            (component._json if component._json.get("custom_id") else [])
+                            (
+                                component._json
+                                if component._json.get("custom_id") or component._json.get("url")
+                                else []
+                            )
                             for component in (
                                 action_row
                                 if isinstance(action_row, list)
@@ -250,14 +262,20 @@ class CommandContext(Context):
                 )
         elif isinstance(components, ActionRow):
             _components[0]["components"] = [
-                (component._json if component._json.get("custom_id") else [])
+                (
+                    component._json
+                    if component._json.get("custom_id") or component._json.get("url")
+                    else []
+                )
                 for component in components.components
             ]
         elif isinstance(components, (Button, SelectMenu)):
             if isinstance(components, SelectMenu):
                 components._json["options"] = [option._json for option in components.options]
             _components[0]["components"] = (
-                [components._json] if components._json.get("custom_id") else []
+                [components._json]
+                if components._json.get("custom_id") or components._json.get("url")
+                else []
             )
         elif components is None:
             _components = None
@@ -370,7 +388,11 @@ class CommandContext(Context):
                 {
                     "type": 1,
                     "components": [
-                        (component._json if component._json.get("custom_id") else [])
+                        (
+                            component._json
+                            if component._json.get("custom_id") or component._json.get("url")
+                            else []
+                        )
                         for component in action_row.components
                     ],
                 }
@@ -387,7 +409,11 @@ class CommandContext(Context):
                 {
                     "type": 1,
                     "components": [
-                        (component._json if component._json.get("custom_id") else [])
+                        (
+                            component._json
+                            if component._json.get("custom_id") or component._json.get("url")
+                            else []
+                        )
                         for component in components
                     ],
                 }
@@ -408,7 +434,11 @@ class CommandContext(Context):
                     {
                         "type": 1,
                         "components": [
-                            (component._json if component._json.get("custom_id") else [])
+                            (
+                                component._json
+                                if component._json.get("custom_id") or component._json.get("url")
+                                else []
+                            )
                             for component in (
                                 action_row
                                 if isinstance(action_row, list)
@@ -419,14 +449,20 @@ class CommandContext(Context):
                 )
         elif isinstance(components, ActionRow):
             _components[0]["components"] = [
-                (component._json if component._json.get("custom_id") else [])
+                (
+                    component._json
+                    if component._json.get("custom_id") or component._json.get("url")
+                    else []
+                )
                 for component in components.components
             ]
         elif isinstance(components, (Button, SelectMenu)):
             if isinstance(components, SelectMenu):
                 components._json["options"] = [option._json for option in components.options]
             _components[0]["components"] = (
-                [components._json] if components._json.get("custom_id") else []
+                [components._json]
+                if components._json.get("custom_id") or components._json.get("url")
+                else []
             )
         elif components is None:
             _components = None

--- a/interactions/context.py
+++ b/interactions/context.py
@@ -411,7 +411,7 @@ class CommandContext(Context):
                 [components._json] if components._json.get("custom_id") else []
             )
         elif components is None:
-            print(_message_reference)
+            _components = None
         else:
             _components = []
 

--- a/interactions/context.py
+++ b/interactions/context.py
@@ -196,18 +196,26 @@ class CommandContext(Context):
             and (isinstance(action_row, ActionRow) for action_row in components)
         ):
             _components = [
-                {"type": 1, "components": [component._json for component in action_row.components]}
+                {
+                    "type": 1,
+                    "components": [
+                        (component._json if components._json.get("custom_id") else [])
+                        for component in action_row.components
+                    ],
+                }
                 for action_row in components
             ]
         elif isinstance(components, ActionRow):
             _components[0]["components"] = [
-                (component._json if components.get("_json") else [])
+                (component._json if components._json.get("custom_id") else [])
                 for component in components.components
             ]
         elif isinstance(components, (Button, SelectMenu)):
-            _components[0]["components"] = [components._json] if components.get("_json") else []
+            _components[0]["components"] = (
+                [components._json] if components._json.get("custom_id") else []
+            )
         else:
-            _components = [components] if components.get("_json") else []
+            _components = [components] if components._json.get("custom_id") else []
 
         _ephemeral: int = (1 << 6) if ephemeral else 0
 
@@ -310,16 +318,24 @@ class CommandContext(Context):
             and (isinstance(action_row, ActionRow) for action_row in components)
         ):
             _components = [
-                {"type": 1, "components": [component._json for component in action_row.components]}
+                {
+                    "type": 1,
+                    "components": [
+                        (component._json if components._json.get("custom_id") else [])
+                        for component in action_row.components
+                    ],
+                }
                 for action_row in components
             ]
         elif isinstance(components, ActionRow):
             _components[0]["components"] = [
-                (component._json if components.get("_json") else [])
+                (component._json if components._json.get("custom_id") else [])
                 for component in components.components
             ]
         elif isinstance(components, (Button, SelectMenu)):
-            _components[0]["components"] = [components._json] if components.get("_json") else []
+            _components[0]["components"] = (
+                [components._json] if components._json.get("custom_id") else []
+            )
         else:
             _components = []
 

--- a/interactions/context.py
+++ b/interactions/context.py
@@ -200,14 +200,14 @@ class CommandContext(Context):
                 for action_row in components
             ]
         elif isinstance(components, ActionRow):
-            _components[0]["components"] = [component._json for component in components.components]
-        elif isinstance(components, Button):
-            _components[0]["components"] = [] if components is None else [components._json]
-        elif isinstance(components, SelectMenu):
-            components._json["options"] = [option._json for option in components.options]
-            _components[0]["components"] = [] if components is None else [components._json]
+            _components[0]["components"] = [
+                (component._json if components.get("_json") else [])
+                for component in components.components
+            ]
+        elif isinstance(components, (Button, SelectMenu)):
+            _components[0]["components"] = [components._json] if components.get("_json") else []
         else:
-            _components = [] if components is None else [components]
+            _components = [components] if components.get("_json") else []
 
         _ephemeral: int = (1 << 6) if ephemeral else 0
 
@@ -314,13 +314,12 @@ class CommandContext(Context):
                 for action_row in components
             ]
         elif isinstance(components, ActionRow):
-            _components[0]["components"] = [component._json for component in components.components]
-        elif isinstance(components, Button):
-            _components[0]["components"] = [] if components is None else [components._json]
-        elif isinstance(components, SelectMenu):
-            components._json["options"] = [option._json for option in components.options]
-            _components[0]["components"] = [] if components is None else [components._json]
-
+            _components[0]["components"] = [
+                (component._json if components.get("_json") else [])
+                for component in components.components
+            ]
+        elif isinstance(components, (Button, SelectMenu)):
+            _components[0]["components"] = [components._json] if components.get("_json") else []
         else:
             _components = []
 

--- a/interactions/context.py
+++ b/interactions/context.py
@@ -210,6 +210,8 @@ class CommandContext(Context):
             and components
             and all(isinstance(component, (Button, SelectMenu)) for component in components)
         ):
+            if isinstance(components[0], SelectMenu):
+                components[0]._json["options"] = [option._json for option in components[0].options]
             _components = [
                 {
                     "type": 1,
@@ -348,6 +350,8 @@ class CommandContext(Context):
             and components
             and all(isinstance(component, (Button, SelectMenu)) for component in components)
         ):
+            if isinstance(components[0], SelectMenu):
+                components[0]._json["options"] = [option._json for option in components[0].options]
             _components = [
                 {
                     "type": 1,

--- a/interactions/context.pyi
+++ b/interactions/context.pyi
@@ -47,7 +47,9 @@ class CommandContext(Context):
         # attachments: Optional[List[Any]] = None,  # TODO: post-v4: Replace with own file type.
         embeds: Optional[Union[Embed, List[Embed]]] = None,
         allowed_mentions: Optional[MessageInteraction] = None,
-        components: Optional[Union[Component, List[Component]]] = None,
+        components: Optional[
+            Union[Union[ActionRow, Button, SelectMenu], List[Union[ActionRow, Button, SelectMenu]]]
+        ] = None,
         ephemeral: Optional[bool] = False,
     ) -> Message: ...
     async def edit(
@@ -58,7 +60,9 @@ class CommandContext(Context):
         # attachments: Optional[List[Any]] = None,  # TODO: post-v4: Replace with own file type.
         embeds: Optional[Union[Embed, List[Embed]]] = None,
         allowed_mentions: Optional[MessageInteraction] = None,
-        components: Optional[Union[Component, List[Component]]] = None,
+        components: Optional[
+            Union[Union[ActionRow, Button, SelectMenu], List[Union[ActionRow, Button, SelectMenu]]]
+        ] = None,
     ) -> Message: ...
     async def delete(self) -> None: ...
     async def popup(self, modal: Modal): ...

--- a/interactions/context.pyi
+++ b/interactions/context.pyi
@@ -48,7 +48,7 @@ class CommandContext(Context):
         embeds: Optional[Union[Embed, List[Embed]]] = None,
         allowed_mentions: Optional[MessageInteraction] = None,
         components: Optional[
-            Union[Union[ActionRow, Button, SelectMenu], List[Union[ActionRow, Button, SelectMenu]]]
+            Union[ActionRow, Button, SelectMenu, List[Union[ActionRow, Button, SelectMenu]]]
         ] = None,
         ephemeral: Optional[bool] = False,
     ) -> Message: ...
@@ -61,7 +61,7 @@ class CommandContext(Context):
         embeds: Optional[Union[Embed, List[Embed]]] = None,
         allowed_mentions: Optional[MessageInteraction] = None,
         components: Optional[
-            Union[Union[ActionRow, Button, SelectMenu], List[Union[ActionRow, Button, SelectMenu]]]
+            Union[ActionRow, Button, SelectMenu, List[Union[ActionRow, Button, SelectMenu]]]
         ] = None,
     ) -> Message: ...
     async def delete(self) -> None: ...


### PR DESCRIPTION
## About

This pull request is about fixing component sending/editing with context, which lets you send/edit components using the context (`ctx`) properly.
Specifically `await ctx.send(...)` and `await ctx.edit(...)`.

In addition to fixing component sending/editing, I have also filled in missing ways to send/edit components:

### Sending/editing one ActionRow

Here is a sample code example where you can send and edit one ActionRow:
```py
await ctx.send("c", components=button_row1)
await asyncio.sleep(1)
await ctx.edit("c", components=button_row2)
```
Result:
<img src="https://cdn.discordapp.com/attachments/922703586301972561/922705605964234783/lWCDNM1W0L.gif"></img>

### Sending/editing individual components
Sample code:
```py
await ctx.send("b", components=select)
await asyncio.sleep(1)
await ctx.edit("b", components=button1)
await asyncio.sleep(1)
await ctx.edit("b", components=select)
await asyncio.sleep(1)
await ctx.send("b", components=button1)
```
Result:
<img src="https://cdn.discordapp.com/attachments/922703586301972561/922706436704862208/zv4VSpqyAh.gif"></img>

### Sending/editing multiple ActionRows
Sample code:
```py
await ctx.send("lol", components=[button_row1, button_row2])
await asyncio.sleep(1)
await ctx.edit("ayo", components=[button_row2, button_row1])
await asyncio.sleep(1)
await ctx.edit("wow", components=[select_row1, select_row2])
await asyncio.sleep(1)
await ctx.edit("ez", components=[select_row2, select_row1])
```
Result:
<img src="https://cdn.discordapp.com/attachments/922703586301972561/922706983784697856/sJekRy3X8w.gif"></img>

### Sending/editing with lists
Sample code:
```py
await ctx.send("a", components=[[button1, button2], [select]])
await asyncio.sleep(1)
await ctx.edit("a", components=[[select], [button1, button2]])
```
Result:
<img src="https://cdn.discordapp.com/attachments/922703586301972561/922707644265922560/w2qCyOYAIU.gif"></img>

### Finally, removing components
When editing, the components stay if `components=None`, but anything else that is not a list of action rows, a list of components, component, action row, or a list of a list of components (example: `[]`), the components will be removed from the message.
Sample code:
```py
await ctx.send("hi", components=button1)
await asyncio.sleep(1)
await ctx.edit("hi", components=None)
await asyncio.sleep(1)
await ctx.edit("hi", components=[])
```
Result:
<img src="https://cdn.discordapp.com/attachments/922703586301972561/922708789130579978/4niEhc445v.gif"></img>

Please review this code and tell me if I have done anything incorrectly.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [x] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [x] New feature/enhancement
  - [x] Bugfix
