### PR TITLE
feat: add a `get_extension` method to `Client`

### DIFF
--- a/interactions/client.py
+++ b/interactions/client.py
@@ -872,6 +872,9 @@ class Client:
         self.remove(name, package)
         return self.load(name, package, *args, **kwargs)
 
+    def get_extension(self, name: str) -> Optional[Union[ModuleType, "Extension"]]:
+        return self._extensions.get(name)
+
     async def __raw_socket_create(self, data: Dict[Any, Any]) -> Dict[Any, Any]:
         """
         This is an internal function that takes any gateway socket event

--- a/interactions/client.pyi
+++ b/interactions/client.pyi
@@ -2,15 +2,13 @@ from asyncio import AbstractEventLoop
 from types import ModuleType
 from typing import Any, Callable, Coroutine, Dict, List, NoReturn, Optional, Tuple, Union
 
-from .api.models.gw import Presence
-from .api.models.misc import MISSING, Snowflake
-
 from .api.cache import Cache
 from .api.gateway import WebSocket
 from .api.http import HTTPClient
 from .api.models.flags import Intents
 from .api.models.guild import Guild
 from .api.models.gw import Presence
+from .api.models.misc import MISSING, Snowflake
 from .api.models.team import Application
 from .enums import ApplicationCommandType
 from .models.command import ApplicationCommand, Option
@@ -87,7 +85,9 @@ class Client:
         default_permission: Optional[bool] = None,
     ) -> Callable[..., Any]: ...
     def component(self, component: Union[Button, SelectMenu]) -> Callable[..., Any]: ...
-    def autocomplete(self, name: str, command: Union[ApplicationCommand, int, str]) -> Callable[..., Any]: ...
+    def autocomplete(
+        self, name: str, command: Union[ApplicationCommand, int, str]
+    ) -> Callable[..., Any]: ...
     def modal(self, modal: Union[Modal, str]) -> Callable[..., Any]: ...
     def load(
         self, name: str, package: Optional[str] = None, *args, **kwargs
@@ -96,11 +96,11 @@ class Client:
     def reload(
         self, name: str, package: Optional[str] = None, *args, **kwargs
     ) -> Optional["Extension"]: ...
+    def get_extension(self, name: str) -> Union[ModuleType, "Extension"]: ...
     async def raw_socket_create(self, data: Dict[Any, Any]) -> dict: ...
     async def raw_channel_create(self, message) -> dict: ...
     async def raw_message_create(self, message) -> dict: ...
     async def raw_guild_create(self, guild) -> dict: ...
-
     @staticmethod
     def _find_command(commands: List[Dict], command: str) -> ApplicationCommand: ...
 


### PR DESCRIPTION
## About

This pull request adds in a way to fetch a loaded extension

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [x] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent): [519](https://github.com/interactions-py/library/issues/519)
- [x] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [x] New feature/enhancement
  - [ ] Bugfix
