### PR TITLE
REVERT: revert a change that crashes unstable

### DIFF
--- a/interactions/api/models/channel.py
+++ b/interactions/api/models/channel.py
@@ -259,7 +259,7 @@ class Channel(ClientSerializerMixin):
 
         # dumb hack, discord doesn't send the full author data
         author = {"id": None, "username": None, "discriminator": None}
-        author |= res["author"]
+        author.update(res["author"])
         res["author"] = author
 
         return Message(**res, _client=self._client)

--- a/interactions/api/models/message.py
+++ b/interactions/api/models/message.py
@@ -1110,7 +1110,7 @@ class Message(ClientSerializerMixin):
         )
 
         author = {"id": None, "username": None, "discriminator": None}
-        author |= res["author"]
+        author.update(res["author"])
         res["author"] = author
 
         return Message(**res, _client=self._client)


### PR DESCRIPTION
## About

This change causes a crash. see [this](https://ptb.discord.com/channels/789032594456576001/988145524429430844/988147764129038376)

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [ ] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [ ] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
