### PR TITLE
fix!: rename method name `get_application_command`

### DIFF
--- a/interactions/api/http.py
+++ b/interactions/api/http.py
@@ -1994,7 +1994,7 @@ class HTTPClient:
 
     # TODO: Merge single and batch variants ?
 
-    async def get_application_command(
+    async def get_application_commands(
         self, application_id: Union[int, Snowflake], guild_id: Optional[int] = None
     ) -> List[dict]:
         """

--- a/interactions/client.py
+++ b/interactions/client.py
@@ -211,7 +211,7 @@ class Client:
             commands: List[dict] = cache
         else:
             log.info("No command cache was found present, retrieving from Web API instead.")
-            commands: Optional[Union[dict, List[dict]]] = await self._http.get_application_command(
+            commands: Optional[Union[dict, List[dict]]] = await self._http.get_application_commands(
                 application_id=self.me.id, guild_id=payload.get("guild_id") if payload else None
             )
 


### PR DESCRIPTION
`get_application__command` returns an array of commands. `get_application_commands` is more logical

## About

This pull request is about (X), which does (Y).

## Checklist

- [ ] I've ran `pre-commit` to format and lint the change(s) made.
- [ ] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [ ] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [x] Breaking change
  - [ ] New feature/enhancement
  - [ ] Bugfix
