### PR TITLE
fix: small typo in quickstart

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -4,7 +4,7 @@ Quickstart
 Installing
 **********
 
-**discord-interactions** is a :ref:`Python library <index:discord-interactions>` for the Discord Artificial Programming Interface. (API)
+**discord-interactions** is a :ref:`Python library <index:discord-interactions>` for the Discord Application Programming Interface. (API)
 A library in Python has to be installed through the `pip` file. Run this in your terminal/command line
 in order to install our library:
 


### PR DESCRIPTION
## About

fixes a small typo in the quickstart

## Checklist

- [ ] I've ran `pre-commit` to format and lint the change(s) made.
- [ ] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [ ] I've made this pull request for/as: (check all that apply)
  - [X] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [ ] Bugfix
