### PR TITLE
fix: add banner_color to User model

### DIFF
--- a/interactions/api/models/user.py
+++ b/interactions/api/models/user.py
@@ -15,7 +15,7 @@ class User(DictSerializerMixin):
     :ivar Optional[bool] mfa_enabled?: A status denoting if the user has 2fa on their account
     :ivar Optional[str] banner?: The user's banner hash, if any
     # TODO: change banner_color to discord's description when documented
-    :iven Optional[str] banner_color?: The user's banner color as a hex, if any
+    :ivar Optional[str] banner_color?: The user's banner color as a hex, if any
     :ivar Optional[int] accent_color?: The user's banner color as an integer represented of hex color codes
     :ivar Optional[str] locale?: The user's chosen language option
     :ivar Optional[bool] verified?: Whether the email associated with this account has been verified

--- a/interactions/api/models/user.py
+++ b/interactions/api/models/user.py
@@ -14,6 +14,8 @@ class User(DictSerializerMixin):
     :ivar Optional[bool] system?: A status denoting if the user is an Official Discord System user
     :ivar Optional[bool] mfa_enabled?: A status denoting if the user has 2fa on their account
     :ivar Optional[str] banner?: The user's banner hash, if any
+    # TODO: change banner_color to discord's description when documented
+    :iven Optional[str] banner_color?: The user's banner color as a hex, if any
     :ivar Optional[int] accent_color?: The user's banner color as an integer represented of hex color codes
     :ivar Optional[str] locale?: The user's chosen language option
     :ivar Optional[bool] verified?: Whether the email associated with this account has been verified
@@ -34,6 +36,7 @@ class User(DictSerializerMixin):
         "mfa_enabled",
         "banner",
         "accent_color",
+        "banner_color",
         "locale",
         "verified",
         "email",

--- a/interactions/api/models/user.pyi
+++ b/interactions/api/models/user.pyi
@@ -14,6 +14,7 @@ class User(DictSerializerMixin):
     mfa_enabled: Optional[bool]
     banner: Optional[str]
     accent_color: Optional[int]
+    banner_color: Optional[str]
     locale: Optional[str]
     verified: Optional[bool]
     email: Optional[str]


### PR DESCRIPTION
Added banner_color to User model (__slots__ and docstring)

## About

This pull request is about the undocumented banner_color user attribute, which is for user banners..

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [x] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent): https://github.com/interactions-py/library/issues/607
- [ ] I've made this pull request for/as: (check all that apply)
  - [x] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
