### PR TITLE
feat: Fill Context.user from member data if user data is not given

### DIFF
--- a/interactions/context.py
+++ b/interactions/context.py
@@ -58,7 +58,12 @@ class _Context(DictSerializerMixin):
             Member(**self.member, _client=self.client) if self._json.get("member") else None
         )
         self.author = self.member
-        self.user = User(**self.user) if self._json.get("user") else None
+        if self._json.get("user"):
+            self.user = User(**self.user)
+        elif self.member:
+            self.user = self.member.user
+        else:
+            self.user = None
 
         self.id = Snowflake(self.id) if self._json.get("id") else None
         self.application_id = (


### PR DESCRIPTION
## About

This pull request allows _Context.user to be filled by _Context.member.user

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [x] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent): [550](https://github.com/interactions-py/library/issues/550)
- [x] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [x] New feature/enhancement
  - [ ] Bugfix
