### PR TITLE
fix: fill in user data for members in resolved data

### DIFF
--- a/interactions/client/models/misc.py
+++ b/interactions/client/models/misc.py
@@ -33,6 +33,13 @@ class InteractionResolvedData(DictSerializerMixin):
     messages: Dict[str, Message] = field(converter=convert_dict(value_converter=Message))
     attachments: Dict[str, Attachment] = field(converter=convert_dict(value_converter=Attachment))
 
+    def __attrs_post_init__(self):
+        if self.members:
+            # attrs has near zero way of filling this in automatically, so we have to
+            for snowflake_id in self.members.keys():
+                # members have User, user may not have Member. /shrug
+                self.members[snowflake_id].user = self.users[snowflake_id]
+
 
 @define()
 class InteractionData(DictSerializerMixin):


### PR DESCRIPTION
## About

...exactly what the title says, more or less. This fixes a bug where member data from interactions would lack anything about the user.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [x] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
