### PR TITLE
feat: Abstract `modify` method in data models for simplified usage.

### DIFF
--- a/interactions/api/models/channel.py
+++ b/interactions/api/models/channel.py
@@ -339,7 +339,12 @@ class Channel(DictSerializerMixin):
         )
         return Channel(**res, _client=self._client)
 
-    async def set_name(self, name: str, reason: Optional[str] = None) -> "Channel":
+    async def set_name(
+        self,
+        name: str,
+        *,
+        reason: Optional[str] = None,
+    ) -> "Channel":
         """
         Sets the name of the channel.
 
@@ -353,7 +358,12 @@ class Channel(DictSerializerMixin):
 
         return await self.modify(name=name, reason=reason)
 
-    async def set_topic(self, topic: str, reason: Optional[str] = None) -> "Channel":
+    async def set_topic(
+        self,
+        topic: str,
+        *,
+        reason: Optional[str] = None,
+    ) -> "Channel":
         """
         Sets the topic of the channel.
 
@@ -367,7 +377,12 @@ class Channel(DictSerializerMixin):
 
         return await self.modify(topic=topic, reason=reason)
 
-    async def set_bitrate(self, bitrate: int, reason: Optional[str] = None) -> "Channel":
+    async def set_bitrate(
+        self,
+        bitrate: int,
+        *,
+        reason: Optional[str] = None,
+    ) -> "Channel":
         """
         Sets the bitrate of the channel.
 
@@ -384,7 +399,12 @@ class Channel(DictSerializerMixin):
 
         return await self.modify(bitrate=bitrate, reason=reason)
 
-    async def set_user_limit(self, user_limit: int, reason: Optional[str] = None) -> "Channel":
+    async def set_user_limit(
+        self,
+        user_limit: int,
+        *,
+        reason: Optional[str] = None,
+    ) -> "Channel":
         """
         Sets the user_limit of the channel.
 
@@ -402,7 +422,10 @@ class Channel(DictSerializerMixin):
         return await self.modify(user_limit=user_limit, reason=reason)
 
     async def set_rate_limit_per_user(
-        self, rate_limit_per_user: int, reason: Optional[str] = None
+        self,
+        rate_limit_per_user: int,
+        *,
+        reason: Optional[str] = None,
     ) -> "Channel":
         """
         Sets the position of the channel.
@@ -417,7 +440,12 @@ class Channel(DictSerializerMixin):
 
         return await self.modify(rate_limit_per_user=rate_limit_per_user, reason=reason)
 
-    async def set_position(self, position: int, reason: Optional[str] = None) -> "Channel":
+    async def set_position(
+        self,
+        position: int,
+        *,
+        reason: Optional[str] = None,
+    ) -> "Channel":
         """
         Sets the position of the channel.
 
@@ -431,7 +459,12 @@ class Channel(DictSerializerMixin):
 
         return await self.modify(position=position, reason=reason)
 
-    async def set_parent_id(self, parent_id: int, reason: Optional[str] = None) -> "Channel":
+    async def set_parent_id(
+        self,
+        parent_id: int,
+        *,
+        reason: Optional[str] = None,
+    ) -> "Channel":
         """
         Sets the parent_id of the channel.
 
@@ -445,7 +478,12 @@ class Channel(DictSerializerMixin):
 
         return await self.modify(parent_id=parent_id, reason=reason)
 
-    async def set_nsfw(self, nsfw: bool, reason: Optional[str] = None) -> "Channel":
+    async def set_nsfw(
+        self,
+        nsfw: bool,
+        *,
+        reason: Optional[str] = None,
+    ) -> "Channel":
         """
         Sets the nsfw-flag of the channel.
 

--- a/interactions/api/models/channel.py
+++ b/interactions/api/models/channel.py
@@ -302,7 +302,7 @@ class Channel(DictSerializerMixin):
         :type parent_id: Optional[int]
         :param nsfw?: Whether the channel is nsfw or not, defaults to the current value of the channel
         :type nsfw: Optional[bool]
-        :param reason: The reason for the edit
+        :param reason?: The reason for the edit
         :type reason: Optional[str]
         :return: The modified channel as new object
         :rtype: Channel
@@ -338,6 +338,126 @@ class Channel(DictSerializerMixin):
             data=payload._json,
         )
         return Channel(**res, _client=self._client)
+
+    async def set_name(self, name: str, reason: Optional[str] = None) -> "Channel":
+        """
+        Sets the name of the channel.
+
+        :param name: The new name of the channel
+        :type name: str
+        :param reason?: The reason of the edit
+        :type reason: Optional[str]
+        :return: The edited channel
+        :rtype: Channel
+        """
+
+        return await self.modify(name=name, reason=reason)
+
+    async def set_topic(self, topic: str, reason: Optional[str] = None) -> "Channel":
+        """
+        Sets the topic of the channel.
+
+        :param topic: The new topic of the channel
+        :type topic: str
+        :param reason?: The reason of the edit
+        :type reason: Optional[str]
+        :return: The edited channel
+        :rtype: Channel
+        """
+
+        return await self.modify(topic=topic, reason=reason)
+
+    async def set_bitrate(self, bitrate: int, reason: Optional[str] = None) -> "Channel":
+        """
+        Sets the bitrate of the channel.
+
+        :param bitrate: The new bitrate of the channel
+        :type bitrate: int
+        :param reason?: The reason of the edit
+        :type reason: Optional[str]
+        :return: The edited channel
+        :rtype: Channel
+        """
+
+        if self.type != ChannelType.GUILD_VOICE:
+            raise TypeError("Bitrate is only available for VoiceChannels")
+
+        return await self.modify(bitrate=bitrate, reason=reason)
+
+    async def set_user_limit(self, user_limit: int, reason: Optional[str] = None) -> "Channel":
+        """
+        Sets the user_limit of the channel.
+
+        :param user_limit: The new user limit of the channel
+        :type user_limit: int
+        :param reason?: The reason of the edit
+        :type reason: Optional[str]
+        :return: The edited channel
+        :rtype: Channel
+        """
+
+        if self.type != ChannelType.GUILD_VOICE:
+            raise TypeError("user_limit is only available for VoiceChannels")
+
+        return await self.modify(user_limit=user_limit, reason=reason)
+
+    async def set_rate_limit_per_user(
+        self, rate_limit_per_user: int, reason: Optional[str] = None
+    ) -> "Channel":
+        """
+        Sets the position of the channel.
+
+        :param rate_limit_per_user: The new rate_limit_per_user of the channel (0-21600)
+        :type rate_limit_per_user: int
+        :param reason?: The reason of the edit
+        :type reason: Optional[str]
+        :return: The edited channel
+        :rtype: Channel
+        """
+
+        return await self.modify(rate_limit_per_user=rate_limit_per_user, reason=reason)
+
+    async def set_position(self, position: int, reason: Optional[str] = None) -> "Channel":
+        """
+        Sets the position of the channel.
+
+        :param position: The new position of the channel
+        :type position: int
+        :param reason?: The reason of the edit
+        :type reason: Optional[str]
+        :return: The edited channel
+        :rtype: Channel
+        """
+
+        return await self.modify(position=position, reason=reason)
+
+    async def set_parent_id(self, parent_id: int, reason: Optional[str] = None) -> "Channel":
+        """
+        Sets the parent_id of the channel.
+
+        :param parent_id: The new parent_id of the channel
+        :type parent_id: int
+        :param reason?: The reason of the edit
+        :type reason: Optional[str]
+        :return: The edited channel
+        :rtype: Channel
+        """
+
+        return await self.modify(parent_id=parent_id, reason=reason)
+
+    async def set_nsfw(self, nsfw: bool, reason: Optional[str] = None) -> "Channel":
+        """
+        Sets the nsfw-flag of the channel.
+
+        :param nsfw: The new nsfw-flag of the channel
+        :type nsfw: bool
+        :param reason?: The reason of the edit
+        :type reason: Optional[str]
+        :return: The edited channel
+        :rtype: Channel
+        """
+
+        return await self.modify(nsfw=nsfw, reason=reason)
 
     async def add_member(
         self,

--- a/interactions/api/models/channel.pyi
+++ b/interactions/api/models/channel.pyi
@@ -106,41 +106,49 @@ class Channel(DictSerializerMixin):
     async def set_name(
         self,
         name: str,
+        *,
         reason: Optional[str] = None
     ) -> "Channel": ...
     async def set_topic(
         self,
         topic: str,
+        *,
         reason: Optional[str] = None
     ) -> "Channel": ...
     async def set_bitrate(
         self,
         bitrate: int,
+        *,
         reason: Optional[str] = None
     ) -> "Channel": ...
     async def set_user_limit(
         self,
         user_limit: int,
+        *,
         reason: Optional[str] = None
     ) -> "Channel": ...
     async def set_rate_limit_per_user(
         self,
         rate_limit_per_user: int,
+        *,
         reason: Optional[str] = None
     ) -> "Channel": ...
     async def set_position(
         self,
         position: int,
+        *,
         reason: Optional[str] = None
     ) -> "Channel": ...
     async def set_parent_id(
         self,
         parent_id: int,
+        *,
         reason: Optional[str] = None
     ) -> "Channel": ...
     async def set_nsfw(
         self,
         nsfw: bool,
+        *,
         reason: Optional[str] = None
     ) -> "Channel": ...
     async def add_member(
@@ -148,8 +156,8 @@ class Channel(DictSerializerMixin):
         member_id: int,
     ) -> None: ...
     async def pin_message(
-            self,
-            message_id: int,
+        self,
+        message_id: int,
     ) -> None: ...
     async def unpin_message(
         self,
@@ -161,8 +169,8 @@ class Channel(DictSerializerMixin):
     ) -> Message: ...
     async def get_pinned_messages(self) -> List[Message]: ...
     async def get_message(
-            self,
-            message_id: int,
+        self,
+        message_id: int,
     ) -> Message: ...
     async def purge(
         self,

--- a/interactions/api/models/channel.pyi
+++ b/interactions/api/models/channel.pyi
@@ -103,6 +103,46 @@ class Channel(DictSerializerMixin):
         nsfw: Optional[bool] = MISSING,
         reason: Optional[str] = None,
     ) -> "Channel": ...
+    async def set_name(
+        self,
+        name: str,
+        reason: Optional[str] = None
+    ) -> "Channel": ...
+    async def set_topic(
+        self,
+        topic: str,
+        reason: Optional[str] = None
+    ) -> "Channel": ...
+    async def set_bitrate(
+        self,
+        bitrate: int,
+        reason: Optional[str] = None
+    ) -> "Channel": ...
+    async def set_user_limit(
+        self,
+        user_limit: int,
+        reason: Optional[str] = None
+    ) -> "Channel": ...
+    async def set_rate_limit_per_user(
+        self,
+        rate_limit_per_user: int,
+        reason: Optional[str] = None
+    ) -> "Channel": ...
+    async def set_position(
+        self,
+        position: int,
+        reason: Optional[str] = None
+    ) -> "Channel": ...
+    async def set_parent_id(
+        self,
+        parent_id: int,
+        reason: Optional[str] = None
+    ) -> "Channel": ...
+    async def set_nsfw(
+        self,
+        nsfw: bool,
+        reason: Optional[str] = None
+    ) -> "Channel": ...
     async def add_member(
         self,
         member_id: int,

--- a/interactions/api/models/guild.py
+++ b/interactions/api/models/guild.py
@@ -1047,7 +1047,7 @@ class Guild(DictSerializerMixin):
         name: str,
         *,
         reason: Optional[str],
-    ):
+    ) -> "Guild":
         """
         Sets the name of the guild.
 
@@ -1063,7 +1063,7 @@ class Guild(DictSerializerMixin):
         verification_level: VerificationLevel,
         *,
         reason: Optional[str],
-    ):
+    ) -> "Guild":
         """
         Sets the verification level of the guild.
 
@@ -1079,7 +1079,7 @@ class Guild(DictSerializerMixin):
         default_message_notifications: DefaultMessageNotificationLevel,
         *,
         reason: Optional[str],
-    ):
+    ) -> "Guild":
         """
         Sets the default message notifications level of the guild.
 
@@ -1097,7 +1097,7 @@ class Guild(DictSerializerMixin):
         explicit_content_filter: ExplicitContentFilterLevel,
         *,
         reason: Optional[str],
-    ):
+    ) -> "Guild":
         """
         Sets the explicit content filter level of the guild.
 
@@ -1108,14 +1108,14 @@ class Guild(DictSerializerMixin):
         """
         return await self.modify(explicit_content_filter=explicit_content_filter, reason=reason)
 
-    async def set_afk_channel_id(
+    async def set_afk_channel(
         self,
         afk_channel_id: int,
         *,
         reason: Optional[str],
-    ):
+    ) -> "Guild":
         """
-        Sets the afk channel id of the guild.
+        Sets the afk channel of the guild.
 
         :param afk_channel_id: The new name of the guild
         :type afk_channel_id: int
@@ -1129,7 +1129,7 @@ class Guild(DictSerializerMixin):
         afk_timeout: int,
         *,
         reason: Optional[str],
-    ):
+    ) -> "Guild":
         """
         Sets the afk timeout of the guild.
 
@@ -1140,14 +1140,14 @@ class Guild(DictSerializerMixin):
         """
         return await self.modify(afk_timeout=afk_timeout, reason=reason)
 
-    async def system_channel_id(
+    async def set_system_channel(
         self,
         system_channel_id: int,
         *,
         reason: Optional[str],
-    ):
+    ) -> "Guild":
         """
-        Sets the system channel id of the guild.
+        Sets the system channel of the guild.
 
         :param system_channel_id: The new system channel id of the guild
         :type system_channel_id: int
@@ -1155,6 +1155,88 @@ class Guild(DictSerializerMixin):
         :type reason: Optional[str]
         """
         return await self.modify(system_channel_id=system_channel_id, reason=reason)
+
+    async def set_rules_channel(
+        self,
+        rules_channel_id: int,
+        *,
+        reason: Optional[str],
+    ) -> "Guild":
+        """
+        Sets the rules channel of the guild.
+
+        :param rules_channel_id: The new rules channel id of the guild
+        :type rules_channel_id: int
+        :param reason?: The reason of the edit
+        :type reason: Optional[str]
+        """
+        return await self.modify(rules_channel_id=rules_channel_id, reason=reason)
+
+    async def set_public_updates_channel(
+        self,
+        public_updates_channel_id: int,
+        *,
+        reason: Optional[str],
+    ) -> "Guild":
+        """
+        Sets the public updates channel of the guild.
+
+        :param public_updates_channel_id: The new public updates channel id of the guild
+        :type public_updates_channel_id: int
+        :param reason?: The reason of the edit
+        :type reason: Optional[str]
+        """
+        return await self.modify(public_updates_channel_id=public_updates_channel_id, reason=reason)
+
+    async def set_preferred_locale(
+        self,
+        preferred_locale: str,
+        *,
+        reason: Optional[str],
+    ) -> "Guild":
+        """
+        Sets the preferred locale of the guild.
+
+        :param preferred_locale: The new preferredlocale of the guild
+        :type preferred_locale: str
+        :param reason?: The reason of the edit
+        :type reason: Optional[str]
+        """
+        return await self.modify(preferred_locale=preferred_locale, reason=reason)
+
+    async def set_description(
+        self,
+        description: str,
+        *,
+        reason: Optional[str],
+    ) -> "Guild":
+        """
+        Sets the description of the guild.
+
+        :param description: The new description of the guild
+        :type description: str
+        :param reason?: The reason of the edit
+        :type reason: Optional[str]
+        """
+        return await self.modify(description=description, reason=reason)
+
+    async def set_premium_progress_bar_enabled(
+        self,
+        premium_progress_bar_enabled: bool,
+        *,
+        reason: Optional[str],
+    ) -> "Guild":
+        """
+        Sets the visibility of the premium progress bar of the guild.
+
+        :param premium_progress_bar_enabled: Whether the bar is enabled or not
+        :type premium_progress_bar_enabled: bool
+        :param reason?: The reason of the edit
+        :type reason: Optional[str]
+        """
+        return await self.modify(
+            premium_progress_bar_enabled=premium_progress_bar_enabled, reason=reason
+        )
 
     async def create_scheduled_event(
         self,

--- a/interactions/api/models/guild.py
+++ b/interactions/api/models/guild.py
@@ -1042,6 +1042,120 @@ class Guild(DictSerializerMixin):
         )
         return Guild(**res, _client=self._client)
 
+    async def set_name(
+        self,
+        name: str,
+        *,
+        reason: Optional[str],
+    ):
+        """
+        Sets the name of the guild.
+
+        :param name: The new name of the guild
+        :type name: str
+        :param reason?: The reason of the edit
+        :type reason: Optional[str]
+        """
+        return await self.modify(name=name, reason=reason)
+
+    async def set_verification_level(
+        self,
+        verification_level: VerificationLevel,
+        *,
+        reason: Optional[str],
+    ):
+        """
+        Sets the verification level of the guild.
+
+        :param verification_level: The new verification level of the guild
+        :type verification_level: VerificationLevel
+        :param reason?: The reason of the edit
+        :type reason: Optional[str]
+        """
+        return await self.modify(verification_level=verification_level, reason=reason)
+
+    async def set_default_message_notifications(
+        self,
+        default_message_notifications: DefaultMessageNotificationLevel,
+        *,
+        reason: Optional[str],
+    ):
+        """
+        Sets the default message notifications level of the guild.
+
+        :param default_message_notifications: The new default message notification level of the guild
+        :type default_message_notifications: DefaultMessageNotificationLevel
+        :param reason?: The reason of the edit
+        :type reason: Optional[str]
+        """
+        return await self.modify(
+            default_message_notifications=default_message_notifications, reason=reason
+        )
+
+    async def set_explicit_content_filter(
+        self,
+        explicit_content_filter: ExplicitContentFilterLevel,
+        *,
+        reason: Optional[str],
+    ):
+        """
+        Sets the explicit content filter level of the guild.
+
+        :param explicit_content_filter: The new explicit content filter level of the guild
+        :type explicit_content_filter: ExplicitContentFilterLevel
+        :param reason?: The reason of the edit
+        :type reason: Optional[str]
+        """
+        return await self.modify(explicit_content_filter=explicit_content_filter, reason=reason)
+
+    async def set_afk_channel_id(
+        self,
+        afk_channel_id: int,
+        *,
+        reason: Optional[str],
+    ):
+        """
+        Sets the afk channel id of the guild.
+
+        :param afk_channel_id: The new name of the guild
+        :type afk_channel_id: int
+        :param reason?: The reason of the edit
+        :type reason: Optional[str]
+        """
+        return await self.modify(afk_channel_id=afk_channel_id, reason=reason)
+
+    async def afk_timeout(
+        self,
+        afk_timeout: int,
+        *,
+        reason: Optional[str],
+    ):
+        """
+        Sets the afk timeout of the guild.
+
+        :param afk_timeout: The new afk timeout of the guild
+        :type afk_timeout: int
+        :param reason?: The reason of the edit
+        :type reason: Optional[str]
+        """
+        return await self.modify(afk_timeout=afk_timeout, reason=reason)
+
+    async def system_channel_id(
+        self,
+        system_channel_id: int,
+        *,
+        reason: Optional[str],
+    ):
+        """
+        Sets the system channel id of the guild.
+
+        :param system_channel_id: The new system channel id of the guild
+        :type system_channel_id: int
+        :param reason?: The reason of the edit
+        :type reason: Optional[str]
+        """
+        return await self.modify(system_channel_id=system_channel_id, reason=reason)
+
     async def create_scheduled_event(
         self,
         name: str,

--- a/interactions/api/models/guild.pyi
+++ b/interactions/api/models/guild.pyi
@@ -11,15 +11,32 @@ from .role import Role
 from .user import User
 from ..http import HTTPClient
 
-class VerificationLevel(IntEnum): ...
+class VerificationLevel(IntEnum):
+    NONE: int
+    LOW: int
+    MEDIUM: int
+    HIGH: int
+    VERY_HIGH: int
 
-class ExplicitContentFilterLevel(IntEnum): ...
+class ExplicitContentFilterLevel(IntEnum):
+    DISABLED: int
+    MEMBERS_WITHOUT_ROLES: int
+    ALL_MEMBERS: int
 
-class DefaultMessageNotificationLevel(IntEnum): ...
+class DefaultMessageNotificationLevel(IntEnum):
+    ALL_MESSAGES: int
+    ONLY_MENTIONS: int
 
-class EntityType(IntEnum): ...
+class EntityType(IntEnum):
+    STAGE_INSTANCE: int
+    VOICE: int
+    EXTERNAL: int
 
-class EventStatus(IntEnum): ...
+class EventStatus(IntEnum):
+    SCHEDULED: int
+    ACTIVE: int
+    COMPLETED: int
+    CANCELED: int
 
 class WelcomeChannels(DictSerializerMixin):
     _json: dict
@@ -254,6 +271,7 @@ class Guild(DictSerializerMixin):
         premium_progress_bar_enabled: Optional[bool] = MISSING,
         reason: Optional[str] = None,
     ) -> "Guild": ...
+
     async def create_scheduled_event(
         self,
         name: str,

--- a/interactions/api/models/guild.pyi
+++ b/interactions/api/models/guild.pyi
@@ -271,6 +271,78 @@ class Guild(DictSerializerMixin):
         premium_progress_bar_enabled: Optional[bool] = MISSING,
         reason: Optional[str] = None,
     ) -> "Guild": ...
+    async def set_name(
+        self,
+        name: str,
+        *,
+        reason: Optional[str],
+    ) -> "Guild": ...
+    async def set_verification_level(
+        self,
+        verification_level: VerificationLevel,
+        *,
+        reason: Optional[str],
+    ) -> "Guild": ...
+    async def set_default_message_notifications(
+        self,
+        default_message_notifications: DefaultMessageNotificationLevel,
+        *,
+        reason: Optional[str],
+    ) -> "Guild": ...
+    async def set_explicit_content_filter(
+        self,
+        explicit_content_filter: ExplicitContentFilterLevel,
+        *,
+        reason: Optional[str],
+    ) -> "Guild": ...
+    async def set_afk_channel(
+        self,
+        afk_channel_id: int,
+        *,
+        reason: Optional[str],
+    ) -> "Guild": ...
+    async def afk_timeout(
+        self,
+        afk_timeout: int,
+        *,
+        reason: Optional[str],
+    ) -> "Guild": ...
+    async def set_system_channel(
+        self,
+        system_channel_id: int,
+        *,
+        reason: Optional[str],
+    ) -> "Guild": ...
+    async def set_rules_channel(
+        self,
+        rules_channel_id: int,
+        *,
+        reason: Optional[str],
+    ) -> "Guild": ...
+    async def set_public_updates_channel(
+        self,
+        public_updates_channel_id: int,
+        *,
+        reason: Optional[str],
+    ) -> "Guild": ...
+    async def set_preferred_locale(
+        self,
+        preferred_locale: str,
+        *,
+        reason: Optional[str],
+    ) -> "Guild": ...
+    async def set_description(
+        self,
+        description: str,
+        *,
+        reason: Optional[str],
+    ) -> "Guild": ...
+    async def set_premium_progress_bar_enabled(
+        self,
+        premium_progress_bar_enabled: bool,
+        *,
+        reason: Optional[str],
+    ) -> "Guild": ...
 
     async def create_scheduled_event(
         self,

--- a/interactions/api/models/member.py
+++ b/interactions/api/models/member.py
@@ -343,6 +343,16 @@ class Member(DictSerializerMixin):
         )
         return Member(**res, _client=self._client)
 
+    """
+    nick: Optional[str] = MISSING,
+    roles: Optional[List[int]] = MISSING,
+    mute: Optional[bool] = MISSING,
+    deaf: Optional[bool] = MISSING,  # invert this
+    channel_id: Optional[int] = MISSING,
+    communication_disabled_until: Optional[datetime.isoformat] = MISSING,
+    reason: Optional[str] = None,
+    """
+
     async def add_to_thread(
         self,
         thread_id: int,

--- a/interactions/api/models/member.py
+++ b/interactions/api/models/member.py
@@ -343,16 +343,6 @@ class Member(DictSerializerMixin):
         )
         return Member(**res, _client=self._client)
 
-    """
-    nick: Optional[str] = MISSING,
-    roles: Optional[List[int]] = MISSING,
-    mute: Optional[bool] = MISSING,
-    deaf: Optional[bool] = MISSING,  # invert this
-    channel_id: Optional[int] = MISSING,
-    communication_disabled_until: Optional[datetime.isoformat] = MISSING,
-    reason: Optional[str] = None,
-    """
-
     async def add_to_thread(
         self,
         thread_id: int,


### PR DESCRIPTION
Allows the usage of 
```py
await channel.set_name("newname")
```

instead 
```py
await channel.modify(name="newname")
```


## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [ ] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [x] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent): #472
- [ ] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [x] New feature/enhancement
  - [ ] Bugfix
