### PR TITLE
feat!: Implement attachment sending

### DIFF
--- a/interactions/api/models/channel.py
+++ b/interactions/api/models/channel.py
@@ -202,7 +202,7 @@ class Channel(ClientSerializerMixin):
         :type tts: Optional[bool]
         :param files?: A file or list of files to be attached to the message.
         :type files: Optional[Union[File, List[File]]]
-        :param attachments: The attachments to attach to the message. Needs to be uploaded to the CDN first
+        :param attachments?: The attachments to attach to the message. Needs to be uploaded to the CDN first
         :type attachments: Optional[List[Attachment]]
         :param embeds?: An embed, or list of embeds for the message.
         :type embeds: Optional[Union[Embed, List[Embed]]]

--- a/interactions/api/models/channel.py
+++ b/interactions/api/models/channel.py
@@ -178,6 +178,7 @@ class Channel(ClientSerializerMixin):
         content: Optional[str] = MISSING,
         *,
         tts: Optional[bool] = MISSING,
+        attachments: Optional[List["Attachment"]] = MISSING,  # noqa
         files: Optional[Union[File, List[File]]] = MISSING,
         embeds: Optional[Union["Embed", List["Embed"]]] = MISSING,  # noqa
         allowed_mentions: Optional["MessageInteraction"] = MISSING,  # noqa
@@ -201,6 +202,8 @@ class Channel(ClientSerializerMixin):
         :type tts: Optional[bool]
         :param files?: A file or list of files to be attached to the message.
         :type files: Optional[Union[File, List[File]]]
+        :param attachments: The attachments to attach to the message. Needs to be uploaded to the CDN first
+        :type attachments: Optional[List[Attachment]]
         :param embeds?: An embed, or list of embeds for the message.
         :type embeds: Optional[Union[Embed, List[Embed]]]
         :param allowed_mentions?: The message interactions/mention limits that the message can refer to.
@@ -217,8 +220,7 @@ class Channel(ClientSerializerMixin):
 
         _content: str = "" if content is MISSING else content
         _tts: bool = False if tts is MISSING else tts
-        # _file = None if file is None else file
-        # _attachments = [] if attachments else None
+        _attachments = [] if attachments is MISSING else [a._json for a in attachments]
         _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions
         if not embeds or embeds is MISSING:
             _embeds: list = []
@@ -240,6 +242,8 @@ class Channel(ClientSerializerMixin):
             _files = [files._json_payload(0)]
             files = [files]
 
+        _files.extend(_attachments)
+
         payload = dict(
             content=_content,
             tts=_tts,
@@ -255,7 +259,7 @@ class Channel(ClientSerializerMixin):
 
         # dumb hack, discord doesn't send the full author data
         author = {"id": None, "username": None, "discriminator": None}
-        author.update(res["author"])
+        author |= res["author"]
         res["author"] = author
 
         return Message(**res, _client=self._client)

--- a/interactions/api/models/channel.pyi
+++ b/interactions/api/models/channel.pyi
@@ -79,6 +79,7 @@ class Channel(ClientSerializerMixin):
         files: Optional[Union[File, List[File]]] = ...,
         embeds: Optional[Union[Embed, List[Embed]]] = ...,
         allowed_mentions: Optional[MessageInteraction] = ...,
+        attachments: Optional[List["Attachment"]] = MISSING,  # noqa
         components: Optional[
             Union[
                 "ActionRow",

--- a/interactions/api/models/member.py
+++ b/interactions/api/models/member.py
@@ -214,6 +214,7 @@ class Member(ClientSerializerMixin):
             ]
         ] = MISSING,
         tts: Optional[bool] = MISSING,
+        attachments: Optional[List["Attachment"]] = MISSING,  # noqa
         files: Optional[Union[File, List[File]]] = MISSING,
         embeds: Optional[Union["Embed", List["Embed"]]] = MISSING,  # noqa
         allowed_mentions: Optional["MessageInteraction"] = MISSING,  # noqa
@@ -227,6 +228,8 @@ class Member(ClientSerializerMixin):
         :type components: Optional[Union[ActionRow, Button, SelectMenu, List[ActionRow], List[Button], List[SelectMenu]]]
         :param tts?: Whether the message utilizes the text-to-speech Discord programme or not.
         :type tts: Optional[bool]
+        :param attachments: The attachments to attach to the message. Needs to be uploaded to the CDN first
+        :type attachments: Optional[List[Attachment]]
         :param files?: A file or list of files to be attached to the message.
         :type files: Optional[Union[File, List[File]]]
         :param embeds?: An embed, or list of embeds for the message.
@@ -243,7 +246,7 @@ class Member(ClientSerializerMixin):
 
         _content: str = "" if content is MISSING else content
         _tts: bool = False if tts is MISSING else tts
-        # _attachments = [] if attachments else None
+        _attachments = [] if attachments is MISSING else [a._json for a in attachments]
         _embeds: list = (
             []
             if not embeds or embeds is MISSING
@@ -264,7 +267,8 @@ class Member(ClientSerializerMixin):
             _files = [files._json_payload(0)]
             files = [files]
 
-        # TODO: post-v4: Add attachments into Message obj.
+        _files.extend(_attachments)
+
         payload = dict(
             content=_content,
             tts=_tts,

--- a/interactions/api/models/member.py
+++ b/interactions/api/models/member.py
@@ -228,7 +228,7 @@ class Member(ClientSerializerMixin):
         :type components: Optional[Union[ActionRow, Button, SelectMenu, List[ActionRow], List[Button], List[SelectMenu]]]
         :param tts?: Whether the message utilizes the text-to-speech Discord programme or not.
         :type tts: Optional[bool]
-        :param attachments: The attachments to attach to the message. Needs to be uploaded to the CDN first
+        :param attachments?: The attachments to attach to the message. Needs to be uploaded to the CDN first
         :type attachments: Optional[List[Attachment]]
         :param files?: A file or list of files to be attached to the message.
         :type files: Optional[Union[File, List[File]]]

--- a/interactions/api/models/member.pyi
+++ b/interactions/api/models/member.pyi
@@ -59,6 +59,7 @@ class Member(ClientSerializerMixin):
         components: Optional[
             Union[ActionRow, Button, SelectMenu, List[ActionRow], List[Button], List[SelectMenu]]
         ] = ...,
+        attachments: Optional[List["Attachment"]] = ...,  # noqa
         tts: Optional[bool] = ...,
         files: Optional[Union[File, List[File]]] = ...,
         embeds: Optional[Union[Embed, List[Embed]]] = ...,

--- a/interactions/api/models/message.py
+++ b/interactions/api/models/message.py
@@ -1031,6 +1031,7 @@ class Message(ClientSerializerMixin):
         tts: Optional[bool] = MISSING,
         embeds: Optional[Union["Embed", List["Embed"]]] = MISSING,
         files: Optional[Union[File, List[File]]] = MISSING,
+        attachments: Optional[List["Attachment"]] = MISSING,
         allowed_mentions: Optional["MessageInteraction"] = MISSING,
         components: Optional[
             Union[
@@ -1050,6 +1051,8 @@ class Message(ClientSerializerMixin):
         :type content: Optional[str]
         :param tts?: Whether the message utilizes the text-to-speech Discord programme or not.
         :type tts: Optional[bool]
+        :param attachments: The attachments to attach to the message. Needs to be uploaded to the CDN first
+        :type attachments: Optional[List[Attachment]]
         :param files?: A file or list of files to be attached to the message.
         :type files: Optional[Union[File, List[File]]]
         :param embeds?: An embed, or list of embeds for the message.
@@ -1076,7 +1079,7 @@ class Message(ClientSerializerMixin):
         )
         _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions
         _message_reference = MessageReference(message_id=int(self.id))._json
-
+        _attachments = [] if attachments is MISSING else [a._json for a in attachments]
         if not components or components is MISSING:
             _components = []
         else:
@@ -1090,7 +1093,8 @@ class Message(ClientSerializerMixin):
             _files = [files._json_payload(0)]
             files = [files]
 
-        # TODO: post-v4: Add attachments into Message obj.
+        _files.extend(_attachments)
+
         payload = dict(
             content=_content,
             tts=_tts,
@@ -1106,7 +1110,7 @@ class Message(ClientSerializerMixin):
         )
 
         author = {"id": None, "username": None, "discriminator": None}
-        author.update(res["author"])
+        author |= res["author"]
         res["author"] = author
 
         return Message(**res, _client=self._client)

--- a/interactions/api/models/message.py
+++ b/interactions/api/models/message.py
@@ -1051,7 +1051,7 @@ class Message(ClientSerializerMixin):
         :type content: Optional[str]
         :param tts?: Whether the message utilizes the text-to-speech Discord programme or not.
         :type tts: Optional[bool]
-        :param attachments: The attachments to attach to the message. Needs to be uploaded to the CDN first
+        :param attachments?: The attachments to attach to the message. Needs to be uploaded to the CDN first
         :type attachments: Optional[List[Attachment]]
         :param files?: A file or list of files to be attached to the message.
         :type files: Optional[Union[File, List[File]]]

--- a/interactions/api/models/message.pyi
+++ b/interactions/api/models/message.pyi
@@ -284,6 +284,7 @@ class Message(ClientSerializerMixin):
         files: Optional[Union[File, List[File]]] = MISSING,
         embeds: Optional[Union[Embed, List[Embed]]] = MISSING,
         allowed_mentions: Optional[MessageInteraction] = MISSING,
+        attachments: Optional[List["Attachment"]] = MISSING,  # noqa
         components: Optional[
             Union[
                 ActionRow,

--- a/interactions/api/models/webhook.py
+++ b/interactions/api/models/webhook.py
@@ -3,7 +3,6 @@ from typing import Any, List, Optional, Union
 
 from ..error import LibraryException
 from .attrs_utils import MISSING, ClientSerializerMixin, define, field
-from .message import Attachment
 from .misc import File, Image, Snowflake
 from .user import User
 
@@ -177,7 +176,7 @@ class Webhook(ClientSerializerMixin):
         tts: Optional[bool] = MISSING,
         embeds: Optional[Union["Embed", List["Embed"]]] = MISSING,  # noqa
         allowed_mentions: Any = MISSING,
-        attachments: Optional[List[Attachment]] = None,
+        attachments: Optional[List["Attachment"]] = MISSING,  # noqa
         components: Optional[
             Union[
                 "ActionRow",  # noqa

--- a/interactions/api/models/webhook.py
+++ b/interactions/api/models/webhook.py
@@ -205,7 +205,7 @@ class Webhook(ClientSerializerMixin):
         :type avatar_url: str
         :param tts: true if this is a TTS message
         :type tts: bool
-        :param attachments: The attachments to attach to the message. Needs to be uploaded to the CDN first
+        :param attachments?: The attachments to attach to the message. Needs to be uploaded to the CDN first
         :type attachments: Optional[List[Attachment]]
         :param embeds: embedded ``rich`` content
         :type embeds: Union[Embed, List[Embed]]

--- a/interactions/api/models/webhook.pyi
+++ b/interactions/api/models/webhook.pyi
@@ -53,6 +53,7 @@ class Webhook(ClientSerializerMixin):
             Union[ActionRow, Button, SelectMenu, List[ActionRow], List[Button], List[SelectMenu]]
         ] = MISSING,
         files: Optional[Union[File, List[File]]] = MISSING,
+        attachments: Optional[List["Attachment"]] = MISSING,  # noqa
         thread_id: Optional[int] = MISSING,
     ) -> Optional[Message]: ...
     async def delete(self) -> None: ...

--- a/interactions/client/context.py
+++ b/interactions/client/context.py
@@ -121,7 +121,7 @@ class _Context(ClientSerializerMixin):
         :type content: Optional[str]
         :param tts?: Whether the message utilizes the text-to-speech Discord programme or not.
         :type tts: Optional[bool]
-        :param attachments: The attachments to attach to the message. Needs to be uploaded to the CDN first
+        :param attachments?: The attachments to attach to the message. Needs to be uploaded to the CDN first
         :type attachments: Optional[List[Attachment]]
         :param embeds?: An embed, or list of embeds for the message.
         :type embeds: Optional[Union[Embed, List[Embed]]]

--- a/interactions/client/context.pyi
+++ b/interactions/client/context.pyi
@@ -56,6 +56,7 @@ class _Context(ClientSerializerMixin):
         components: Optional[
             Union[ActionRow, Button, SelectMenu, List[ActionRow], List[Button], List[SelectMenu]]
         ] = ...,
+        attachments: Optional[List["Attachment"]] = ...,  # noqa
         ephemeral: Optional[bool] = ...
     ) -> dict: ...
     async def edit(
@@ -66,6 +67,7 @@ class _Context(ClientSerializerMixin):
         embeds: Optional[Union[Embed, List[Embed]]] = ...,
         allowed_mentions: Optional[MessageInteraction] = ...,
         message_reference: Optional[MessageReference] = ...,
+        attachments: Optional[List["Attachment"]] = MISSING,  # noqa
         components: Optional[
             Union[ActionRow, Button, SelectMenu, List[ActionRow], List[Button], List[SelectMenu]]
         ] = ...


### PR DESCRIPTION
## About

this PR gives the ability to append already uploaded images to a message without reuploading it

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [ ] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [ ] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [x] New feature/enhancement
  - [ ] Bugfix
