### PR TITLE
refactor: Align guild get-ban helper methods to the change of their endpoint

### DIFF
--- a/interactions/api/models/guild.pyi
+++ b/interactions/api/models/guild.pyi
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, List, Optional, Union
+from typing import Any, List, Optional, Union, Dict
 from enum import IntEnum
 
 from .channel import Channel, ChannelType, Thread
@@ -391,7 +391,13 @@ class Guild(DictSerializerMixin):
         position: int,
         reason: Optional[str] = None,
     ) -> List[Role]: ...
-    async def get_bans(self) -> List[dict]: ...
+    async def get_bans(
+        self,
+        limit: Optional[int] = 1000,
+        before: Optional[int] = None,
+        after: Optional[int] = None,
+    ) -> List[dict]: ...
+    async def get_all_bans(self) -> List[Dict[str, User]]: ...
     async def get_emoji(
         self,
         emoji_id: int


### PR DESCRIPTION
- Updated the `get_bans` helper method to reflect changes made to its endpoint
- Added `get_all_bans` helper method to reflect changes to the endpoint not making it return all at once anymore.


## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [ ] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
