### PR TITLE
docs(quickstart): remove extra quote in example

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -274,7 +274,7 @@ implementation of a component:
     async def button_test(ctx):
         await ctx.send("testing", components=button)
 
-    @bot.component("hello"")
+    @bot.component("hello")
     async def button_response(ctx):
         await ctx.send("You clicked the Button :O", ephemeral=True)
 


### PR DESCRIPTION
## About

This pull request removes an extra quote from the Quickstart page. This quote causes the code to throw a `SyntaxError`. The change has been made in the first example in the [Creating and sending Components](https://discord-py-slash-command.readthedocs.io/en/latest/quickstart.html#creating-and-sending-components) section.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [x] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - #643 :
- [x] I've made this pull request for/as: (check all that apply)
  - [x] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [ ] Bugfix
