### PR TITLE
Fix/autocomplete doc

### DIFF
--- a/interactions/client.py
+++ b/interactions/client.py
@@ -414,7 +414,7 @@ class Client:
         .. code-block:: python
 
             @autocomplete("option_name")
-            async def autocomplete_choice_list(ctx):
+            async def autocomplete_choice_list(ctx, user_input: str = ""):
                 await ctx.populate([...])
 
         :param name: The name of the option to autocomplete.


### PR DESCRIPTION
## About

Small fix for the code example in `Client.autocomplete`.

The current example doesn't really work, since the decorated handler is called with the current user input string as first argument if the input is not empty. Not accepting this positional arg causes some call mismatch in the event handling stack.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [x] I've made this pull request for/as: (check all that apply)
  - [x] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [ ] Bugfix
