### PR TITLE
[Fix] Add support to create Embed not only with dictionary attributes.

### DIFF
--- a/interactions/api/models/message.py
+++ b/interactions/api/models/message.py
@@ -301,7 +301,7 @@ class Message(DictSerializerMixin):
 
     def __repr__(self) -> str:
         return self.content
-
+  
     async def get_channel(self) -> Channel:
         """
         Gets the channel where the message was sent.
@@ -872,7 +872,7 @@ class EmbedProvider(DictSerializerMixin):
     A class object representing the provider of an embed.
 
     :ivar Optional[str] name?: Name of provider
-    :ivar Optional[str] name?: URL of provider
+    :ivar Optional[str] url?: URL of provider
     """
 
     __slots__ = ("_json", "url", "name")
@@ -1048,38 +1048,38 @@ class Embed(DictSerializerMixin):
         )
         self.footer = (
             EmbedFooter(**self.footer)
-            if isinstance(self._json.get("footer"), dict)
-            else self._json.get("footer")
+            if isinstance(self.footer, dict)
+            else self.footer
         )
         self.image = (
             EmbedImageStruct(**self.image)
-            if isinstance(self._json.get("image"), dict)
-            else self._json.get("image")
+            if isinstance(self.image, dict)
+            else self.image
         )
         self.thumbnail = (
             EmbedImageStruct(**self.thumbnail)
-            if isinstance(self._json.get("thumbnail"), dict)
-            else self._json.get("thumbnail")
+            if isinstance(self.thumbnail, dict)
+            else self.thumbnail
         )
         self.video = (
             EmbedImageStruct(**self.video)
-            if isinstance(self._json.get("video"), dict)
-            else self._json.get("video")
+            if isinstance(self.video, dict)
+            else self.video
         )
         self.provider = (
             EmbedProvider(**self.provider)
-            if isinstance(self._json.get("provider"), dict)
-            else self._json.get("provider")
+            if isinstance(self.provider, dict)
+            else self.provider
         )
         self.author = (
             EmbedAuthor(**self.author)
-            if isinstance(self._json.get("author"), dict)
-            else self._json.get("author")
+            if isinstance(self.author, dict)
+            else self.author
         )
         self.fields = (
             [
                 EmbedField(**field) if isinstance(field, dict) else field
-                for field in self._json["fields"]
+                for field in self.fields
             ]
             if self._json.get("fields")
             else None

--- a/interactions/api/models/message.py
+++ b/interactions/api/models/message.py
@@ -854,9 +854,6 @@ class EmbedImageStruct(DictSerializerMixin):
 
     __slots__ = ("_json", "url", "proxy_url", "height", "width")
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
     def __setattr__(self, key, value) -> None:
         super().__setattr__(key, value)
         if key != "_json" and (key not in self._json or value != self._json.get(key)):
@@ -876,9 +873,6 @@ class EmbedProvider(DictSerializerMixin):
     """
 
     __slots__ = ("_json", "url", "name")
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
 
     def __setattr__(self, key, value) -> None:
         super().__setattr__(key, value)
@@ -910,9 +904,6 @@ class EmbedAuthor(DictSerializerMixin):
 
     __slots__ = ("_json", "url", "proxy_icon_url", "icon_url", "name")
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
     def __setattr__(self, key, value) -> None:
         super().__setattr__(key, value)
         if key != "_json" and (key not in self._json or value != self._json.get(key)):
@@ -941,9 +932,6 @@ class EmbedFooter(DictSerializerMixin):
     """
 
     __slots__ = ("_json", "text", "proxy_icon_url", "icon_url")
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
 
     def __setattr__(self, key, value) -> None:
         super().__setattr__(key, value)
@@ -975,9 +963,6 @@ class EmbedField(DictSerializerMixin):
     """
 
     __slots__ = ("_json", "name", "inline", "value")
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
 
     def __setattr__(self, key, value) -> None:
         super().__setattr__(key, value)

--- a/interactions/api/models/message.py
+++ b/interactions/api/models/message.py
@@ -301,7 +301,7 @@ class Message(DictSerializerMixin):
 
     def __repr__(self) -> str:
         return self.content
-  
+
     async def get_channel(self) -> Channel:
         """
         Gets the channel where the message was sent.
@@ -1031,41 +1031,20 @@ class Embed(DictSerializerMixin):
             if self._json.get("timestamp")
             else datetime.utcnow()
         )
-        self.footer = (
-            EmbedFooter(**self.footer)
-            if isinstance(self.footer, dict)
-            else self.footer
-        )
-        self.image = (
-            EmbedImageStruct(**self.image)
-            if isinstance(self.image, dict)
-            else self.image
-        )
+        self.footer = EmbedFooter(**self.footer) if isinstance(self.footer, dict) else self.footer
+        self.image = EmbedImageStruct(**self.image) if isinstance(self.image, dict) else self.image
         self.thumbnail = (
             EmbedImageStruct(**self.thumbnail)
             if isinstance(self.thumbnail, dict)
             else self.thumbnail
         )
-        self.video = (
-            EmbedImageStruct(**self.video)
-            if isinstance(self.video, dict)
-            else self.video
-        )
+        self.video = EmbedImageStruct(**self.video) if isinstance(self.video, dict) else self.video
         self.provider = (
-            EmbedProvider(**self.provider)
-            if isinstance(self.provider, dict)
-            else self.provider
+            EmbedProvider(**self.provider) if isinstance(self.provider, dict) else self.provider
         )
-        self.author = (
-            EmbedAuthor(**self.author)
-            if isinstance(self.author, dict)
-            else self.author
-        )
+        self.author = EmbedAuthor(**self.author) if isinstance(self.author, dict) else self.author
         self.fields = (
-            [
-                EmbedField(**field) if isinstance(field, dict) else field
-                for field in self.fields
-            ]
+            [EmbedField(**field) if isinstance(field, dict) else field for field in self.fields]
             if self._json.get("fields")
             else None
         )


### PR DESCRIPTION
## About

Previously, all custom attributes for an Embed had to be instantiated as dictionaries. For example:
```py
return interactions.Embed(
        title=title,
        description=description,
        color=color,
        footer=footer,
        thumbnail=interactions.EmbedImageStruct(url=URL)._json,
        image=interactions.EmbedImageStruct(url=URL)._json,
        video=interactions.EmbedImageStruct(url=URL)._json
    )
```
Now adding `._json` will not be required anymore

## Checklist

- [ ] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [x] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent): #657 
- [x] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
