### PR TITLE
fix: message from ComponentContext.edit has missing attributes

### DIFF
--- a/interactions/client/context.py
+++ b/interactions/client/context.py
@@ -538,6 +538,7 @@ class ComponentContext(_Context):
             for attr in payload.__slots__:
                 if getattr(self.message, attr, None) and not getattr(payload, attr, None):
                     setattr(payload, attr, getattr(self.message, attr))
+                    payload._json[attr] = self.message._json[attr]
             self.message = payload
             self.responded = True
         elif self.callback != InteractionCallbackType.DEFERRED_UPDATE_MESSAGE:

--- a/interactions/client/context.py
+++ b/interactions/client/context.py
@@ -534,7 +534,11 @@ class ComponentContext(_Context):
                 token=self.token,
                 application_id=int(self.id),
             )
-            # self.message = payload
+            payload = Message(**payload, _client=self._client)
+            for attr in payload.__slots__:
+                if getattr(self.message, attr, None) and not getattr(payload, attr, None):
+                    setattr(payload, attr, getattr(self.message, attr))
+            self.message = payload
             self.responded = True
         elif self.callback != InteractionCallbackType.DEFERRED_UPDATE_MESSAGE:
             res = await self._client._post_followup(


### PR DESCRIPTION
## About

This pull request fixes missing attributes in `ComponentContext.message` and message returned from `ComponentContext.edit` (both are the same message).

Missing attributes:
`id` is missing from payload
`channel_id` is missing from payload
`author` is missing from payload
`timestamp` is missing from payload
`edited_timestamp` is missing from payload
`webhook_id` is missing from payload
`type` is missing from payload
`application_id` is missing from payload
`interaction` is missing from payload

This PR successfully adds them back.
Related to #870, it is actually missing in `ComponentContext.edit`.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [x] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent): #870 
- [ ] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
