### PR TITLE
fix: Catch `CancelledError`/`Exception` in `start()`

### DIFF
--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -1,6 +1,6 @@
 import re
 import sys
-from asyncio import get_event_loop, iscoroutinefunction
+from asyncio import CancelledError, get_event_loop, iscoroutinefunction
 from functools import wraps
 from importlib import import_module
 from importlib.util import resolve_name
@@ -135,7 +135,10 @@ class Client:
 
     def start(self) -> None:
         """Starts the client session."""
-        self._loop.run_until_complete(self._ready())
+        try:
+            self._loop.run_until_complete(self._ready())
+        except (CancelledError, Exception) as e:
+            raise e from e
 
     def __register_events(self) -> None:
         """Registers all raw gateway events to the known events."""


### PR DESCRIPTION
## About

Catch and reraise exceptions that occur in `Client.start()`. I honestly don't know why exceptions weren't getting raised beforehand, but this now allows you to cancel the task.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [x] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
