### PR TITLE
docs(components.py/Button): label typo

### DIFF
--- a/interactions/models/component.py
+++ b/interactions/models/component.py
@@ -114,7 +114,7 @@ class Button(DictSerializerMixin):
     :ivar ComponentType type: The type of button. Always defaults to ``2``.
     :ivar ButtonStyle style: The style of the button.
     :ivar str label: The label of the button.
-    :ivar Optional[Emoji] emoji?: The emoji used alongside the laebl of the button.
+    :ivar Optional[Emoji] emoji?: The emoji used alongside the label of the button.
     :ivar Optional[str] custom_id?: The customized "ID" of the button.
     :ivar Optional[str] url?: The URL route/path of the button.
     :ivar Optional[bool] disabled?: Whether the button is unable to be used.


### PR DESCRIPTION
## About

This pull request is about a typo, which is fixed.

## Checklist

- [ ] I've ran `pre-commit` to format and lint the change(s) made.
- [X] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [X] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues/399).
  - (If existent): [Issue 399](https://github.com/goverfl0w/discord-interactions/issues/399)
- [ ] I've made this pull request for/as: (check all that apply)
  - [X] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [ ] Bugfix
