### PR TITLE
fix: actually fix weird behavior with msgs and embeds

### DIFF
--- a/interactions/api/models/attrs_utils.py
+++ b/interactions/api/models/attrs_utils.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from functools import wraps
 from typing import Dict, Mapping, Optional, Tuple
 
@@ -18,9 +19,17 @@ class DictSerializerMixin:
     _extras: dict = attrs.field(init=False, repr=False)
     """A dict containing values that were not serialized from Discord."""
 
+    @property
+    def _deepcopy(self):
+        return False
+
     def __init__(self, kwargs_dict: dict = None, /, **other_kwargs):
         kwargs = kwargs_dict or other_kwargs
         client = kwargs.pop("_client", None)
+
+        if self._deepcopy:
+            kwargs = deepcopy(kwargs)
+
         self._json = kwargs.copy()
         passed_kwargs = {}
 
@@ -167,6 +176,31 @@ def convert_type(type_: type, *, classmethod: Optional[str] = None):
             return value if isinstance(value, type_) else getattr(type_, classmethod)(value)
 
     return inner_convert_object
+
+
+def deepcopy_kwargs(cls: Optional[type] = None):
+    """
+    A decorator to make the DictSerializerMixin deepcopy the kwargs before processing them.
+    This can help avoid weird bugs with some objects, though will error out in others.
+    """
+
+    @property
+    def _deepcopy(self):
+        return True
+
+    # yes, we really do overwrite a property here
+    # overriding an attribute doesn't work well, and we have no other way
+    # of telling the class to deepcopy the kwargs
+
+    def decorator(cls: type):
+        cls._deepcopy = _deepcopy  # type: ignore
+        return cls
+
+    if cls is not None:
+        cls._deepcopy = _deepcopy  # type: ignore
+        return cls
+
+    return decorator
 
 
 define_defaults = dict(kw_only=True, eq=False, init=False, on_setattr=attrs.setters.NO_OP)

--- a/interactions/api/models/attrs_utils.py
+++ b/interactions/api/models/attrs_utils.py
@@ -19,15 +19,13 @@ class DictSerializerMixin:
     _extras: dict = attrs.field(init=False, repr=False)
     """A dict containing values that were not serialized from Discord."""
 
-    @property
-    def _deepcopy(self):
-        return False
+    __deepcopy__ = False
 
     def __init__(self, kwargs_dict: dict = None, /, **other_kwargs):
         kwargs = kwargs_dict or other_kwargs
         client = kwargs.pop("_client", None)
 
-        if self._deepcopy:
+        if self.__deepcopy__:
             kwargs = deepcopy(kwargs)
 
         self._json = kwargs.copy()
@@ -184,20 +182,12 @@ def deepcopy_kwargs(cls: Optional[type] = None):
     This can help avoid weird bugs with some objects, though will error out in others.
     """
 
-    @property
-    def _deepcopy(self):
-        return True
-
-    # yes, we really do overwrite a property here
-    # overriding an attribute doesn't work well, and we have no other way
-    # of telling the class to deepcopy the kwargs
-
     def decorator(cls: type):
-        cls._deepcopy = _deepcopy  # type: ignore
+        cls.__deepcopy__ = True  # type: ignore
         return cls
 
     if cls is not None:
-        cls._deepcopy = _deepcopy  # type: ignore
+        cls.__deepcopy__ = True  # type: ignore
         return cls
 
     return decorator

--- a/interactions/api/models/attrs_utils.py
+++ b/interactions/api/models/attrs_utils.py
@@ -20,6 +20,7 @@ class DictSerializerMixin:
     """A dict containing values that were not serialized from Discord."""
 
     __deepcopy__ = False
+    """Should the kwargs be deepcopied or not?"""
 
     def __init__(self, kwargs_dict: dict = None, /, **other_kwargs):
         kwargs = kwargs_dict or other_kwargs

--- a/interactions/api/models/attrs_utils.pyi
+++ b/interactions/api/models/attrs_utils.pyi
@@ -63,3 +63,9 @@ def convert_dict(
     value_converter: Optional[Callable[[Any], _P]] = None,
 ) -> Callable[[Dict[Any, Any]], Dict[_T, _P]]:
     """A helper function to convert the keys and values of a dictionary with the specified converters"""
+
+def deepcopy_kwargs(cls: Optional[Type[_T]] = None) -> Callable[[Any], _T]:
+    """
+    A decorator to make the DictSerializerMixin deepcopy the kwargs before processing them.
+    This can help avoid weird bugs with some objects, though will error out in others.
+    """

--- a/interactions/api/models/attrs_utils.pyi
+++ b/interactions/api/models/attrs_utils.pyi
@@ -18,6 +18,8 @@ class DictSerializerMixin:
     _json: dict = attrs.field(init=False)
     _extras: dict = attrs.field(init=False)
     """A dict containing values that were not serialized from Discord."""
+    __deepcopy__: bool = attrs.field(init=False)
+    """Should the kwargs be deepcopied or not?"""
     def __init__(self, kwargs_dict: dict = None, /, **other_kwargs): ...
 
 @attrs.define(eq=False, init=False, on_setattr=attrs.setters.NO_OP)

--- a/interactions/api/models/message.py
+++ b/interactions/api/models/message.py
@@ -458,6 +458,7 @@ class EmbedField(DictSerializerMixin):
 
 
 @define()
+@deepcopy_kwargs()
 class Embed(DictSerializerMixin):
     """
     A class object representing an embed.
@@ -796,7 +797,6 @@ class ReactionObject(DictSerializerMixin):
 
 
 @define()
-@deepcopy_kwargs()
 class Message(ClientSerializerMixin):
     """
     A class object representing a message.
@@ -878,20 +878,6 @@ class Message(ClientSerializerMixin):
     stickers: Optional[List[Sticker]] = field(
         converter=convert_list(Sticker), default=None
     )  # deprecated
-
-    def __attrs_post_init__(self):
-        if self.embeds:
-            # note from astrea49: this dumb fix is necessary to make sure the _json
-            # is correct when using a dict for the embeds when initializing
-            # otherwise, attributes like the footer will be missing or incorrect
-            # i have no idea why this is necessary and i've have tried debugging for hours
-            # to find why it's necessary, but i've came up with nothing
-            # by all means, the converters and json should be correct, but it isn't
-            # this also happens nowhere else as far as i can tell
-
-            # this line should NOT be touched unless you somehow find a solution to
-            # this, or end up modifying how _json works altogether
-            self._json["embeds"] = [e._json for e in self.embeds]
 
     async def get_channel(self) -> Channel:
         """

--- a/interactions/api/models/message.py
+++ b/interactions/api/models/message.py
@@ -11,6 +11,7 @@ from .attrs_utils import (
     DictSerializerMixin,
     convert_list,
     convert_type,
+    deepcopy_kwargs,
     define,
     field,
 )
@@ -795,6 +796,7 @@ class ReactionObject(DictSerializerMixin):
 
 
 @define()
+@deepcopy_kwargs()
 class Message(ClientSerializerMixin):
     """
     A class object representing a message.


### PR DESCRIPTION
## About

This PR attempts to properly work around a very strange bug that made some extensions break.

Basically:
- Make an embed with a footer.
- Initialize a `Message` and use the `_json` for the embed when specifying the embeds.
- Look at the `Message`'s `_json`.

In post-attrs, pre-this PR, the `_json` would be missing the footer. While this *seems* too niche of a problem to really solve (especially as the *actual* embeds were fine), this caused issues with extensions that overwrote `_Context` and subclasses of it, as many were using the pre-attrs way of handling the payload needed (using a `Message` object to ensure everything was right).

To fix this, we need to deepcopy the kwargs passed in to prevent other classes from accidentally modifying the input. Sadly, deepcopying every class's kwargs isn't possible as many will throw errors (especially anything involving HTTP or the gateway), so there's now a decorator to specify that any kwargs passed to a certain object should be deepcopied. You could also set the underlying magic variable that handles it too if desired.

This decorator was applied to embeds, which were the major pain point.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [x] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [x] New feature/enhancement (technically)
  - [x] Bugfix
