### PR TITLE
feat: implement @message_command and @user_command

### DIFF
--- a/interactions/client.py
+++ b/interactions/client.py
@@ -372,6 +372,117 @@ class Client:
 
         return decorator
 
+    def message_command(
+        self,
+        *,
+        name: Optional[str] = None,
+        scope: Optional[Union[int, Guild, List[int], List[Guild]]] = None,
+        default_permission: Optional[bool] = None,
+    ) -> Callable[..., Any]:
+        """
+        A decorator for registering a message context menu to the Discord API,
+        as well as being able to listen for ``INTERACTION_CREATE`` dispatched
+        gateway events.
+        The structure of a user context menu:
+        .. code-block:: python
+            @message_command(name="Context menu name")
+            async def context_menu_name(ctx):
+                ...
+        The ``scope`` kwarg field may also be used to designate the command in question
+        applicable to a guild or set of guilds.
+        :param name: The name of the application command. This *is* required but kept optional to follow kwarg rules.
+        :type name: Optional[str]
+        :param scope?: The "scope"/applicable guilds the application command applies to. Defaults to ``None``.
+        :type scope: Optional[Union[int, Guild, List[int], List[Guild]]]
+        :param default_permission?: The default permission of accessibility for the application command. Defaults to ``True``.
+        :type default_permission: Optional[bool]
+        :return: A callable response.
+        :rtype: Callable[..., Any]
+        """
+
+        def decorator(coro: Coroutine) -> Callable[..., Any]:
+            if not name:
+                raise InteractionException(11, message="Your command must have a name.")
+
+            if not len(coro.__code__.co_varnames):
+                raise InteractionException(
+                    11,
+                    message="Your command needs at least one argument to return context.",
+                )
+
+            commands: List[ApplicationCommand] = command(
+                type=ApplicationCommandType.MESSAGE,
+                name=name,
+                description=None,
+                scope=scope,
+                options=None,
+                default_permission=default_permission,
+            )
+
+            if self.automate_sync:
+                [self.loop.run_until_complete(self.synchronize(command)) for command in commands]
+
+            return self.event(coro, name=f"command_{name}")
+
+        return decorator
+    
+    def user_command(
+        self,
+        *,
+        name: Optional[str] = None,
+        scope: Optional[Union[int, Guild, List[int], List[Guild]]] = None,
+        default_permission: Optional[bool] = None,
+    ) -> Callable[..., Any]:
+        """
+        A decorator for registering a user context menu to the Discord API,
+        as well as being able to listen for ``INTERACTION_CREATE`` dispatched
+        gateway events.
+        The structure of a user context menu:
+        .. code-block:: python
+            @user_command(name="Context menu name")
+            async def context_menu_name(ctx):
+                ...
+        The ``scope`` kwarg field may also be used to designate the command in question
+        applicable to a guild or set of guilds.
+        :param name: The name of the application command. This *is* required but kept optional to follow kwarg rules.
+        :type name: Optional[str]
+        :param scope?: The "scope"/applicable guilds the application command applies to. Defaults to ``None``.
+        :type scope: Optional[Union[int, Guild, List[int], List[Guild]]]
+        :param default_permission?: The default permission of accessibility for the application command. Defaults to ``True``.
+        :type default_permission: Optional[bool]
+        :return: A callable response.
+        :rtype: Callable[..., Any]
+        """
+
+        def decorator(coro: Coroutine) -> Callable[..., Any]:
+            if not name:
+                raise InteractionException(11, message="Your command must have a name.")
+
+            if not len(coro.__code__.co_varnames):
+                raise InteractionException(
+                    11,
+                    message="Your command needs at least one argument to return context.",
+                )
+
+            commands: List[ApplicationCommand] = command(
+                type=ApplicationCommandType.USER,
+                name=name,
+                description=None,
+                scope=scope,
+                options=None,
+                default_permission=default_permission,
+            )
+
+            if self.automate_sync:
+                [
+                    self.loop.run_until_complete(self.synchronize(command))
+                    for command in commands
+                ]
+
+            return self.event(coro, name=f"command_{name}")
+
+        return decorator
+
     def component(self, component: Union[str, Button, SelectMenu]) -> Callable[..., Any]:
         """
         A decorator for listening to ``INTERACTION_CREATE`` dispatched gateway

--- a/interactions/client.py
+++ b/interactions/client.py
@@ -372,7 +372,7 @@ class Client:
         as well as being able to listen for ``INTERACTION_CREATE`` dispatched
         gateway events.
 
-        The structure of a user context menu:
+        The structure of a message context menu:
 
         .. code-block:: python
 

--- a/interactions/client.py
+++ b/interactions/client.py
@@ -413,9 +413,7 @@ class Client:
             commands: List[ApplicationCommand] = command(
                 type=ApplicationCommandType.MESSAGE,
                 name=name,
-                description=None,
                 scope=scope,
-                options=None,
                 default_permission=default_permission,
             )
 
@@ -425,7 +423,7 @@ class Client:
             return self.event(coro, name=f"command_{name}")
 
         return decorator
-    
+
     def user_command(
         self,
         *,
@@ -467,17 +465,12 @@ class Client:
             commands: List[ApplicationCommand] = command(
                 type=ApplicationCommandType.USER,
                 name=name,
-                description=None,
                 scope=scope,
-                options=None,
                 default_permission=default_permission,
             )
 
             if self.automate_sync:
-                [
-                    self.loop.run_until_complete(self.synchronize(command))
-                    for command in commands
-                ]
+                [self.loop.run_until_complete(self.synchronize(command)) for command in commands]
 
             return self.event(coro, name=f"command_{name}")
 

--- a/interactions/client.py
+++ b/interactions/client.py
@@ -425,7 +425,7 @@ class Client:
             return self.event(coro, name=f"command_{name}")
 
         return decorator
-    
+
     def user_command(
         self,
         *,
@@ -474,10 +474,7 @@ class Client:
             )
 
             if self.automate_sync:
-                [
-                    self.loop.run_until_complete(self.synchronize(command))
-                    for command in commands
-                ]
+                [self.loop.run_until_complete(self.synchronize(command)) for command in commands]
 
             return self.event(coro, name=f"command_{name}")
 

--- a/interactions/client.py
+++ b/interactions/client.py
@@ -383,13 +383,18 @@ class Client:
         A decorator for registering a message context menu to the Discord API,
         as well as being able to listen for ``INTERACTION_CREATE`` dispatched
         gateway events.
+
         The structure of a user context menu:
+
         .. code-block:: python
+
             @message_command(name="Context menu name")
             async def context_menu_name(ctx):
                 ...
+
         The ``scope`` kwarg field may also be used to designate the command in question
         applicable to a guild or set of guilds.
+
         :param name: The name of the application command. This *is* required but kept optional to follow kwarg rules.
         :type name: Optional[str]
         :param scope?: The "scope"/applicable guilds the application command applies to. Defaults to ``None``.
@@ -435,13 +440,18 @@ class Client:
         A decorator for registering a user context menu to the Discord API,
         as well as being able to listen for ``INTERACTION_CREATE`` dispatched
         gateway events.
+
         The structure of a user context menu:
+
         .. code-block:: python
+
             @user_command(name="Context menu name")
             async def context_menu_name(ctx):
                 ...
+
         The ``scope`` kwarg field may also be used to designate the command in question
         applicable to a guild or set of guilds.
+
         :param name: The name of the application command. This *is* required but kept optional to follow kwarg rules.
         :type name: Optional[str]
         :param scope?: The "scope"/applicable guilds the application command applies to. Defaults to ``None``.


### PR DESCRIPTION
## About

This pull request is about implementing context menus, which lets you easily create context menus.

Due to #406 and #407, I was not able to get them to work. However, I implemented decorators that work and sync the commands properly, so at least I was able to test that.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [x] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [x] New feature/enhancement
  - [ ] Bugfix
