### PR TITLE
fix: Introduce no name argument support for ext listeners.

### DIFF
--- a/interactions/client.py
+++ b/interactions/client.py
@@ -1206,6 +1206,7 @@ def extension_command(*args, **kwargs):
     return decorator
 
 
+@wraps(Client.event)
 def extension_listener(name=None):
     def decorator(func):
         func.__listener_name__ = name or func.__name__


### PR DESCRIPTION
## About

This pull request fixes name-less argument support for `@interactions.extension_listener`

On testing, this codeblock fails to execute let alone register
```py
    @interactions.extension_listener
    async def on_interaction(self, interaction: interactions.CommandContext):
        print(interaction)
```
However, this does:
```py
    @interactions.extension_listener("on_interaction")
    async def on_interaction(self, interaction: interactions.CommandContext):
        print(interaction)
```

(see [here](https://canary.discord.com/channels/789032594456576001/876490879815254097/946443356903473166) for details)

## Checklist

- [X] I've ran `pre-commit` to format and lint the change(s) made.
- [X] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [X] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [X] Bugfix
