### PR TITLE
feat: add Get Guild Audit Log to `HTTPClient`

### DIFF
--- a/interactions/api/http.py
+++ b/interactions/api/http.py
@@ -1087,7 +1087,12 @@ class HTTPClient:
         return await self._req.request(Route("GET", f"/guilds/{guild_id}/prune"), params=payload)
 
     async def get_guild_auditlog(
-        self, guild_id: int, user_id: Optional[int] = None, action_type: Optional[int] = None, before: Optional[int] = None, limit: int = 50
+        self,
+        guild_id: int,
+        user_id: Optional[int] = None,
+        action_type: Optional[int] = None,
+        before: Optional[int] = None,
+        limit: int = 50,
     ) -> dict:
         """
         Returns an audit log object for the guild. Requires the 'VIEW_AUDIT_LOG' permission.
@@ -1097,7 +1102,7 @@ class HTTPClient:
         :param before: filter the log before a certain entry id.
         :param limit: how many entries are returned (default 50, minimum 1, maximum 100)
         """
-        
+
         payload = {"limit": limit}
         if user_id:
             payload["user_id"] = user_id
@@ -1105,8 +1110,10 @@ class HTTPClient:
             payload["action_type"] = action_type
         if before:
             payload["before"] = before
-        
-        return await self._req.request(Route("GET", f"/guilds/{guild_id}/audit-logs"), params=payload)
+
+        return await self._req.request(
+            Route("GET", f"/guilds/{guild_id}/audit-logs"), params=payload
+        )
 
     # Guild (Member) endpoint
 

--- a/interactions/api/http.py
+++ b/interactions/api/http.py
@@ -1086,6 +1086,28 @@ class HTTPClient:
 
         return await self._req.request(Route("GET", f"/guilds/{guild_id}/prune"), params=payload)
 
+    async def get_guild_auditlog(
+        self, guild_id: int, user_id: Optional[int] = None, action_type: Optional[int] = None, before: Optional[int] = None, limit: int = 50
+    ) -> dict:
+        """
+        Returns an audit log object for the guild. Requires the 'VIEW_AUDIT_LOG' permission.
+        :param guild_id: Guild ID snowflake.
+        :param user_id: User ID snowflake. filter the log for actions made by a user.
+        :param action_type: the type ID of audit log event.
+        :param before: filter the log before a certain entry id.
+        :param limit: how many entries are returned (default 50, minimum 1, maximum 100)
+        """
+        
+        payload = {"limit": limit}
+        if user_id:
+            payload["user_id"] = user_id
+        if action_type:
+            payload["action_type"] = action_type
+        if before:
+            payload["before"] = before
+        
+        return await self._req.request(Route("GET", f"/guilds/{guild_id}/audit-logs"), params=payload)
+
     # Guild (Member) endpoint
 
     async def get_member(self, guild_id: int, member_id: int) -> Optional[Member]:


### PR DESCRIPTION
## About

add a GET request for Audit Log in HTTPClient.
Based on the Discord Docs:
https://discord.com/developers/docs/resources/audit-log#get-guild-audit-log

## Checklist

- [ ] I've ran `pre-commit` to format and lint the change(s) made.
- [ ] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [ ] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [X] New feature/enhancement
  - [ ] Bugfix
