### PR TITLE
fix!: fix possible bug with event names for extensions

### DIFF
--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -1340,7 +1340,7 @@ def extension_listener(func: Optional[Coroutine] = None, name: Optional[str] = N
 
     if func:
         # allows omitting `()` on `@listener`
-        func.__listener_name__ = func.__name__ if not name else name
+        func.__listener_name__ = name or func.__name__
         return func
 
     return decorator

--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -490,7 +490,7 @@ class Client:
             if _option.name is MISSING:
                 raise InteractionException(11, message="Options must have a name.")
             if _sub_command is not MISSING:
-                __indent = 8 if not _sub_groups_present else 12
+                __indent = 12 if _sub_groups_present else 8
                 log.debug(
                     f"{' ' * __indent}checking option '{_option.name}' of sub command '{_sub_command.name}'"
                 )
@@ -1340,7 +1340,7 @@ def extension_listener(func: Optional[Coroutine] = None, name: Optional[str] = N
 
     if func:
         # allows omitting `()` on `@listener`
-        func.__listener_name__ = func.__name__
+        func.__listener_name__ = func.__name__ if not name else name
         return func
 
     return decorator


### PR DESCRIPTION
## About
Fixes a bug that was already fixed for the normal event decorator but not for ext listeners so it could possibly occur there

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [ ] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [ ] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
