### PR TITLE
added check for uppercase letters in command option names

### DIFF
--- a/interactions/client.py
+++ b/interactions/client.py
@@ -442,6 +442,11 @@ class Client:
                                 11,
                                 message="Command option descriptions must be less than 100 characters.",
                             )
+                        if _option.name.lower() != _option.name:
+                            raise InteractionException(
+                                11,
+                                message="Command option names must be lowercase.",
+                            )
 
                     if len(_option.name) > 32:
                         raise InteractionException(


### PR DESCRIPTION
check for uppercase in option names

## About

This pull request fixes an issue where when a user creates an option name with an uppercase letter, an unhelpful error shows up.

## Checklist

- [ ] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [x] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [x] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
