### PR TITLE
fix: fill in author alias for context

### DIFF
--- a/interactions/client/context.py
+++ b/interactions/client/context.py
@@ -62,6 +62,8 @@ class _Context(DictSerializerMixin):
     deferred: bool = field(default=False)
 
     def __attrs_post_init__(self) -> None:
+        self.author = self.member
+
         if self.user is None:
             self.user = self.member.user if self.member else None
 


### PR DESCRIPTION
## About

Simple PR to make the author alias work again.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [x] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
