### PR TITLE
fix: Fix _json parsing for non-existent Emoji argument

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-- blank_issues_enabled: false
+blank_issues_enabled: false
 contact_links:
   - name: Discord server
     url: https://discord.gg/KkgMBVuEkx

--- a/.github/ISSUE_TEMPLATE/report-bug.yml
+++ b/.github/ISSUE_TEMPLATE/report-bug.yml
@@ -31,7 +31,7 @@ body:
         1. Import the module in Python.
         2. Create a client variable for the library.
         3. Try creating a slash command.
-        4. See the traceback error given in the terminal or logger file. 
+        4. See the traceback error given in the terminal or logger file.
     validations:
       required: true
   - type: textarea

--- a/interactions/models/component.py
+++ b/interactions/models/component.py
@@ -40,7 +40,8 @@ class SelectOption(DictSerializerMixin):
             if self._json.get("emoji")
             else None
         )
-        self._json.update({"emoji": self.emoji._json})
+        if self.emoji:
+            self._json.update({"emoji": self.emoji._json})
 
 
 class SelectMenu(DictSerializerMixin):


### PR DESCRIPTION
## About

This pull request fixes the `_json` attribute when `self.emoji` is None.

## Checklist

- [X] I've ran `pre-commit` to format and lint the change(s) made.
- [X] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [X] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent): #537
- [X] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [X] Bugfix
