### PR TITLE
fix: cannot provide Client.intents as list

### DIFF
--- a/interactions/client.py
+++ b/interactions/client.py
@@ -60,6 +60,7 @@ class Client:
         :type presence: Optional[Presence]
         """
         if isinstance(intents, list):
+            self.intents = Intents(0)
             for intent in intents:
                 self.intents |= intent
         else:


### PR DESCRIPTION
## About

Fixes bug where intents provided as a list causes error.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [x] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent): Fixes #442 
- [x] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
