### PR TITLE
fix: change print to log.debug

### DIFF
--- a/interactions/client.py
+++ b/interactions/client.py
@@ -269,8 +269,8 @@ class Client:
             command.get("name") for command in cached_commands if command.get("name")
         ]
 
-        print(cached_commands)
-        print(cached_command_names)
+        log.debug(f"Cached commands: {cached_commands}")
+        log.debug(f"Cached command names: {cached_command_names}")
 
         if cached_commands:
             for command in commands:


### PR DESCRIPTION
## About

Changes a pair of leftover `print`s for `log.debug`s.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [x] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent): Fixes #443 
- [x] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
