### PR TITLE
chore: isolate dev dependencies into [dev] extra

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -10,7 +10,7 @@ the library off of pip:
 
 .. code-block:: bash
 
-    pip install -U discord-py-interactions
+    pip install -U discord-py-interactions[dev]
 
 Once you have the library installed in Python, you are able to instantiate and run a basic bot
 with a logging level that is set for debugging purposes. This is recommend in order to make it easier

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,2 @@
+Sphinx==4.1.2
+sphinx-hoverxref==1.0.0

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -1,0 +1,4 @@
+black==21.11b1
+flake8==3.9.2
+isort==5.9.3
+pre-commit==2.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,3 @@
 aiohttp==3.7.4.post0
-black==21.11b1
 colorama==0.4.4
-flake8==3.9.2
-isort==5.9.3
-orjson
-pre-commit==2.16.0
-Sphinx==4.1.2
-sphinx-hoverxref==1.0.0
+orjson==3.6.3

--- a/setup.py
+++ b/setup.py
@@ -12,14 +12,18 @@ with open("README.rst", "r", encoding="UTF-8") as f:
 with open(path.join(HERE, PACKAGE_NAME, "base.py"), encoding="utf-8") as fp:
     VERSION = re.search('__version__ = "([^"]+)"', fp.read()).group(1)
 
-extras = {
-    "lint": ["black", "flake8", "isort"],
-    "readthedocs": ["sphinx", "karma-sphinx-theme"],
-}
-extras["lint"] += extras["readthedocs"]
-extras["dev"] = extras["lint"] + extras["readthedocs"]
 
-requirements = open("requirements.txt").read().split("\n")[:-1]
+def read_requirements(filename):
+    with open(filename, "r", encoding="utf-8") as fp:
+        return fp.read().strip().splitlines()
+
+
+extras = {
+    "lint": read_requirements("requirements-lint.txt"),
+    "readthedocs": read_requirements("requirements-docs.txt"),
+}
+extras["dev"] = extras["lint"] + extras["readthedocs"]
+requirements = read_requirements("requirements.txt")
 
 setup(
     name="discord-py-interactions",


### PR DESCRIPTION
## About

Fixes #398 

Move code quality and documentation dependencies into an the [dev] extra. This will stop force-installing code quality tools in projects that make use of this library, in order to prevent a large amount of unnecessary code and potential version conflicts.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [x] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent): #398
- [x] I've made this pull request for/as: (check all that apply)
  - [x] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix

## Additional Notes

I have not changed any of the requirements in this PR. However, libraries in `requirements-lint.txt` can be removed completely since this project uses pre-commit for linting. pre-commit does not rely on the user's current environment and thus does not require these libraries to be installed. Since linting options are specified in pre-commit scripts instead of config files, running these tools manually is error prone, so it may be a better idea to simply not include them and instead direct contributors to run them with precommit, e.g. `pre-commit run flake8`

I can create a new issue/PR for this or add it to this PR if needed.