### PR TITLE
fix: always make repr return a str for Member

### DIFF
--- a/interactions/api/models/member.py
+++ b/interactions/api/models/member.py
@@ -55,7 +55,7 @@ class Member(ClientSerializerMixin):
     flags: int = field()  # TODO: Investigate what this is for when documented by Discord.
 
     def __repr__(self) -> str:
-        return self.name
+        return self.name or ""
 
     @property
     def avatar(self) -> Optional[str]:


### PR DESCRIPTION
## About

This PR is a quick little fix to always make the `__repr__` in `Member` return something, even if there's no user and the member doesn't have a nickname.

In the future, this `__repr__` should be replaced by an `attrs`-generated one, but that's a feat, not a fix, anyways.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [x] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
