### PR TITLE
fix: Fix typehints for the HTTPClient 

### DIFF
--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -465,7 +465,7 @@ class WebSocketClient:
             # sub_command_groups must have options so there is no extra check needed for those
             __kwargs["sub_command"] = _data["name"]
 
-        elif _data.get("value") is not None and _data.get("name") is not None:
+        elif _data.get("value") and _data.get("name"):
             __kwargs[_data["name"]] = _data["value"]
 
         return __kwargs

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -465,7 +465,7 @@ class WebSocketClient:
             # sub_command_groups must have options so there is no extra check needed for those
             __kwargs["sub_command"] = _data["name"]
 
-        elif _data.get("value") and _data.get("name"):
+        elif _data.get("value") is not None and _data.get("name") is not None:
             __kwargs[_data["name"]] = _data["value"]
 
         return __kwargs

--- a/interactions/api/http/client.pyi
+++ b/interactions/api/http/client.pyi
@@ -10,7 +10,6 @@ from .member import _MemberRequest
 from .message import _MessageRequest
 from .reaction import _ReactionRequest
 from .request import _Request
-from .route import Route
 from .scheduledEvent import _ScheduledEventRequest
 from .sticker import _StickerRequest
 from .thread import _ThreadRequest

--- a/interactions/api/http/client.pyi
+++ b/interactions/api/http/client.pyi
@@ -2,14 +2,40 @@ from typing import Optional, Tuple
 
 from .request import _Request
 from ...api.cache import Cache
+from .channel import _ChannelRequest
+from .emoji import _EmojiRequest
+from .guild import _GuildRequest
+from .interaction import _InteractionRequest
+from .member import _MemberRequest
+from .message import _MessageRequest
+from .reaction import _ReactionRequest
+from .request import _Request
+from .route import Route
+from .scheduledEvent import _ScheduledEventRequest
+from .sticker import _StickerRequest
+from .thread import _ThreadRequest
+from .user import _UserRequest
+from .webhook import _WebhookRequest
 
 
-class HTTPClient:
+class HTTPClient(
+    _ChannelRequest,
+    _EmojiRequest,
+    _GuildRequest,
+    _InteractionRequest,
+    _MemberRequest,
+    _MessageRequest,
+    _ReactionRequest,
+    _ScheduledEventRequest,
+    _StickerRequest,
+    _ThreadRequest,
+    _UserRequest,
+    _WebhookRequest,
+):
+
     token: str
     _req: _Request
     cache: Cache
-
-
 
     def __init__(self, token: str): ...
 


### PR DESCRIPTION
## About

This pull request attempts to fix an issue where http typehints are not available 

## Checklist

- [ ] I've ran `pre-commit` to format and lint the change(s) made.
- [ ] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [ ] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
