### PR TITLE
fix: check for WS_CLOSED_MESSAGE after receiving

### DIFF
--- a/interactions/api/gateway.py
+++ b/interactions/api/gateway.py
@@ -18,6 +18,7 @@ from time import perf_counter
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from aiohttp import WSMessage
+from aiohttp.http import WS_CLOSED_MESSAGE
 
 from ..base import get_logger
 from ..enums import InteractionType, OptionType
@@ -198,7 +199,7 @@ class WebSocketClient:
 
                 if stream is None:
                     continue
-                if self._client is None:
+                if self._client is None or stream == WS_CLOSED_MESSAGE:
                     await self._establish_connection()
                     break
 
@@ -536,6 +537,8 @@ class WebSocketClient:
         """
 
         packet: WSMessage = await self._client.receive()
+        if packet == WS_CLOSED_MESSAGE:
+            return packet
         return loads(packet.data) if packet and isinstance(packet.data, str) else None
 
     async def _send_packet(self, data: Dict[str, Any]) -> None:


### PR DESCRIPTION
## About

This pull request is about the gateway. It makes sure the packet isn't a WS_CLOSED_MESSAGE before trying to receive packets. Previously, the lib attempted to continuously receive packets even though they were all WS_CLOSED_MESSAGE.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [x] This fixes/solves an Issue
  - [x] #623 
- [x] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
