### PR TITLE
fix: make DictSerializerMixin respect factories

### DIFF
--- a/interactions/api/models/attrs_utils.py
+++ b/interactions/api/models/attrs_utils.py
@@ -52,10 +52,18 @@ class DictSerializerMixin:
                         self._json[attrib_name] = value._json  # type: ignore
 
                     passed_kwargs[attrib_name] = value
+
+                elif attrib.default:
+                    # handle defaults like attrs does
+                    default = attrib.default
+                    if isinstance(default, attrs.Factory):  # type: ignore
+                        passed_kwargs[attrib_name] = (
+                            default.factory(self) if default.takes_self else default.factory()
+                        )
+                    else:
+                        passed_kwargs[attrib_name] = default
                 else:
-                    passed_kwargs[attrib_name] = (
-                        attrib.default if attrib.default is not attrs.NOTHING else None
-                    )
+                    passed_kwargs[attrib_name] = None
 
         self._extras = kwargs
         self.__attrs_init__(**passed_kwargs)  # type: ignore


### PR DESCRIPTION
## About

This makes the mixin respect factories, allowing for lists and the like to be used.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [x] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
