### PR TITLE
feat: fill Context's Guild and Channel when possible, or replace with MISSING

### DIFF
--- a/interactions/context.py
+++ b/interactions/context.py
@@ -27,8 +27,8 @@ class Context(DictSerializerMixin):
     :ivar Optional[Message] message?: The message data model.
     :ivar Member author: The member data model.
     :ivar User user: The user data model.
-    :ivar Union[Channel, MISSING] channel: The channel data model.
-    :ivar Union[Guild, None, MISSING] guild: The guild data model.
+    :ivar Optional[Channel] channel: The channel data model.
+    :ivar Optional[Guild] guild: The guild data model.
     """
 
     __slots__ = ("message", "member", "author", "user", "channel", "guild", "client")

--- a/interactions/context.py
+++ b/interactions/context.py
@@ -27,8 +27,8 @@ class Context(DictSerializerMixin):
     :ivar Optional[Message] message?: The message data model.
     :ivar Member author: The member data model.
     :ivar User user: The user data model.
-    :ivar Channel channel: The channel data model.
-    :ivar Guild guild: The guild data model.
+    :ivar Union[Channel, MISSING] channel: The channel data model.
+    :ivar Union[Guild, None, MISSING] guild: The guild data model.
     """
 
     __slots__ = ("message", "member", "author", "user", "channel", "guild", "client")
@@ -44,9 +44,21 @@ class Context(DictSerializerMixin):
         self.author = self.member
         self.user = User(**self.user) if self._json.get("user") else None
 
-        # TODO: The below attributes are always None because they aren't by API return.
-        self.channel = Channel(**self.channel) if self._json.get("channel") else None
-        self.guild = Guild(**self.guild) if self._json.get("guild") else None
+        if guild := self._json.get("guild"):
+            self.guild = Guild(**guild)
+        elif self.guild_id is None:
+            self.guild = None
+        elif guild := self.client.cache.guilds.get(self.guild_id):
+            self.guild = guild
+        else:
+            self.guild = MISSING
+
+        if channel := self._json.get("channel"):
+            self.channel = Channel(**channel)
+        elif channel := self.client.cache.channels.get(self.channel_id):
+            self.channel = channel
+        else:
+            self.channel = MISSING
 
 
 class CommandContext(Context):

--- a/interactions/context.pyi
+++ b/interactions/context.pyi
@@ -17,8 +17,8 @@ class Context(DictSerializerMixin):
     author: Member
     member: Member
     user: User
-    channel: Union[Channel, MISSING]
-    guild: Union[Guild, None, MISSING]
+    channel: Optional[Channel]
+    guild: Optional[Guild]
     client: HTTPClient
     def __init__(self, **kwargs) -> None: ...
 

--- a/interactions/context.pyi
+++ b/interactions/context.pyi
@@ -17,8 +17,8 @@ class Context(DictSerializerMixin):
     author: Member
     member: Member
     user: User
-    channel: Channel
-    guild: Guild
+    channel: Union[Channel, MISSING]
+    guild: Union[Guild, None, MISSING]
     client: HTTPClient
     def __init__(self, **kwargs) -> None: ...
 


### PR DESCRIPTION
## About

This pull request checks the cache if the guild or channel is absent from the Context class. If there is no data, and the id (if it exists) is not found in cache, then the value is replaced with MISSING to signal that the data wasn't found

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [x] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
