### PR TITLE
fix: Fix overridden implementation attribute for Choice.

### DIFF
--- a/interactions/client/models/command.py
+++ b/interactions/client/models/command.py
@@ -31,7 +31,6 @@ class Choice(DictSerializerMixin):
     :ivar Optional[Dict[Union[str, Locale], str]] name_localizations?: The dictionary of localization for the ``name`` field. This enforces the same restrictions as the ``name`` field.
     """
 
-    _json: dict = field()
     name: str = field()
     value: Union[str, int, float] = field()
     name_localizations: Optional[Dict[Union[str, Locale], str]] = field()


### PR DESCRIPTION
## About

This pull request fixes autocomplete dispatch and by extension, Choice usage for attrs by removing an overridden _json attribute.

## Checklist

- [X] I've ran `pre-commit` to format and lint the change(s) made.
- [X] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [X] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [X] Bugfix
