### PR TITLE
fix: give SelectMenu a default type

### DIFF
--- a/interactions/client/models/component.py
+++ b/interactions/client/models/component.py
@@ -84,7 +84,7 @@ class SelectMenu(ComponentMixin):
     :ivar Optional[bool] disabled?: Whether the select menu is unable to be used.
     """
 
-    type: ComponentType = field(converter=ComponentType)
+    type: ComponentType = field(converter=ComponentType, default=ComponentType.SELECT)
     custom_id: str = field()
     options: List[SelectOption] = field(converter=convert_list(SelectOption))
     placeholder: Optional[str] = field(default=None)


### PR DESCRIPTION
## About
This PR fixes `SelectMenu` not working for many users by giving it a default type.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [x] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
