### PR TITLE
refactor: Logger parse structure

### DIFF
--- a/interactions/api/dispatch.py
+++ b/interactions/api/dispatch.py
@@ -1,8 +1,10 @@
 from asyncio import get_event_loop
-from logging import Logger, getLogger
+from logging import Logger
 from typing import Coroutine, Optional
 
-log: Logger = getLogger("dispatch")
+from interactions.base import get_logger
+
+log: Logger = get_logger("dispatch")
 
 
 class Listener:

--- a/interactions/api/gateway.py
+++ b/interactions/api/gateway.py
@@ -1,7 +1,7 @@
 import sys
 from asyncio import get_event_loop, run_coroutine_threadsafe
 from json import dumps
-from logging import Logger, getLogger
+from logging import Logger
 from random import random
 from threading import Event, Thread
 from typing import Any, List, Optional, Union
@@ -10,6 +10,7 @@ from orjson import dumps as ordumps
 from orjson import loads
 
 from interactions.api.models.gw import Presence
+from interactions.base import get_logger
 from interactions.enums import InteractionType, OptionType
 
 from .dispatch import Listener
@@ -18,7 +19,7 @@ from .error import GatewayException
 from .http import HTTPClient
 from .models.flags import Intents
 
-log: Logger = getLogger("gateway")
+log: Logger = get_logger("gateway")
 
 __all__ = ("Heartbeat", "WebSocket")
 

--- a/interactions/api/http.py
+++ b/interactions/api/http.py
@@ -11,7 +11,6 @@ from aiohttp import ClientSession, FormData
 from aiohttp import __version__ as http_version
 
 import interactions.api.cache
-
 from interactions.base import __version__, get_logger
 from interactions.models.misc import MISSING
 

--- a/interactions/api/http.py
+++ b/interactions/api/http.py
@@ -9,6 +9,7 @@ from aiohttp import ClientSession, FormData
 from aiohttp import __version__ as http_version
 
 import interactions.api.cache
+from interactions.base import __version__, get_logger
 
 from ..api.cache import Cache, Item
 from ..api.error import HTTPException
@@ -28,7 +29,6 @@ from ..api.models import (
     User,
     WelcomeScreen,
 )
-from interactions.base import __version__, get_logger
 
 log: Logger = get_logger("http")
 

--- a/interactions/api/http.py
+++ b/interactions/api/http.py
@@ -1,6 +1,6 @@
 from asyncio import AbstractEventLoop, Event, Lock, get_event_loop, sleep
 from json import dumps
-from logging import Logger, getLogger
+from logging import Logger
 from sys import version_info
 from typing import Any, ClassVar, Dict, List, Optional, Tuple, Union
 from urllib.parse import quote
@@ -28,9 +28,9 @@ from ..api.models import (
     User,
     WelcomeScreen,
 )
-from ..base import __version__
+from interactions.base import __version__, get_logger
 
-log: Logger = getLogger("http")
+log: Logger = get_logger("http")
 
 __all__ = ("Route", "Padlock", "Request", "HTTPClient")
 session: ClientSession = ClientSession()

--- a/interactions/api/models/misc.py
+++ b/interactions/api/models/misc.py
@@ -4,11 +4,13 @@
 # TODO: Reorganise mixins to its own thing, currently placed here because circular import sucks.
 # also, it should be serialiser* but idk, fl0w'd say something if I left it like that. /shrug
 import datetime
-import logging
+from logging import Logger
 from math import floor
 from typing import Union
 
-log = logging.getLogger("mixin")
+from interactions.base import get_logger
+
+log: Logger = get_logger("mixin")
 
 
 class DictSerializerMixin(object):

--- a/interactions/base.py
+++ b/interactions/base.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Union, Optional, List
+from typing import List, Optional, Union
 
 from colorama import Fore, Style, init
 
@@ -27,8 +27,10 @@ class Data:
     LOGGERS: List[str] = []
 
 
-def get_logger(logger: Optional[Union[logging.Logger, str]] = None,
-               handler: Optional[logging.Handler] = logging.NullHandler()) -> logging.Logger:
+def get_logger(
+    logger: Optional[Union[logging.Logger, str]] = None,
+    handler: Optional[logging.Handler] = logging.NullHandler(),
+) -> logging.Logger:
     _logger = logging.getLogger(logger) if isinstance(logger, str) else logger
     _logger_name = logger if isinstance(logger, str) else logger.name
     if len(_logger.handlers) > 1:

--- a/interactions/base.py
+++ b/interactions/base.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Optional, Union
+from typing import ClassVar, List, Optional, Union
 
 from colorama import Fore, Style, init
 
@@ -23,13 +23,13 @@ class Data:
     :ivar LOGGERS List[str]: A list of all loggers registered from this library
     """
 
-    # LOG_LEVEL: ClassVar[int] = logging.WARNING
+    LOG_LEVEL: ClassVar[int] = logging.ERROR
     LOGGERS: List[str] = []
 
 
 def get_logger(
     logger: Optional[Union[logging.Logger, str]] = None,
-    handler: Optional[logging.Handler] = logging.NullHandler(),
+    handler: Optional[logging.Handler] = logging.StreamHandler(),
 ) -> logging.Logger:
     _logger = logging.getLogger(logger) if isinstance(logger, str) else logger
     _logger_name = logger if isinstance(logger, str) else logger.name
@@ -37,8 +37,9 @@ def get_logger(
         _logger.removeHandler(_logger.handlers[0])
     _handler = handler
     _handler.setFormatter(CustomFormatter)
-    # _handler.setLevel(Data.LOG_LEVEL)  # this is sort of useless
+    _handler.setLevel(Data.LOG_LEVEL)
     _logger.addHandler(handler)
+    _logger.propagate = True
 
     Data.LOGGERS.append(_logger_name)
     return _logger

--- a/interactions/base.py
+++ b/interactions/base.py
@@ -20,6 +20,7 @@ __authors__ = {
 class Data:
     """A class representing constants for the library.
 
+    :ivar LOG_LEVEL ClassVar[int]: The default level of logging as an integer
     :ivar LOGGERS List[str]: A list of all loggers registered from this library
     """
 
@@ -38,7 +39,7 @@ def get_logger(
     _handler = handler
     _handler.setFormatter(CustomFormatter)
     _handler.setLevel(Data.LOG_LEVEL)
-    _logger.addHandler(handler)
+    _logger.addHandler(_handler)
     _logger.propagate = True
 
     Data.LOGGERS.append(_logger_name)

--- a/interactions/base.py
+++ b/interactions/base.py
@@ -1,5 +1,5 @@
 import logging
-from typing import ClassVar
+from typing import Union, Optional, List
 
 from colorama import Fore, Style, init
 
@@ -18,9 +18,28 @@ __authors__ = {
 
 
 class Data:
-    """A class representing constants for the library."""
+    """A class representing constants for the library.
 
-    LOGGER: ClassVar[int] = logging.WARNING
+    :ivar LOGGERS List[str]: A list of all loggers registered from this library
+    """
+
+    # LOG_LEVEL: ClassVar[int] = logging.WARNING
+    LOGGERS: List[str] = []
+
+
+def get_logger(logger: Optional[Union[logging.Logger, str]] = None,
+               handler: Optional[logging.Handler] = logging.NullHandler()) -> logging.Logger:
+    _logger = logging.getLogger(logger) if isinstance(logger, str) else logger
+    _logger_name = logger if isinstance(logger, str) else logger.name
+    if len(_logger.handlers) > 1:
+        _logger.removeHandler(_logger.handlers[0])
+    _handler = handler
+    _handler.setFormatter(CustomFormatter)
+    # _handler.setLevel(Data.LOG_LEVEL)  # this is sort of useless
+    _logger.addHandler(handler)
+
+    Data.LOGGERS.append(_logger_name)
+    return _logger
 
 
 class CustomFormatter(logging.Formatter):

--- a/interactions/base.py
+++ b/interactions/base.py
@@ -49,13 +49,13 @@ def get_logger(
 class CustomFormatter(logging.Formatter):
     """A class that allows for customized logged outputs from the library."""
 
-    format: str = "%(levelname)s:%(name)s:(ln.%(lineno)d):%(message)s"
+    format_str: str = "%(levelname)s:%(name)s:(ln.%(lineno)d):%(message)s"
     formats: dict = {
-        logging.DEBUG: Fore.CYAN + format + Fore.RESET,
-        logging.INFO: Fore.GREEN + format + Fore.RESET,
-        logging.WARNING: Fore.YELLOW + format + Fore.RESET,
-        logging.ERROR: Fore.RED + format + Fore.RESET,
-        logging.CRITICAL: Style.BRIGHT + Fore.RED + format + Fore.RESET + Style.NORMAL,
+        logging.DEBUG: Fore.CYAN + format_str + Fore.RESET,
+        logging.INFO: Fore.GREEN + format_str + Fore.RESET,
+        logging.WARNING: Fore.YELLOW + format_str + Fore.RESET,
+        logging.ERROR: Fore.RED + format_str + Fore.RESET,
+        logging.CRITICAL: Style.BRIGHT + Fore.RED + format_str + Fore.RESET + Style.NORMAL,
     }
 
     def __init__(self):

--- a/interactions/client.py
+++ b/interactions/client.py
@@ -2,7 +2,7 @@ import sys
 from asyncio import get_event_loop
 from importlib import import_module
 from importlib.util import resolve_name
-from logging import Logger, getLogger
+from logging import Logger
 from typing import Any, Callable, Coroutine, Dict, List, Optional, Union
 
 from interactions.api.dispatch import Listener
@@ -17,13 +17,14 @@ from .api.models.flags import Intents
 from .api.models.guild import Guild
 from .api.models.gw import Presence
 from .api.models.team import Application
+from .base import get_logger
 from .decor import command
 from .decor import component as _component
 from .enums import ApplicationCommandType
 from .models.command import ApplicationCommand, Option
 from .models.component import Button, Modal, SelectMenu
 
-log: Logger = getLogger("client")
+log: Logger = get_logger("client")
 _token: str = ""  # noqa
 _cache: Optional[Cache] = None
 

--- a/interactions/context.py
+++ b/interactions/context.py
@@ -1,4 +1,4 @@
-from logging import Logger, getLogger
+from logging import Logger
 from typing import List, Optional, Union
 
 from .api.models.channel import Channel
@@ -7,12 +7,13 @@ from .api.models.member import Member
 from .api.models.message import Embed, Message, MessageInteraction, MessageReference
 from .api.models.misc import DictSerializerMixin, Snowflake
 from .api.models.user import User
+from .base import get_logger
 from .enums import InteractionCallbackType, InteractionType
 from .models.command import Choice
 from .models.component import ActionRow, Button, Modal, SelectMenu
 from .models.misc import InteractionData
 
-log: Logger = getLogger("context")
+log: Logger = get_logger("context")
 
 
 class Context(DictSerializerMixin):


### PR DESCRIPTION
## About

Related to #421

~~Unless a simple logging configuration is setup, log messages should be hidden.~~ Users can set the level with `logging.basicConfig(level=logging.DEBUG)` ex. if they desire. `interactions` should then propagate its loggers to that StreamHandler

A list of loggers (their names) is present in `base.Data` which gets populated after importing `interactions`

## Checklist

- [X] I've ran `pre-commit` to format and lint the change(s) made.
- [X] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [X] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [X] Bugfix
