### PR TITLE
fix: prevent `NoneType` closure during guild member check.

### DIFF
--- a/interactions/api/models/guild.py
+++ b/interactions/api/models/guild.py
@@ -292,11 +292,18 @@ class Guild(DictSerializerMixin):
             else None
         )
         if not self.members and self._client:
-            members = self._client.cache.self_guilds.values[str(self.id)].members
-            if all(isinstance(member, Member) for member in members):
-                self.members = members
+
+            if (
+                not len(self._client.cache.self_guilds.view) > 1
+                or not self._client.cache.self_guilds.values[str(self.id)].members
+            ):
+                pass
             else:
-                self.members = [Member(**member, _client=self._client) for member in members]
+                members = self._client.cache.self_guilds.values[str(self.id)].members
+                if all(isinstance(member, Member) for member in members):
+                    self.members = members
+                else:
+                    self.members = [Member(**member, _client=self._client) for member in members]
 
     async def ban(
         self,


### PR DESCRIPTION
- fixed a bug (prevented iterating the NoneType)

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [ ] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
