### PR TITLE
Fix incorrect acronyms in documentation

### DIFF
--- a/docs/locale/de/LC_MESSAGES/quickstart.po
+++ b/docs/locale/de/LC_MESSAGES/quickstart.po
@@ -42,7 +42,7 @@ msgstr ""
 
 #: ../../quickstart.rst:16
 msgid ""
-"**discord-interactions** is a Python library for the Discord Artificial "
+"**discord-interactions** is a Python library for the Discord Application "
 "Programming Interface. (API) A library in Python has to be installed "
 "through the `pip` file. Run this in your terminal/command line in order "
 "to install our library:"

--- a/docs/locale/fr/LC_MESSAGES/quickstart.po
+++ b/docs/locale/fr/LC_MESSAGES/quickstart.po
@@ -42,7 +42,7 @@ msgstr ""
 
 #: ../../quickstart.rst:16
 msgid ""
-"**discord-interactions** is a Python library for the Discord Artificial "
+"**discord-interactions** is a Python library for the Discord Application "
 "Programming Interface. (API) A library in Python has to be installed "
 "through the `pip` file. Run this in your terminal/command line in order "
 "to install our library:"

--- a/docs/locale/hi/LC_MESSAGES/quickstart.po
+++ b/docs/locale/hi/LC_MESSAGES/quickstart.po
@@ -42,7 +42,7 @@ msgstr ""
 
 #: ../../quickstart.rst:16
 msgid ""
-"**discord-interactions** is a Python library for the Discord Artificial "
+"**discord-interactions** is a Python library for the Discord Application "
 "Programming Interface. (API) A library in Python has to be installed "
 "through the `pip` file. Run this in your terminal/command line in order "
 "to install our library:"

--- a/docs/locale/it/LC_MESSAGES/quickstart.po
+++ b/docs/locale/it/LC_MESSAGES/quickstart.po
@@ -42,7 +42,7 @@ msgstr ""
 
 #: ../../quickstart.rst:16
 msgid ""
-"**discord-interactions** is a Python library for the Discord Artificial "
+"**discord-interactions** is a Python library for the Discord Application "
 "Programming Interface. (API) A library in Python has to be installed "
 "through the `pip` file. Run this in your terminal/command line in order "
 "to install our library:"

--- a/docs/locale/pl/LC_MESSAGES/quickstart.po
+++ b/docs/locale/pl/LC_MESSAGES/quickstart.po
@@ -42,7 +42,7 @@ msgstr ""
 
 #: ../../quickstart.rst:16
 msgid ""
-"**discord-interactions** is a Python library for the Discord Artificial "
+"**discord-interactions** is a Python library for the Discord Application "
 "Programming Interface. (API) A library in Python has to be installed "
 "through the `pip` file. Run this in your terminal/command line in order "
 "to install our library:"

--- a/docs/locale/ru/LC_MESSAGES/quickstart.po
+++ b/docs/locale/ru/LC_MESSAGES/quickstart.po
@@ -42,7 +42,7 @@ msgstr ""
 
 #: ../../quickstart.rst:16
 msgid ""
-"**discord-interactions** is a Python library for the Discord Artificial "
+"**discord-interactions** is a Python library for the Discord Application "
 "Programming Interface. (API) A library in Python has to be installed "
 "through the `pip` file. Run this in your terminal/command line in order "
 "to install our library:"


### PR DESCRIPTION
## About

API stands for **Application** Progamming Interface, not **Artificial** Programming Interface.

## Checklist

- ~~[ ] I've ran `pre-commit` to format and lint the change(s) made.~~ No need
- ~~[ ] I've checked to make sure the change(s) work on `3.8.6` and higher.~~ No need
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [ ] I've made this pull request for/as: (check all that apply)
  - [x] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [ ] Bugfix
