### PR TITLE
feat: Add missing attributes when creating an invite

### DIFF
--- a/interactions/api/models/guild.py
+++ b/interactions/api/models/guild.py
@@ -1628,9 +1628,19 @@ class Invite(DictSerializerMixin):
         self.inviter = User(**self._json.get("inviter")) if self._json.get("inviter") else None
         self.channel_id = int(self.channel_id) if self._json.get("channel_id") else None
         self.guild_id = int(self.guild_id) if self._json.get("guild_id") else None
-        self.target_user = User(**self._json.get("target_user")) if self._json.get("target_user") else None
-        self.guild = Guild(**self._json.get("guild"), _client=self._client) if self._json.get("guild") else None
-        self.channel = Channel(**self._json.get("channel"), _client=self._client) if self._json.get("channel") else None
+        self.target_user = (
+            User(**self._json.get("target_user")) if self._json.get("target_user") else None
+        )
+        self.guild = (
+            Guild(**self._json.get("guild"), _client=self._client)
+            if self._json.get("guild")
+            else None
+        )
+        self.channel = (
+            Channel(**self._json.get("channel"), _client=self._client)
+            if self._json.get("channel")
+            else None
+        )
 
 
 class GuildTemplate(DictSerializerMixin):

--- a/interactions/api/models/guild.py
+++ b/interactions/api/models/guild.py
@@ -1574,11 +1574,17 @@ class Invite(DictSerializerMixin):
     """
     The invite object.
 
-    :ivar int uses: The amount of uses on the invite.
-    :ivar int max_uses: The amount of maximum uses on the invite.
-    :ivar int max_age: The maximum age of this invite.
-    :ivar bool temporary: A detection of whether this invite is temporary or not.
+    :ivar int uses: The amount of uses on this invite.
+    :ivar int max_uses: The amount of maximum uses on this invite.
+    :ivar int max_age: The maximum age of this invite, in seconds.
+    :ivar bool temporary: A detection of whether this invite only grants temporary membership.
     :ivar datetime created_at: The time when this invite was created.
+    :ivar datetime expires_at: The time when this invite will expire.
+    :ivar int type: The type of this invite.
+    :ivar User inviter: The user who created this invite.
+    :ivar int guild_id: The guild ID of this invite.
+    :ivar str code: The code of this invite.
+    :ivar int channel_id: The channel ID of this invite.
     """
 
     __slots__ = (
@@ -1589,8 +1595,7 @@ class Invite(DictSerializerMixin):
         "max_age",
         "temporary",
         "created_at",
-        # TODO: Investigate their purposes and document.
-        "types",
+        "type",
         "inviter",
         "guild_id",
         "expires_at",
@@ -1605,6 +1610,18 @@ class Invite(DictSerializerMixin):
             if self._json.get("created_at")
             else None
         )
+        self.expires_at = (
+            datetime.fromisoformat(self._json.get("expires_at"))
+            if self._json.get("expires_at")
+            else None
+        )
+        self.inviter = (
+            User(**self._json.get("inviter"))
+            if self._json.get("inviter")
+            else None
+        )
+        self.channel_id = int(self.channel_id)
+        self.guild_id = int(self.guild_id)
 
 
 class GuildTemplate(DictSerializerMixin):

--- a/interactions/api/models/guild.py
+++ b/interactions/api/models/guild.py
@@ -1615,11 +1615,7 @@ class Invite(DictSerializerMixin):
             if self._json.get("expires_at")
             else None
         )
-        self.inviter = (
-            User(**self._json.get("inviter"))
-            if self._json.get("inviter")
-            else None
-        )
+        self.inviter = User(**self._json.get("inviter")) if self._json.get("inviter") else None
         self.channel_id = int(self.channel_id)
         self.guild_id = int(self.guild_id)
 

--- a/interactions/api/models/guild.py
+++ b/interactions/api/models/guild.py
@@ -1582,9 +1582,14 @@ class Invite(DictSerializerMixin):
     :ivar datetime expires_at: The time when this invite will expire.
     :ivar int type: The type of this invite.
     :ivar User inviter: The user who created this invite.
-    :ivar int guild_id: The guild ID of this invite.
     :ivar str code: The code of this invite.
-    :ivar int channel_id: The channel ID of this invite.
+    :ivar Optional[int] guild_id: The guild ID of this invite.
+    :ivar Optional[int] channel_id: The channel ID of this invite.
+    :ivar Optional[int] target_user_type: The type of the target user of this invite.
+    :ivar Optional[User] target_user: The target user of this invite.
+    :ivar Optional[int] target_type: The target type of this invite.
+    :ivar Optional[Guild] guild: The guild of this invite.
+    :ivar Optional[Channel] channel: The channel of this invite.
     """
 
     __slots__ = (
@@ -1601,6 +1606,11 @@ class Invite(DictSerializerMixin):
         "expires_at",
         "code",
         "channel_id",
+        "target_user_type",
+        "target_user",
+        "target_type",
+        "guild",
+        "channel",
     )
 
     def __init__(self, **kwargs):
@@ -1616,8 +1626,11 @@ class Invite(DictSerializerMixin):
             else None
         )
         self.inviter = User(**self._json.get("inviter")) if self._json.get("inviter") else None
-        self.channel_id = int(self.channel_id)
-        self.guild_id = int(self.guild_id)
+        self.channel_id = int(self.channel_id) if self._json.get("channel_id") else None
+        self.guild_id = int(self.guild_id) if self._json.get("guild_id") else None
+        self.target_user = User(**self._json.get("target_user")) if self._json.get("target_user") else None
+        self.guild = Guild(**self._json.get("guild"), _client=self._client) if self._json.get("guild") else None
+        self.channel = Channel(**self._json.get("channel"), _client=self._client) if self._json.get("channel") else None
 
 
 class GuildTemplate(DictSerializerMixin):


### PR DESCRIPTION
## About

Some attributes from PR #605 were missing (the ones sent when creating a new invite).

## Checklist

- [ ] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [x] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues). #604 
  - (If existent):
- [ ] I've made this pull request for/as: (check all that apply)
  - [x] Documentation
  - [ ] Breaking change
  - [x] New feature/enhancement
  - [x] Bugfix
