### PR TITLE
fix!: remove `._json` from dict object when editing comnponents

### DIFF
--- a/interactions/context.py
+++ b/interactions/context.py
@@ -472,10 +472,7 @@ class CommandContext(Context):
 
         if self.message.components is not None or components is not MISSING:
             if components is MISSING:
-                if isinstance(self.message.components, list):
-                    _components = [component._json for component in self.message.components]
-                else:
-                    _components = [self.message.components._json]
+                _components = self.message.components
             elif not components:
                 _components = []
             else:


### PR DESCRIPTION
## About

This pull request is about (X), which does (Y).

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [ ] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [ ] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
