### PR TITLE
feat: add py.typed file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,5 @@ include LICENSE
 include requirements.txt
 include requirements-docs.txt
 include requirements-lint.txt
+include interactions/py.typed
 recursive-include interactions *.pyi


### PR DESCRIPTION
## About

This pull request adds a `py.typed` file to the top level of the library, which allows type checkers to note that this package supports type hints. This is _usually_ unnecessary, but it should be included just in case.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [x] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent): #732 
- [x] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [x] New feature/enhancement
  - [ ] Bugfix
