### PR TITLE
fix!: check for a `CLOSING_MESSAGE` in the WebSocketClient connection

### DIFF
--- a/interactions/api/gateway.py
+++ b/interactions/api/gateway.py
@@ -199,7 +199,7 @@ class WebSocketClient:
 
                 if stream is None:
                     continue
-                if self._client is None or stream == WS_CLOSED_MESSAGE:
+                if self._client is None or stream == WS_CLOSED_MESSAGE or stream == WSMsgType.CLOSE:
                     await self._establish_connection()
                     break
 

--- a/interactions/api/gateway.py
+++ b/interactions/api/gateway.py
@@ -17,7 +17,7 @@ from sys import platform, version_info
 from time import perf_counter
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from aiohttp import WSMessage
+from aiohttp import WSMessage, WSMsgType
 from aiohttp.http import WS_CLOSED_MESSAGE, WS_CLOSING_MESSAGE
 
 from ..base import get_logger
@@ -537,7 +537,12 @@ class WebSocketClient:
         """
 
         packet: WSMessage = await self._client.receive()
-        if packet == WS_CLOSED_MESSAGE:
+
+        if packet == WSMsgType.CLOSE:
+            await self._client.close()
+            return packet
+
+        elif packet == WS_CLOSED_MESSAGE:
             return packet
 
         elif packet == WS_CLOSING_MESSAGE:

--- a/interactions/api/gateway.py
+++ b/interactions/api/gateway.py
@@ -1,5 +1,3 @@
-from aiohttp.http_websocket import WS_CLOSING_MESSAGE
-
 try:
     from orjson import dumps, loads
 except ImportError:
@@ -20,7 +18,7 @@ from time import perf_counter
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from aiohttp import WSMessage
-from aiohttp.http import WS_CLOSED_MESSAGE
+from aiohttp.http import WS_CLOSED_MESSAGE, WS_CLOSING_MESSAGE
 
 from ..base import get_logger
 from ..enums import InteractionType, OptionType

--- a/interactions/api/gateway.py
+++ b/interactions/api/gateway.py
@@ -1,3 +1,5 @@
+from aiohttp.http_websocket import WS_CLOSING_MESSAGE
+
 try:
     from orjson import dumps, loads
 except ImportError:
@@ -539,6 +541,11 @@ class WebSocketClient:
         packet: WSMessage = await self._client.receive()
         if packet == WS_CLOSED_MESSAGE:
             return packet
+
+        elif packet == WS_CLOSING_MESSAGE:
+            await self._client.close()
+            return WS_CLOSED_MESSAGE
+
         return loads(packet.data) if packet and isinstance(packet.data, str) else None
 
     async def _send_packet(self, data: Dict[str, Any]) -> None:


### PR DESCRIPTION


## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [ ] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [ ] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
