### PR TITLE
fix: use input for timestamp if datetime

### DIFF
--- a/interactions/api/models/attrs_utils.py
+++ b/interactions/api/models/attrs_utils.py
@@ -1,5 +1,5 @@
 from functools import wraps
-from typing import Dict, Mapping, Tuple
+from typing import Dict, Mapping, Optional, Tuple
 
 import attrs
 
@@ -157,11 +157,14 @@ def convert_dict(key_converter=None, value_converter=None):
     return inner_convert_dict
 
 
-def convert_type(type_: type):
+def convert_type(type_: type, *, classmethod: Optional[str] = None):
     """A helper function to convert an input to a specified type."""
 
     def inner_convert_object(value):
-        return value if isinstance(value, type_) else type_(value)
+        if not classmethod:
+            return value if isinstance(value, type_) else type_(value)
+        else:
+            return value if isinstance(value, type_) else getattr(type_, classmethod)(value)
 
     return inner_convert_object
 

--- a/interactions/api/models/attrs_utils.pyi
+++ b/interactions/api/models/attrs_utils.pyi
@@ -55,7 +55,7 @@ def convert_list(converter: Callable[[_T], _P]) -> Callable[[List[_T]], List[_P]
 def convert_int(converter: Callable[[int], _T]) -> Callable[[Any], _T]:
     """A helper function to pass an int to the converter, e.x. for Enums"""
 
-def convert_type(object: Type[_T]) -> Callable[[Any], _T]:
+def convert_type(type_: Type[_T], *, classmethod: Optional[str] = None) -> Callable[[Any], _T]:
     """A helper function to convert an input to a specified type."""
 
 def convert_dict(

--- a/interactions/api/models/message.py
+++ b/interactions/api/models/message.py
@@ -10,6 +10,7 @@ from .attrs_utils import (
     ClientSerializerMixin,
     DictSerializerMixin,
     convert_list,
+    convert_type,
     define,
     field,
 )
@@ -454,7 +455,9 @@ class Embed(DictSerializerMixin):
     type: Optional[str] = field(default=None)
     description: Optional[str] = field(default=None)
     url: Optional[str] = field(default=None)
-    timestamp: Optional[datetime] = field(converter=datetime.fromisoformat, default=None)
+    timestamp: Optional[datetime] = field(
+        converter=convert_type(datetime, classmethod="fromisoformat"), default=None
+    )
     color: Optional[int] = field(default=None)
     footer: Optional[EmbedFooter] = field(converter=EmbedFooter, default=None)
     image: Optional[EmbedImageStruct] = field(converter=EmbedImageStruct, default=None)


### PR DESCRIPTION
## About

This PR allows for `timestamp` in `Embed` to use a datetime if it's provided one. This also modifies `convert_type` to make this possible, allowing the use of `classmethod`s, but that's more of a happy accident with how this fix worked out.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [x] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
