### PR TITLE
fix: properly set embed json for Message

### DIFF
--- a/interactions/api/models/message.py
+++ b/interactions/api/models/message.py
@@ -834,6 +834,20 @@ class Message(ClientSerializerMixin):
         converter=convert_list(Sticker), default=None
     )  # deprecated
 
+    def __attrs_post_init__(self):
+        if self.embeds:
+            # note from astrea49: this dumb fix is necessary to make sure the _json
+            # is correct when using a dict for the embeds when initializing
+            # otherwise, attributes like the footer will be missing or incorrect
+            # i have no idea why this is necessary and i've have tried debugging for hours
+            # to find why it's necessary, but i've came up with nothing
+            # by all means, the converters and json should be correct, but it isn't
+            # this also happens nowhere else as far as i can tell
+
+            # this line should NOT be touched unless you somehow find a solution to
+            # this, or end up modifying how _json works altogether
+            self._json["embeds"] = [e._json for e in self.embeds]
+
     async def get_channel(self) -> Channel:
         """
         Gets the channel where the message was sent.


### PR DESCRIPTION
## About

This PR makes sure that a `Message`'s embeds in its `_json` are correct. Admittedly, it's a rather dumb fix, but... it works.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [x] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
