### PR TITLE
fix: respect defaults for dict mixin if field has one

### DIFF
--- a/interactions/api/models/attrs_utils.py
+++ b/interactions/api/models/attrs_utils.py
@@ -53,7 +53,9 @@ class DictSerializerMixin:
 
                     passed_kwargs[attrib_name] = value
                 else:
-                    passed_kwargs[attrib_name] = None
+                    passed_kwargs[attrib_name] = (
+                        attrib.default if attrib.default is not attrs.NOTHING else None
+                    )
 
         self._extras = kwargs
         self.__attrs_init__(**passed_kwargs)  # type: ignore


### PR DESCRIPTION
## About

A very quick fix to make `DictSerializerMixin` respect defaults for fields in subclasses.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [x] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
