### PR TITLE
fix: missing f string in leave_guild (#584)

### DIFF
--- a/interactions/api/http.py
+++ b/interactions/api/http.py
@@ -683,7 +683,7 @@ class HTTPClient:
         :return: None
         """
         return await self._req.request(
-            Route("DELETE", "/users/@me/guilds/{guild_id}", guild_id=guild_id)
+            Route("DELETE", f"/users/@me/guilds/{guild_id}", guild_id=guild_id)
         )
 
     async def delete_guild(self, guild_id: int) -> None:


### PR DESCRIPTION
## About

This pull request fixes a simple bug with leave_guild, with a missing f string

## Checklist

- [ ] I've ran `pre-commit` to format and lint the change(s) made.
- [ ] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [x] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent): https://github.com/interactions-py/library/issues/584
- [x] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
