### PR TITLE
Fix: allow variable optional values in command arg signatures

### DIFF
--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -465,7 +465,7 @@ class WebSocketClient:
             # sub_command_groups must have options so there is no extra check needed for those
             __kwargs["sub_command"] = _data["name"]
 
-        elif _data.get("value") and _data.get("name"):
+        elif _data.get("value") is not None and _data.get("name") is not None:
             __kwargs[_data["name"]] = _data["value"]
 
         return __kwargs


### PR DESCRIPTION

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [ ] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [x] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent): #570, #735
- [ ] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
