### PR TITLE
doc: changing sub commands example code

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -208,7 +208,7 @@ Nested commands: subcommands
             ),
         ],
     )
-    async def cmd(ctx: interactions.CommandContext, sub_command: str, second_option: str, option: int = None):
+    async def cmd(ctx: interactions.CommandContext, sub_command: str, second_option: str = "", option: int = None):
         if sub_command == "command_name":
           await ctx.send(f"You selected the command_name sub command and put in {option}")
         elif sub_command == "second_command":


### PR DESCRIPTION
part of sub commands make trouble in example code
`TypeError: run.<locals>.cmd() missing 1 required positional argument: 'second_option'` so
changed `second_option: str` to `second_option: str =""`

## About

This pull request is about (X), which does (Y).

## Checklist

- [ ] I've ran `pre-commit` to format and lint the change(s) made.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [x] I've made this pull request for/as: (check all that apply)
  - [x] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [ ] Bugfix
