### PR TITLE
fix: create new event loop if none exists on Python 3.10

### DIFF
--- a/interactions/api/http.py
+++ b/interactions/api/http.py
@@ -1,6 +1,6 @@
 import asyncio
 import traceback
-from asyncio import AbstractEventLoop, Lock, get_event_loop, get_running_loop
+from asyncio import AbstractEventLoop, Lock, get_event_loop, get_running_loop, new_event_loop
 from json import dumps
 from logging import Logger
 from sys import version_info
@@ -165,7 +165,10 @@ class Request:
         :type token: str
         """
         self.token = token
-        self._loop = get_event_loop() if version_info < (3, 10) else get_running_loop()
+        try:
+            self._loop = get_event_loop() if version_info < (3, 10) else get_running_loop()
+        except RuntimeError:
+            self._loop = new_event_loop()
         self.ratelimits = {}
         self.buckets = {}
         self._headers = {


### PR DESCRIPTION
## About

This pull request is about a bug in http.py, which does not create an event loop in Python 3.10 if one isn't running.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [ ] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
