### PR TITLE
feat: error handling for KeyboardInterrupt in `start()`

### DIFF
--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -140,7 +140,7 @@ class Client:
         except (CancelledError, Exception) as e:
             raise e from e
         except KeyboardInterrupt:
-            log.error("KeyboardInterrupt")
+            log.error("KeyboardInterrupt detected, shutting down the bot.")
 
     def __register_events(self) -> None:
         """Registers all raw gateway events to the known events."""

--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -139,6 +139,8 @@ class Client:
             self._loop.run_until_complete(self._ready())
         except (CancelledError, Exception) as e:
             raise e from e
+        except KeyboardInterrupt:
+            log.error("KeyboardInterrupt")
 
     def __register_events(self) -> None:
         """Registers all raw gateway events to the known events."""


### PR DESCRIPTION
## About

This pull request introduces error handling for `KeyboardInterrupt` in `Client.start()`, which previously displayed a huge, useless traceback whenever someone stops the bot using `Ctrl + C`.

A side effect of this particular fix: any code that is *after* `client.start()` would be executed after `KeyboardInterrupt`, which is a cool feature in my opinion.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [ ] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [x] New feature/enhancement
  - [ ] Bugfix
