### PR TITLE
feat: implement ctx.custom_id and ctx.label properties

### DIFF
--- a/interactions/context.py
+++ b/interactions/context.py
@@ -772,8 +772,8 @@ class ComponentContext(CommandContext):
         self.deferred = False  # remind components they not have been deferred
         self.custom_id = self.data.custom_id
         for action_row in self.message.components:
-            for component in action_row['components']:
-                if component['custom_id'] == self.custom_id and component['type'] == 2:
+            for component in action_row["components"]:
+                if component["custom_id"] == self.custom_id and component["type"] == 2:
                     self.label = component.get("label")
 
     async def defer(

--- a/interactions/context.py
+++ b/interactions/context.py
@@ -753,6 +753,8 @@ class ComponentContext(CommandContext):
         "type",
         "data",
         "target",
+        "custom_id",
+        "label",
         "version",
         "token",
         "guild_id",
@@ -768,6 +770,11 @@ class ComponentContext(CommandContext):
         super().__init__(**kwargs)
         self.responded = False  # remind components that it was not responded to.
         self.deferred = False  # remind components they not have been deferred
+        self.custom_id = self.data.custom_id
+        for action_row in self.message.components:
+            for component in action_row['components']:
+                if component['custom_id'] == self.custom_id and component['type'] == 2:
+                    self.label = component.get("label")
 
     async def defer(
         self, ephemeral: Optional[bool] = False, edit_origin: Optional[bool] = False

--- a/interactions/context.py
+++ b/interactions/context.py
@@ -753,8 +753,6 @@ class ComponentContext(CommandContext):
         "type",
         "data",
         "target",
-        "custom_id",
-        "label",
         "version",
         "token",
         "guild_id",
@@ -770,11 +768,17 @@ class ComponentContext(CommandContext):
         super().__init__(**kwargs)
         self.responded = False  # remind components that it was not responded to.
         self.deferred = False  # remind components they not have been deferred
-        self.custom_id = self.data.custom_id
+
+    @property
+    def custom_id(self):
+        return self.data.custom_id
+
+    @property
+    def label(self):
         for action_row in self.message.components:
             for component in action_row["components"]:
                 if component["custom_id"] == self.custom_id and component["type"] == 2:
-                    self.label = component.get("label")
+                    return component.get("label")
 
     async def defer(
         self, ephemeral: Optional[bool] = False, edit_origin: Optional[bool] = False


### PR DESCRIPTION
## About

This pull request is about adding custom_id and label properties to ComponentContext, which makes it easier to retrieve these commonly used values.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [x] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - #480 
- [ ] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [x] New feature/enhancement
  - [ ] Bugfix
