### PR TITLE
docs: fix incorrect type note for Overwrite id

### DIFF
--- a/interactions/api/models/misc.py
+++ b/interactions/api/models/misc.py
@@ -63,7 +63,7 @@ class Overwrite(DictSerializerMixin):
     """
     This is used for the PermissionOverride object.
 
-    :ivar int id: Role or User ID
+    :ivar str id: Role or User ID
     :ivar int type: Type that corresponds ot the ID; 0 for role and 1 for member.
     :ivar str allow: Permission bit set.
     :ivar str deny: Permission bit set.

--- a/interactions/api/models/misc.pyi
+++ b/interactions/api/models/misc.pyi
@@ -11,7 +11,7 @@ class DictSerializerMixin(object):
 
 class Overwrite(DictSerializerMixin):
     _json: dict
-    id: int
+    id: str
     type: int
     allow: str
     deny: str


### PR DESCRIPTION
## About

`Overwrite`'s `id` was incorrectly noted as an integer. In reality, it's a string. This PR just fixes the note about it to note that.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [x] I've made this pull request for/as: (check all that apply)
  - [x] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [ ] Bugfix
