### PR TITLE
fix: parse sub cmd (and groups) options properly

### DIFF
--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -668,7 +668,7 @@ class Client:
                     11, message="A sub command group cannot contain more than 25 sub commands!"
                 )
             for _sub_command in _sub_group.options:
-                __check_sub_command(Option(**_sub_command), _sub_group)
+                __check_sub_command(_sub_command, _sub_group)
 
         def __check_sub_command(_sub_command: Option, _sub_group: Option = MISSING):
             nonlocal _sub_cmds_present
@@ -704,7 +704,7 @@ class Client:
                     )
                 _sub_opt_names = []
                 for _opt in _sub_command.options:
-                    __check_options(Option(**_opt), _sub_opt_names, _sub_command)
+                    __check_options(_opt, _sub_opt_names, _sub_command)
                 del _sub_opt_names
 
         def __check_options(_option: Option, _names: list, _sub_command: Option = MISSING):

--- a/interactions/client/models/command.py
+++ b/interactions/client/models/command.py
@@ -114,7 +114,12 @@ class Option(DictSerializerMixin):
     def __attrs_post_init__(self):
         # needed for nested classes
         self.options = (
-            [Option(**option) for option in self.options] if self.options is not None else None
+            [
+                Option(**option._json) if hasattr(option, "_json") else Option(**option)  # type: ignore
+                for option in self.options
+            ]
+            if self.options is not None
+            else None
         )
 
 

--- a/interactions/client/models/command.py
+++ b/interactions/client/models/command.py
@@ -115,7 +115,7 @@ class Option(DictSerializerMixin):
         # needed for nested classes
         self.options = (
             [
-                Option(**option._json) if hasattr(option, "_json") else Option(**option)  # type: ignore
+                option if hasattr(option, "_json") else Option(**option)  # type: ignore
                 for option in self.options
             ]
             if self.options is not None

--- a/interactions/client/models/command.py
+++ b/interactions/client/models/command.py
@@ -114,10 +114,7 @@ class Option(DictSerializerMixin):
     def __attrs_post_init__(self):
         # needed for nested classes
         self.options = (
-            [
-                option if hasattr(option, "_json") else Option(**option)  # type: ignore
-                for option in self.options
-            ]
+            [Option(**option) if isinstance(option, dict) else option for option in self.options]
             if self.options is not None
             else None
         )


### PR DESCRIPTION
## About

This PR adjusts the option conversion logic for subcommands so that it handles both the `Option` object and the dict way. This method also adjusts the checks so that they use the resulting object, since it already has been converted.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [x] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
