### PR TITLE
fix: various fixes for contexts

### DIFF
--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -417,7 +417,7 @@ class WebSocketClient:
             elif data["type"] == InteractionType.MESSAGE_COMPONENT:
                 _context = "ComponentContext"
 
-            data["client"] = self._http
+            data["_client"] = self._http
             context: object = getattr(__import__("interactions.client.context"), _context)
 
             return context(**data)

--- a/interactions/client/context.py
+++ b/interactions/client/context.py
@@ -349,8 +349,6 @@ class CommandContext(_Context):
                 )
                 if res["flags"] == 64:
                     log.warning("You can't edit hidden messages.")
-                    self.message = payload
-                    self.message["_client"] = self._client
                 else:
                     await self._client.edit_message(
                         int(self.channel_id), res["id"], payload=payload

--- a/interactions/client/context.py
+++ b/interactions/client/context.py
@@ -434,7 +434,7 @@ class CommandContext(_Context):
         return Message(
             **payload,
             _client=self._client,
-            author={"client": self._client, "id": None, "username": None, "discriminator": None},
+            author={"_client": self._client, "id": None, "username": None, "discriminator": None},
         )
 
     async def delete(self) -> None:

--- a/interactions/client/context.py
+++ b/interactions/client/context.py
@@ -353,7 +353,7 @@ class CommandContext(_Context):
                     await self._client.edit_message(
                         int(self.channel_id), res["id"], payload=payload
                     )
-                    self.message = msg = Message(**res, _client=self.client)
+                    self.message = msg = Message(**res, _client=self._client)
         else:
             res = await self._client.edit_interaction_response(
                 token=self.token,

--- a/interactions/client/context.pyi
+++ b/interactions/client/context.pyi
@@ -1,7 +1,7 @@
 from typing import Any, List, Optional, Union
 
 from ..api.http.client import HTTPClient
-from ..api.models.attrs_utils import DictSerializerMixin, define
+from ..api.models.attrs_utils import ClientSerializerMixin, define
 from ..api.models.channel import Channel as Channel
 from ..api.models.guild import Guild as Guild
 from ..api.models.member import Member as Member
@@ -23,7 +23,7 @@ from .models.misc import InteractionData as InteractionData
 log: Logger
 
 @define()
-class _Context(DictSerializerMixin):
+class _Context(ClientSerializerMixin):
     client: HTTPClient
     message: Optional[Message]
     author: Member

--- a/interactions/client/context.pyi
+++ b/interactions/client/context.pyi
@@ -1,3 +1,4 @@
+from logging import Logger
 from typing import Any, List, Optional, Union
 
 from ..api.http.client import HTTPClient


### PR DESCRIPTION
## About

This PR has a number fixes for the context:
- `_Context` now inherits from `ClientSerializerMixin` to have a `_client` attribute, allowing for `add_client` for the various fields to work correctly. The `_Context.client` attribute still exists for backwards compatibility, though most of the code has been changed to use `_client`.
- There were a couple of issues with `_client` vs. `client` - most of those have been fixed.
- The `message` for a context was accidentally a dict under very specific circumstance - that has been fixed.
- `context.pyi` finally has `Logger` properly typehinted.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [x] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
