### PR TITLE
 fix!: prevent exception for non-chat-input commands when no description is present

### DIFF
--- a/interactions/client.py
+++ b/interactions/client.py
@@ -471,7 +471,6 @@ class Client:
 
         else:
             log.debug(f"checking command '{command.name}':")
-
         if (
             not re.fullmatch(reg, command.name)
             and command.type == ApplicationCommandType.CHAT_INPUT
@@ -479,17 +478,11 @@ class Client:
             raise InteractionException(
                 11, message=f"Your command does not match the regex for valid names ('{regex}')"
             )
-        elif (
-            command.type == ApplicationCommandType.CHAT_INPUT
-            and command.description is MISSING
-            or not command.description
+        elif command.type == ApplicationCommandType.CHAT_INPUT and (
+            command.description is MISSING or not command.description
         ):
             raise InteractionException(11, message="A description is required.")
-        elif (
-            command.type != ApplicationCommandType.CHAT_INPUT
-            and command.description is not MISSING
-            and command.description
-        ):
+        elif command.type != ApplicationCommandType.CHAT_INPUT and command.description:
             raise InteractionException(
                 11, message="Only chat-input commands can have a description."
             )

--- a/interactions/client.py
+++ b/interactions/client.py
@@ -482,7 +482,9 @@ class Client:
             command.description is MISSING or not command.description
         ):
             raise InteractionException(11, message="A description is required.")
-        elif command.type != ApplicationCommandType.CHAT_INPUT and command.description:
+        elif command.type != ApplicationCommandType.CHAT_INPUT and (
+            command.description is not MISSING and command.description
+        ):
             raise InteractionException(
                 11, message="Only chat-input commands can have a description."
             )


### PR DESCRIPTION


- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [ ] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
