### PR TITLE
feat: Add method to get all users of a reaction

### DIFF
--- a/interactions/api/models/message.py
+++ b/interactions/api/models/message.py
@@ -667,12 +667,38 @@ class Message(DictSerializerMixin):
         :param user: The user or user_id to remove the reaction of
         :type user: Union[Member, user, int]
         """
+        if not self._client:
+            raise AttributeError("HTTPClient not found!")
+
         _emoji = f":{emoji.name.replace(':', '')}:{emoji.id}" if isinstance(emoji, Emoji) else emoji
 
         _user_id = user if isinstance(user, int) else user.id
         return await self._client.remove_user_reaction(
             channel_id=int(self.channel_id), message_id=int(self.id), user_id=_user_id, emoji=_emoji
         )
+
+    async def get_users_from_reaction(
+        self, emoji: Union[str, "Emoji"],
+    ) -> List[User]:
+        """
+        Retrieves all users that reacted to the message with the given emoji
+
+        :param emoji: The Emoji as object or formatted as `name:id`
+        :type emoji: Union[str, Emoji]
+        :return: A list of user objects
+        :rtype: List[User]
+        """
+        if not self._client:
+            raise AttributeError("HTTPClient not found!")
+
+        _emoji = f":{emoji.name.replace(':', '')}:{emoji.id or ''}" if isinstance(emoji, Emoji) else emoji
+
+        res = await self._client.get_reactions_of_emoji(
+            channel_id=int(self.channel_id),
+            message_id=int(self.id),
+            emoji=_emoji,
+        )
+        return [User(**_) for _ in res]
 
     @classmethod
     async def get_from_url(cls, url: str, client: "HTTPClient") -> "Message":  # noqa,

--- a/interactions/api/models/message.py
+++ b/interactions/api/models/message.py
@@ -678,7 +678,8 @@ class Message(DictSerializerMixin):
         )
 
     async def get_users_from_reaction(
-        self, emoji: Union[str, "Emoji"],
+        self,
+        emoji: Union[str, "Emoji"],
     ) -> List[User]:
         """
         Retrieves all users that reacted to the message with the given emoji
@@ -691,7 +692,11 @@ class Message(DictSerializerMixin):
         if not self._client:
             raise AttributeError("HTTPClient not found!")
 
-        _emoji = f":{emoji.name.replace(':', '')}:{emoji.id or ''}" if isinstance(emoji, Emoji) else emoji
+        _emoji = (
+            f":{emoji.name.replace(':', '')}:{emoji.id or ''}"
+            if isinstance(emoji, Emoji)
+            else emoji
+        )
 
         res = await self._client.get_reactions_of_emoji(
             channel_id=int(self.channel_id),

--- a/interactions/api/models/message.pyi
+++ b/interactions/api/models/message.pyi
@@ -161,6 +161,9 @@ class Message(DictSerializerMixin):
     async def remove_reaction_from(
         self, emoji: Union[str, "Emoji"], user: Union[Member, User, int]
     ) -> None: ...
+    async def get_users_from_reaction(
+        self, emoji: Union[str, "Emoji"],
+    ) -> List[User]: ...
     @classmethod
     async def get_from_url(
         cls,


### PR DESCRIPTION


## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [ ] I've made this pull request for/as: (check all that apply)
  - [x] Documentation
  - [ ] Breaking change
  - [x] New feature/enhancement
  - [ ] Bugfix
