### PR TITLE
refactor: allow archiving of threads in channel helper methods

### DIFF
--- a/interactions/api/models/channel.py
+++ b/interactions/api/models/channel.py
@@ -535,6 +535,63 @@ class Channel(DictSerializerMixin):
 
         return await self.modify(nsfw=nsfw, reason=reason)
 
+    async def archive(
+        self,
+        archived: bool = True,
+        *,
+        reason: Optional[str] = None,
+    ) -> "Channel":
+        """
+        Sets the archived state of the thread.
+
+        :param archived: Whether the Thread is archived, defaults to True
+        :type archived: bool
+        :param reason?: The reason of the archiving
+        :type reason: Optional[str]
+        :return: The edited channel
+        :rtype: Channel
+        """
+
+        return await self.modify(archived=archived, reason=reason)
+
+    async def set_auto_archive_duration(
+        self,
+        auto_archive_duration: int,
+        *,
+        reason: Optional[str] = None,
+    ) -> "Channel":
+        """
+        Sets the time after the thread is automatically archived.
+
+        :param auto_archive_duration: The time after the thread is automatically archived. One of 60, 1440, 4320, 10080
+        :type auto_archive_duration: int
+        :param reason?: The reason of the edit
+        :type reason: Optional[str]
+        :return: The edited channel
+        :rtype: Channel
+        """
+
+        return await self.modify(auto_archive_duration=auto_archive_duration, reason=reason)
+
+    async def lock(
+        self,
+        locked: bool = True,
+        *,
+        reason: Optional[str] = None,
+    ) -> "Channel":
+        """
+        Sets the locked state of the thread.
+
+        :param locked: Whether the Thread is locked, defaults to True
+        :type locked: bool
+        :param reason?: The reason of the edit
+        :type reason: Optional[str]
+        :return: The edited channel
+        :rtype: Channel
+        """
+
+        return await self.modify(locked=locked, reason=reason)
+
     async def add_member(
         self,
         member_id: int,

--- a/interactions/api/models/channel.pyi
+++ b/interactions/api/models/channel.pyi
@@ -103,6 +103,9 @@ class Channel(DictSerializerMixin):
         permission_overwrites: Optional[List[Overwrite]] = MISSING,
         parent_id: Optional[int] = MISSING,
         nsfw: Optional[bool] = MISSING,
+        archived: Optional[bool] = MISSING,
+        auto_archive_duration: Optional[int] = MISSING,
+        locked: Optional[bool] = MISSING,
         reason: Optional[str] = None,
     ) -> "Channel": ...
     async def set_name(
@@ -152,6 +155,24 @@ class Channel(DictSerializerMixin):
         nsfw: bool,
         *,
         reason: Optional[str] = None
+    ) -> "Channel": ...
+    async def archive(
+        self,
+        archived: bool = True,
+        *,
+        reason: Optional[str] = None,
+    ) -> "Channel": ...
+    async def set_auto_archive_duration(
+        self,
+        auto_archive_duration: int,
+        *,
+        reason: Optional[str] = None,
+    ) -> "Channel": ...
+    async def lock(
+        self,
+        locked: bool = True,
+        *,
+        reason: Optional[str] = None,
     ) -> "Channel": ...
     async def add_member(
         self,

--- a/interactions/api/models/guild.pyi
+++ b/interactions/api/models/guild.pyi
@@ -236,6 +236,9 @@ class Guild(DictSerializerMixin):
         permission_overwrites: Optional[List[Overwrite]] = MISSING,
         parent_id: Optional[int] = MISSING,
         nsfw: Optional[bool] = MISSING,
+        archived: Optional[bool] = MISSING,
+        auto_archive_duration: Optional[int] = MISSING,
+        locked: Optional[bool] = MISSING,
         reason: Optional[str] = None,
     ) -> Channel: ...
     async def modify_member(


### PR DESCRIPTION


## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [ ] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [x] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent): #666 
- [ ] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
