### PR TITLE
feat: implement `Client.get()` dynamically

### DIFF
--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -7,7 +7,7 @@ from importlib.util import resolve_name
 from inspect import getmembers
 from logging import Logger
 from types import ModuleType
-from typing import Any, Callable, Coroutine, Dict, List, Optional, Union
+from typing import Any, Callable, Coroutine, Dict, List, Optional, TypeVar, Union
 
 from ..api import Cache
 from ..api import Item as Build
@@ -18,6 +18,7 @@ from ..api.models.flags import Intents
 from ..api.models.guild import Guild
 from ..api.models.misc import MISSING, Snowflake
 from ..api.models.presence import ClientPresence
+from ..api.models.role import Role
 from ..api.models.team import Application
 from ..base import get_logger
 from .decor import command
@@ -26,6 +27,7 @@ from .enums import ApplicationCommandType, Locale, OptionType
 from .models.command import ApplicationCommand, Option
 from .models.component import Button, Modal, SelectMenu
 
+T = TypeVar("T")
 log: Logger = get_logger("client")
 _token: str = ""  # noqa
 _cache: Optional[Cache] = None
@@ -362,6 +364,55 @@ class Client:
         :type presence: ClientPresence
         """
         await self._websocket._update_presence(presence)
+
+    async def get(
+        self, model: T, http_method: Optional[str] = None, **kwargs: Dict[str, Snowflake]
+    ) -> T:
+        """
+        A helper function for getting a model from the Discord API.
+
+        :param model: The model to get.
+        :type model: object
+        :param http_method: The HTTP method to use instead of `get_x`.
+        :type http_method: Optional[str]
+        :param kwargs: The arguments to pass to the HTTP method.
+        :type kwargs: Dict[str, Snowflake]
+        :return: The model.
+        :rtype: object
+        """
+        if model is Role:
+            if not kwargs.get("guild_id") and kwargs.get("role_id"):
+                raise TypeError(
+                    "Client.get() missing some of the following required keyword arguments: guild_id, role_id."
+                )
+            try:
+                roles: List[dict] = await self._http.get_all_roles(int(kwargs["guild_id"]))
+            except TypeError as e:
+                raise ValueError("Invalid guild_id provided.") from e
+            role = next((_role for _role in roles if _role["id"] == str(kwargs["role_id"])), None)
+            if role is None:
+                raise ValueError("Role not found.")
+            return Role(**role, _client=self._http)
+        else:
+            class_name: str = model.__name__.removesuffix("s")
+            try:
+                _http_method: Coroutine = getattr(
+                    self._http, http_method or f"get_{class_name.lower()}"
+                )
+            except AttributeError as e:
+                raise ValueError(f"Client.get() does not support the model {class_name}.") from e
+            try:
+                res: Union[dict, List[dict]] = await _http_method(**kwargs)
+            except TypeError as e:
+                raise ValueError(
+                    f"Client.get() could not find a {class_name} with the given IDs."
+                ) from e
+            if isinstance(res, dict):
+                return model(**res, _client=self._http)
+            elif isinstance(res, list):
+                return [model(**r, _client=self._http) for r in res]
+            else:
+                return res
 
     def __check_command(
         self,

--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -368,15 +368,15 @@ class Client:
     async def get(
         self, model: T, http_method: Optional[str] = None, **kwargs: Dict[str, Snowflake]
     ) -> T:
-        """
+        r"""
         A helper function for getting a model from the Discord API.
 
         :param model: The model to get.
         :type model: object
         :param http_method: The HTTP method to use instead of `get_x`.
         :type http_method: Optional[str]
-        :param kwargs: The arguments to pass to the HTTP method.
-        :type kwargs: Dict[str, Snowflake]
+        :param \**kwargs: The arguments to pass to the HTTP method.
+        :type \**kwargs: Dict[str, Snowflake]
         :return: The model.
         :rtype: object
         """

--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -391,7 +391,7 @@ class Client:
                     return Role(**role, _client=self._http)
             raise ValueError("Role not found.")
         elif __obj is not List:
-            class_name: str = __obj.__name__.removesuffix("s")
+            class_name: str = __obj.__name__
             try:
                 _http_method: Coroutine = getattr(
                     self._http, http_method or f"get_{class_name.lower()}"

--- a/interactions/client/bot.pyi
+++ b/interactions/client/bot.pyi
@@ -7,31 +7,22 @@ from typing import (
     Dict,
     List,
     Optional,
-    overload,
     Tuple,
-    Type,
-    TypeVar,
     Union,
 )
 
 from ..api.cache import Cache
 from ..api.gateway import WebSocketClient
 from ..api.http.client import HTTPClient
-from ..api.models.channel import Channel
 from ..api.models.flags import Intents
 from ..api.models.guild import Guild
-from ..api.models.member import Member
-from ..api.models.message import Message
 from ..api.models.misc import MISSING, Snowflake
 from ..api.models.presence import ClientPresence
-from ..api.models.role import Role
 from ..api.models.team import Application
-from ..api.models.user import User
 from .enums import ApplicationCommandType, Locale
 from .models.command import ApplicationCommand, Option
 from .models.component import Button, Modal, SelectMenu
 
-T = TypeVar("T")
 _token: str = ""  # noqa
 _cache: Optional[Cache] = None
 
@@ -69,52 +60,7 @@ class Client:
     async def wait_until_ready(self) -> None: ...
     def event(self, coro: Coroutine, name: Optional[str] = None) -> Callable[..., Any]: ...
     def change_presence(self, presence: ClientPresence) -> None: ...
-    @overload
-    async def get(
-        self, model: Type[Channel], http_method: Optional[str] = None, *, channel_id: Snowflake
-    ) -> Channel: ...
-    @overload
-    async def get(
-        self, model: Type[Guild], http_method: Optional[str] = None, *, guild_id: Snowflake
-    ) -> Guild: ...
-    @overload
-    async def get(
-        self,
-        model: Type[Member],
-        http_method: Optional[str] = None,
-        *,
-        guild_id: Snowflake,
-        member_id: Snowflake,
-    ) -> Member: ...
-    @overload
-    async def get(
-        self,
-        model: Type[Message],
-        http_method: Optional[str] = None,
-        *,
-        channel_id: Snowflake,
-        message_id: Snowflake,
-    ) -> Message: ...
-    @overload
-    async def get(
-        self,
-        model: Type[Role],
-        http_method: Optional[str] = None,
-        *,
-        guild_id: Snowflake,
-        role_id: Snowflake,
-    ) -> Role: ...
-    @overload
-    async def get(
-        self,
-        model: Type[User],
-        http_method: Optional[str] = None,
-        *,
-        user_id: Optional[Snowflake] = None,
-    ) -> User: ...
-    async def get(
-        self, model: T, http_method: Optional[str] = None, **kwargs: Dict[str, Snowflake]
-    ) -> T: ...
+    async def get(self, __obj: object, http_method: Optional[str] = None, **kwargs) -> object: ...
     def __check_command(
         self,
         command: ApplicationCommand,

--- a/interactions/client/bot.pyi
+++ b/interactions/client/bot.pyi
@@ -1,19 +1,37 @@
 from asyncio import AbstractEventLoop
 from types import ModuleType
-from typing import Any, Callable, Coroutine, Dict, List, Optional, Tuple, Union
+from typing import (
+    Any,
+    Callable,
+    Coroutine,
+    Dict,
+    List,
+    Optional,
+    overload,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
 
 from ..api.cache import Cache
 from ..api.gateway import WebSocketClient
 from ..api.http.client import HTTPClient
+from ..api.models.channel import Channel
 from ..api.models.flags import Intents
 from ..api.models.guild import Guild
+from ..api.models.member import Member
+from ..api.models.message import Message
 from ..api.models.misc import MISSING, Snowflake
 from ..api.models.presence import ClientPresence
+from ..api.models.role import Role
 from ..api.models.team import Application
+from ..api.models.user import User
 from .enums import ApplicationCommandType, Locale
 from .models.command import ApplicationCommand, Option
 from .models.component import Button, Modal, SelectMenu
 
+T = TypeVar("T")
 _token: str = ""  # noqa
 _cache: Optional[Cache] = None
 
@@ -51,12 +69,58 @@ class Client:
     async def wait_until_ready(self) -> None: ...
     def event(self, coro: Coroutine, name: Optional[str] = None) -> Callable[..., Any]: ...
     def change_presence(self, presence: ClientPresence) -> None: ...
+    @overload
+    async def get(
+        self, model: Type[Channel], http_method: Optional[str] = None, *, channel_id: Snowflake
+    ) -> Channel: ...
+    @overload
+    async def get(
+        self, model: Type[Guild], http_method: Optional[str] = None, *, guild_id: Snowflake
+    ) -> Guild: ...
+    @overload
+    async def get(
+        self,
+        model: Type[Member],
+        http_method: Optional[str] = None,
+        *,
+        guild_id: Snowflake,
+        member_id: Snowflake,
+    ) -> Member: ...
+    @overload
+    async def get(
+        self,
+        model: Type[Message],
+        http_method: Optional[str] = None,
+        *,
+        channel_id: Snowflake,
+        message_id: Snowflake,
+    ) -> Message: ...
+    @overload
+    async def get(
+        self,
+        model: Type[Role],
+        http_method: Optional[str] = None,
+        *,
+        guild_id: Snowflake,
+        role_id: Snowflake,
+    ) -> Role: ...
+    @overload
+    async def get(
+        self,
+        model: Type[User],
+        http_method: Optional[str] = None,
+        *,
+        user_id: Optional[Snowflake] = None,
+    ) -> User: ...
+    async def get(
+        self, model: T, http_method: Optional[str] = None, **kwargs: Dict[str, Snowflake]
+    ) -> T: ...
     def __check_command(
         self,
         command: ApplicationCommand,
         coro: Coroutine,
         regex: str = r"^[a-z0-9_-]{1,32}$",
-    )-> None: ...
+    ) -> None: ...
     def command(
         self,
         *,
@@ -67,7 +131,7 @@ class Client:
         options: Optional[List[Option]] = MISSING,
         default_permission: Optional[bool] = MISSING,
         name_localizations: Optional[Dict[Union[str, Locale], str]] = MISSING,
-        description_localizations: Optional[Dict[Union[str, Locale], str]]  = MISSING,
+        description_localizations: Optional[Dict[Union[str, Locale], str]] = MISSING,
     ) -> Callable[..., Any]: ...
     def message_command(
         self,
@@ -75,7 +139,7 @@ class Client:
         name: str,
         scope: Optional[Union[int, Guild, List[int], List[Guild]]] = MISSING,
         default_permission: Optional[bool] = MISSING,
-        name_localizations: Optional[Dict[Union[str, Locale], str]]  = MISSING,
+        name_localizations: Optional[Dict[Union[str, Locale], str]] = MISSING,
     ) -> Callable[..., Any]: ...
     def user_command(
         self,
@@ -83,7 +147,7 @@ class Client:
         name: str,
         scope: Optional[Union[int, Guild, List[int], List[Guild]]] = MISSING,
         default_permission: Optional[bool] = MISSING,
-        name_localizations: Optional[Dict[Union[str, Locale], str]]  = MISSING,
+        name_localizations: Optional[Dict[Union[str, Locale], str]] = MISSING,
     ) -> Callable[..., Any]: ...
     def component(self, component: Union[Button, SelectMenu]) -> Callable[..., Any]: ...
     def autocomplete(


### PR DESCRIPTION
## About

This pull request implements the helper function `Client.get()`, which lets you dynamically and effortlessly get models from the Discord API.

You use this function by assigning a variable to the result of the function call.
The keyword arguments depend on what kind of model you want to get.
Input the keyword arguments as integers, or as the HTTP methods in the `HTTPClient` require.

Here are examples of how you can use this helper function:
```py
from interactions import Channel, Guild, Member, Message, Role, User, Client
...
client: Client = Client(...)
...
channel: Channel = await client.get(
    Channel,
    channel_id=...,
)
guild: Guild = await client.get(
    Guild,
    guild_id=...,
)
member: Member = await client.get(
    Member,
    guild_id=...,
    member_id=...,
)
message: Message = await client.get(
    Message,
    channel_id=...,
    message_id=...,
)
role: Role = await client.get(
    Role,
    guild_id=...,
    role_id=...,
)
user: User = await client.get(
    User,
    user_id=...,
)
```
## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [x] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent): #691 
- [x] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [x] New feature/enhancement
  - [ ] Bugfix
