### PR TITLE
fix: Fix webhook execution payload.

### DIFF
--- a/interactions/api/http.py
+++ b/interactions/api/http.py
@@ -2407,7 +2407,7 @@ class HTTPClient:
         webhook_id: int,
         webhook_token: str,
         payload: dict,
-        wait: bool = False,
+        wait: Optional[bool] = False,
         thread_id: Optional[int] = None,
     ) -> Optional[Message]:
         """
@@ -2421,9 +2421,13 @@ class HTTPClient:
         :return: The message sent, if wait=True, else None.
         """
 
+        dct = {"wait": "true" if wait else "false"}
+        if thread_id:
+            dct["thread_id"] = thread_id
+
         return await self._req.request(
             Route("POST", f"/webhooks/{webhook_id}/{webhook_token}"),
-            params={"wait": wait, "thread_id": thread_id},
+            params=dct,
             json=payload,
         )
 

--- a/interactions/api/http/webhook.py
+++ b/interactions/api/http/webhook.py
@@ -105,7 +105,7 @@ class _WebhookRequest:
         webhook_id: int,
         webhook_token: str,
         payload: dict,
-        wait: bool = False,
+        wait: Optional[bool] = False,
         thread_id: Optional[int] = None,
     ) -> Optional[dict]:
         """
@@ -119,9 +119,13 @@ class _WebhookRequest:
         :return: The message sent, if wait=True, else None.
         """
 
+        dct = {"wait": "true" if wait else "false"}
+        if thread_id:
+            dct["thread_id"] = thread_id
+
         return await self._req.request(
             Route("POST", f"/webhooks/{webhook_id}/{webhook_token}"),
-            params={"wait": wait, "thread_id": thread_id},
+            params=dct,
             json=payload,
         )
 

--- a/interactions/api/http/webhook.py
+++ b/interactions/api/http/webhook.py
@@ -119,13 +119,13 @@ class _WebhookRequest:
         :return: The message sent, if wait=True, else None.
         """
 
-        dct = {"wait": "true" if wait else "false"}
+        params = {"wait": "true" if wait else "false"}
         if thread_id:
-            dct["thread_id"] = thread_id
+            params["thread_id"] = thread_id
 
         return await self._req.request(
             Route("POST", f"/webhooks/{webhook_id}/{webhook_token}"),
-            params=dct,
+            params=params,
             json=payload,
         )
 


### PR DESCRIPTION
## About

This pull request fixes the usage of `execute_webhook()` within the http file.
This was first pointed out at https://canary.discord.com/channels/789032594456576001/952983486715797565

## Checklist

- [X] I've ran `pre-commit` to format and lint the change(s) made.
- [X] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [X] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [X] Bugfix
