### PR TITLE
fix: allow autocomplete http get_application_commands if sync is false

### DIFF
--- a/interactions/client.py
+++ b/interactions/client.py
@@ -849,7 +849,7 @@ class Client:
         elif isinstance(command, str):
             _command_obj: ApplicationCommand = self._http.cache.interactions.get(command)
             if not _command_obj or not _command_obj.id:
-                if getattr(_command_obj, "guild_id", None) or self._automate_sync:
+                if getattr(_command_obj, "guild_id", None) or not self._automate_sync:
                     _application_commands = self._loop.run_until_complete(
                         self._http.get_application_commands(
                             application_id=self.me.id,


### PR DESCRIPTION
## About

Call `get_application_commands` if sync is false in the autocomplete logic. Fixes #582 

## Checklist

- [ ] I've ran `pre-commit` to format and lint the change(s) made.
- [ ] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [x] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent): #582 
- [x] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
