### PR TITLE
fix: prevent kwargs modification during `for` loop iteration

### DIFF
--- a/interactions/api/models/misc.py
+++ b/interactions/api/models/misc.py
@@ -36,7 +36,7 @@ class DictSerializerMixin(object):
         # for key in kwargs:
         #    setattr(self, key, kwargs[key])
 
-        for key in kwargs:
+        for key in list(kwargs):
             if key in self.__slots__ if hasattr(self, "__slots__") else True:
                 # else case if the mixin is used outside of this library and/or SDK.
                 setattr(self, key, kwargs[key])


### PR DESCRIPTION
## About

Creates a protected instance of `kwargs` during the DictSerializerMixin for `for` loop to prevent RuntimeError

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [x] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent): #683 
- [x] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
