### PR TITLE
Message.mentions as a list of users

### DIFF
--- a/interactions/api/models/message.py
+++ b/interactions/api/models/message.py
@@ -237,7 +237,7 @@ class Message(DictSerializerMixin):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        
+
         self.id = Snowflake(self.id) if self._json.get("id") else None
         self.channel_id = Snowflake(self.channel_id) if self._json.get("channel_id") else None
         self.guild_id = Snowflake(self.guild_id) if self._json.get("guild_id") else None
@@ -267,9 +267,7 @@ class Message(DictSerializerMixin):
             else datetime.utcnow()
         )
         self.mentions = (
-            [User(**mention) for mention in self.mentions]
-            if self._json.get("mentions")
-            else None
+            [User(**mention) for mention in self.mentions] if self._json.get("mentions") else None
         )
         self.mention_channels = (
             [ChannelMention(**mention) for mention in self.mention_channels]

--- a/interactions/api/models/message.py
+++ b/interactions/api/models/message.py
@@ -176,7 +176,7 @@ class Message(DictSerializerMixin):
     :ivar Optional[datetime] edited_timestamp?: Timestamp denoting when the message was edited, if any.
     :ivar bool tts: Status dictating if this was a TTS message or not.
     :ivar bool mention_everyone: Status dictating of this message mentions everyone
-    :ivar Optional[List[Union[Member, User]]] mentions?: Array of user objects with an additional partial member field.
+    :ivar Optional[List[User]] mentions?: Array of user objects with an additional partial member field.
     :ivar Optional[List[str]] mention_roles?: Array of roles mentioned in this message
     :ivar Optional[List[ChannelMention]] mention_channels?: Channels mentioned in this message, if any.
     :ivar List[Attachment] attachments: An array of attachments
@@ -237,7 +237,7 @@ class Message(DictSerializerMixin):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-
+        
         self.id = Snowflake(self.id) if self._json.get("id") else None
         self.channel_id = Snowflake(self.channel_id) if self._json.get("channel_id") else None
         self.guild_id = Snowflake(self.guild_id) if self._json.get("guild_id") else None
@@ -265,6 +265,11 @@ class Message(DictSerializerMixin):
             datetime.fromisoformat(self._json.get("edited_timestamp"))
             if self._json.get("edited_timestamp")
             else datetime.utcnow()
+        )
+        self.mentions = (
+            [User(**mention) for mention in self.mentions]
+            if self._json.get("mentions")
+            else None
         )
         self.mention_channels = (
             [ChannelMention(**mention) for mention in self.mention_channels]


### PR DESCRIPTION
## About

Transform Message.mentions as a list of Users instead of a dict

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [x] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent): #512 
- [ ] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [x] New feature/enhancement
  - [ ] Bugfix
