### PR TITLE
fix: include .pyi files when building

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include README.rst
+include LICENSE
+include requirements.txt
+include requirements-docs.txt
+include requirements-lint.txt
+recursive-include interactions *.pyi

--- a/interactions/api/http/request.py
+++ b/interactions/api/http/request.py
@@ -115,7 +115,7 @@ class _Request:
         # The idea is that its regulated by the priority of Discord's bucket header and not just self-computation.
         # This implementation is based on JDA's bucket implementation, which we heavily use in favour of allowing routes
         # and other resources to be exhausted first on a separate lock call before hitting global limits.
-        
+
         if self.ratelimits.get(bucket):
             _limiter: Limiter = self.ratelimits.get(bucket)
             if _limiter.lock.locked():

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
     long_description_content_type="text/x-rst",
     url="https://github.com/interactions-py/library",
     packages=find_packages(),
+    include_package_data=True,
     python_requires=">=3.8.6",
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
## About

This PR properly includes `.pyi` files when building, allowing people who install it to have rich typehinting. This uses the [recommended way](https://setuptools.pypa.io/en/latest/userguide/quickstart.html#including-data-files) of doing so, which is to use a `MANIFEST.in` and make `include_package_data=True` in `setup.py`.

`MANIFEST.in` includes a few other basics, like the requirement files, the LICENSE, and the README.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [x] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent): #730
- [x] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
