### PR TITLE
fix: Fix commands not being registered properly

### DIFF
--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -359,7 +359,7 @@ class Client:
             return coro
 
         if coro is not MISSING:
-            self._websocket._dispatch.register(coro, coro.__name__)
+            self._websocket._dispatch.register(coro, name if name is not MISSING else coro.__name__)
             # it is not possible to provide a name here since it is only called when you use `@event`
             # for a name you would need `@bot.event()`, but this is handled in the decorator function
             return coro

--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -355,11 +355,15 @@ class Client:
         """
 
         def decorator(coro: Coroutine):
-            self._websocket._dispatch.register(coro, name if name is not MISSING else coro.__name__)
+            self._websocket._dispatch.register(
+                coro, name=name if name is not MISSING else coro.__name__
+            )
             return coro
 
         if coro is not MISSING:
-            self._websocket._dispatch.register(coro, name if name is not MISSING else coro.__name__)
+            self._websocket._dispatch.register(
+                coro, name=name if name is not MISSING else coro.__name__
+            )
             return coro
 
         return decorator

--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -360,8 +360,6 @@ class Client:
 
         if coro is not MISSING:
             self._websocket._dispatch.register(coro, name if name is not MISSING else coro.__name__)
-            # it is not possible to provide a name here since it is only called when you use `@event`
-            # for a name you would need `@bot.event()`, but this is handled in the decorator function
             return coro
 
         return decorator


### PR DESCRIPTION
## About

This fixes commands not being registered properly, first noticed after 9ae143b8ba5bd8a0cf5c6cb64a8133fbc3fba16a.

## Checklist

- [X] I've ran `pre-commit` to format and lint the change(s) made.
- [X] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [X] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent): https://github.com/interactions-py/library/issues/744
- [X] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
