### PR TITLE
fix: filter out _extras for custom setattrs

### DIFF
--- a/interactions/api/models/message.py
+++ b/interactions/api/models/message.py
@@ -286,7 +286,9 @@ class EmbedImageStruct(DictSerializerMixin):
 
     def __setattr__(self, key, value) -> None:
         super().__setattr__(key, value)
-        if key != "_json" and (key not in self._json or value != self._json.get(key)):
+        if key not in {"_json", "_extras"} and (
+            key not in self._json or value != self._json.get(key)
+        ):
             if value is not None and value is not MISSING:
                 self._json.update({key: value})
 
@@ -308,7 +310,9 @@ class EmbedProvider(DictSerializerMixin):
 
     def __setattr__(self, key, value) -> None:
         super().__setattr__(key, value)
-        if key != "_json" and (key not in self._json or value != self._json.get(key)):
+        if key not in {"_json", "_extras"} and (
+            key not in self._json or value != self._json.get(key)
+        ):
             if value is not None and value is not MISSING:
                 self._json.update({key: value})
 
@@ -342,7 +346,9 @@ class EmbedAuthor(DictSerializerMixin):
 
     def __setattr__(self, key, value) -> None:
         super().__setattr__(key, value)
-        if key != "_json" and (key not in self._json or value != self._json.get(key)):
+        if key not in {"_json", "_extras"} and (
+            key not in self._json or value != self._json.get(key)
+        ):
             if value is not None and value is not MISSING:
                 self._json.update({key: value})
 
@@ -374,7 +380,9 @@ class EmbedFooter(DictSerializerMixin):
 
     def __setattr__(self, key, value) -> None:
         super().__setattr__(key, value)
-        if key != "_json" and (key not in self._json or value != self._json.get(key)):
+        if key not in {"_json", "_extras"} and (
+            key not in self._json or value != self._json.get(key)
+        ):
             if value is not None and value is not MISSING:
                 self._json.update({key: value})
 
@@ -408,7 +416,9 @@ class EmbedField(DictSerializerMixin):
 
     def __setattr__(self, key, value) -> None:
         super().__setattr__(key, value)
-        if key != "_json" and (key not in self._json or value != self._json.get(key)):
+        if key not in {"_json", "_extras"} and (
+            key not in self._json or value != self._json.get(key)
+        ):
             if value is not None and value is not MISSING:
                 self._json.update({key: value})
 
@@ -466,7 +476,8 @@ class Embed(DictSerializerMixin):
 
     def __setattr__(self, key, value) -> None:
         super().__setattr__(key, value)
-        if key != "_json" and (
+
+        if key not in {"_json", "_extras"} and (
             key not in self._json
             or (
                 value != self._json.get(key)

--- a/interactions/client/models/component.py
+++ b/interactions/client/models/component.py
@@ -26,7 +26,9 @@ class ComponentMixin(DictSerializerMixin):
 
     def __setattr__(self, key, value) -> None:
         super().__setattr__(key, value)
-        if key != "_json" and (key not in self._json or value != self._json.get(key)):
+        if key not in {"_json", "_extras"} and (
+            key not in self._json or value != self._json.get(key)
+        ):
             if value is not None and value is not MISSING:
                 try:
                     value = [val._json for val in value] if isinstance(value, list) else value._json


### PR DESCRIPTION
## About

Just a little thing to filter out `_extras` for custom `__setattr__` so the `_json` doesn't become unnecessarily polluted. *Technically*, not filtering it out wasn't a huge issue, but it could in the future, so...

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [x] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
