### PR TITLE
fix!: constant command synchronization even without changes on the command

### DIFF
--- a/interactions/client.py
+++ b/interactions/client.py
@@ -133,14 +133,8 @@ class Client:
         :rtype: bool
         """
         attrs: List[str] = [
-            "type",
-            "name",
-            "description",
-            "options",
-            "guild_id",
-            "default_permission",
+            name for name in ApplicationCommand.__slots__ if not name.startswith("_")
         ]
-        # TODO: implement permission/localization check when available.
         log.info(f"Current attributes to compare: {', '.join(attrs)}.")
         clean: bool = True
 

--- a/interactions/client.pyi
+++ b/interactions/client.pyi
@@ -28,9 +28,6 @@ class Client:
     _scopes: set[List[Union[int, Snowflake]]]
     _automate_sync: bool
     _extensions: Optional[Dict[str, Union[ModuleType, Extension]]]
-    __to_delete: list
-    __to_sync: list
-    __has_commands: bool
     me: Optional[Application]
     def __init__(
         self,
@@ -48,7 +45,6 @@ class Client:
     async def __bulk_update_sync(
         self, data: List[dict], delete: Optional[bool] = False
     ) -> None: ...
-    async def __prepare_sync(self, payload: Optional[dict] = None) -> None: ...
     async def _synchronize(self, payload: Optional[dict] = None) -> None: ...
     async def _ready(self) -> None: ...
     async def _login(self) -> None: ...

--- a/interactions/client.pyi
+++ b/interactions/client.pyi
@@ -28,6 +28,9 @@ class Client:
     _scopes: set[List[Union[int, Snowflake]]]
     _automate_sync: bool
     _extensions: Optional[Dict[str, Union[ModuleType, Extension]]]
+    __to_delete: list
+    __to_sync: list
+    __has_commands: bool
     me: Optional[Application]
     def __init__(
         self,
@@ -45,6 +48,7 @@ class Client:
     async def __bulk_update_sync(
         self, data: List[dict], delete: Optional[bool] = False
     ) -> None: ...
+    async def __prepare_sync(self, payload: Optional[dict] = None) -> None: ...
     async def _synchronize(self, payload: Optional[dict] = None) -> None: ...
     async def _ready(self) -> None: ...
     async def _login(self) -> None: ...


### PR DESCRIPTION
## About

This PR fixes an issue where commands would always be synced.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [x] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent): #662 
- [ ] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
