### PR TITLE
fix: Fix Emoji ** argument for SelectOption.

### DIFF
--- a/interactions/models/component.py
+++ b/interactions/models/component.py
@@ -35,7 +35,12 @@ class SelectOption(DictSerializerMixin):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.emoji = Emoji(**self.emoji) if self._json.get("emoji") else None
+        self.emoji = (
+            Emoji(**self.emoji if isinstance(self.emoji, dict) else self.emoji._json)
+            if self._json.get("emoji")
+            else None
+        )
+        self._json.update({"emoji": self.emoji._json})
 
 
 class SelectMenu(DictSerializerMixin):


### PR DESCRIPTION
## About

This pull request fixes the issue of sending Emoji objects inside `SelectOption`.
(See the Attached issue for details)

## Checklist

- [X] I've ran `pre-commit` to format and lint the change(s) made.
- [X] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [X] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent): #528 
- [X] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [X] Bugfix
