### PR TITLE
feat: implement Member.id

### DIFF
--- a/interactions/api/models/member.py
+++ b/interactions/api/models/member.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Union
 
 from .channel import Channel
 from .flags import Permissions
-from .misc import MISSING, DictSerializerMixin
+from .misc import MISSING, DictSerializerMixin, Snowflake
 from .role import Role
 from .user import User
 
@@ -18,7 +18,6 @@ class Member(DictSerializerMixin):
         to speak.
 
     :ivar User user: The user of the guild.
-    :ivar int id: The id of the user.
     :ivar str nick: The nickname of the member.
     :ivar Optional[str] avatar?: The hash containing the user's guild avatar, if applicable.
     :ivar List[Role] roles: The list of roles of the member.
@@ -77,7 +76,13 @@ class Member(DictSerializerMixin):
             self.avatar = self.user.avatar
     
     @property
-    def id(self):
+    def id(self) -> Snowflake:
+        """
+        Returns the ID of the user.
+        
+        :return: The ID of the user
+        :rtype: Snowflake
+        """
         return self.user.id if self.user else None
 
     async def ban(

--- a/interactions/api/models/member.py
+++ b/interactions/api/models/member.py
@@ -34,7 +34,6 @@ class Member(DictSerializerMixin):
     __slots__ = (
         "_json",
         "user",
-        "id",
         "nick",
         "avatar",
         "roles",
@@ -57,7 +56,6 @@ class Member(DictSerializerMixin):
             if isinstance(self.user, User)
             else (User(**self.user) if self._json.get("user") else None)
         )
-        self.id = self.user.id if self.user else None
         self.joined_at = (
             datetime.fromisoformat(self._json.get("joined_at"))
             if self._json.get("joined_at")
@@ -77,6 +75,10 @@ class Member(DictSerializerMixin):
 
         if not self.avatar and self.user:
             self.avatar = self.user.avatar
+    
+    @property
+    def id(self):
+        return self.user.id if self.user else None
 
     async def ban(
         self,

--- a/interactions/api/models/member.py
+++ b/interactions/api/models/member.py
@@ -18,6 +18,7 @@ class Member(DictSerializerMixin):
         to speak.
 
     :ivar User user: The user of the guild.
+    :ivar int id: The id of the user.
     :ivar str nick: The nickname of the member.
     :ivar Optional[str] avatar?: The hash containing the user's guild avatar, if applicable.
     :ivar List[Role] roles: The list of roles of the member.
@@ -33,6 +34,7 @@ class Member(DictSerializerMixin):
     __slots__ = (
         "_json",
         "user",
+        "id",
         "nick",
         "avatar",
         "roles",
@@ -55,6 +57,7 @@ class Member(DictSerializerMixin):
             if isinstance(self.user, User)
             else (User(**self.user) if self._json.get("user") else None)
         )
+        self.id = self.user.id if self.user else None
         self.joined_at = (
             datetime.fromisoformat(self._json.get("joined_at"))
             if self._json.get("joined_at")

--- a/interactions/api/models/member.pyi
+++ b/interactions/api/models/member.pyi
@@ -9,12 +9,12 @@ from ..http import HTTPClient
 from .message import Message, Embed, MessageInteraction
 from ...models.component import ActionRow, Button, SelectMenu
 
-
 class Member(DictSerializerMixin):
 
     _json: dict
     _client: HTTPClient
     user: Optional[User]
+    id: Optional[int]
     nick: Optional[str]
     avatar: Optional[str]
     roles: List[Role]

--- a/interactions/api/models/member.pyi
+++ b/interactions/api/models/member.pyi
@@ -14,7 +14,6 @@ class Member(DictSerializerMixin):
     _json: dict
     _client: HTTPClient
     user: Optional[User]
-    id: Optional[int]
     nick: Optional[str]
     avatar: Optional[str]
     roles: List[Role]
@@ -28,6 +27,8 @@ class Member(DictSerializerMixin):
     communication_disabled_until: Optional[datetime.isoformat]
     hoisted_role: Any  # TODO: post-v4: Investigate what this is for when documented by Discord.
     def __init__(self, **kwargs): ...
+    @property
+    def id(self): ...
     async def ban(
         self,
         guild_id: int,

--- a/interactions/api/models/member.pyi
+++ b/interactions/api/models/member.pyi
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Any, List, Optional, Union
 
-from .misc import DictSerializerMixin, MISSING
+from .misc import DictSerializerMixin, MISSING, Snowflake
 from .role import Role
 from .user import User
 from .flags import Permissions
@@ -28,7 +28,7 @@ class Member(DictSerializerMixin):
     hoisted_role: Any  # TODO: post-v4: Investigate what this is for when documented by Discord.
     def __init__(self, **kwargs): ...
     @property
-    def id(self): ...
+    def id(self) -> Snowflake: ...
     async def ban(
         self,
         guild_id: int,


### PR DESCRIPTION
## About

This pull request is about implementing `interactions.Member.id`, which lets you use `member.id` instead of `member.user.id`.
Another example is `ctx.author.id` instead of `ctx.author.user.id`.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [x] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [x] New feature/enhancement
  - [ ] Bugfix
