### PR TITLE
fix!: use a diff name for deepcopy to avoid builtin

### DIFF
--- a/interactions/api/models/attrs_utils.py
+++ b/interactions/api/models/attrs_utils.py
@@ -19,14 +19,14 @@ class DictSerializerMixin:
     _extras: dict = attrs.field(init=False, repr=False)
     """A dict containing values that were not serialized from Discord."""
 
-    __deepcopy__ = False
-    """Should the kwargs be deepcopied or not?"""
+    __ipy_deepcopy__ = False
+    """Should the kwargs be deepcopied for interactions.py or not?"""
 
     def __init__(self, kwargs_dict: dict = None, /, **other_kwargs):
         kwargs = kwargs_dict or other_kwargs
         client = kwargs.pop("_client", None)
 
-        if self.__deepcopy__:
+        if self.__ipy_deepcopy__:
             kwargs = deepcopy(kwargs)
 
         self._json = kwargs.copy()
@@ -184,11 +184,11 @@ def deepcopy_kwargs(cls: Optional[type] = None):
     """
 
     def decorator(cls: type):
-        cls.__deepcopy__ = True  # type: ignore
+        cls.__ipy_deepcopy__ = True  # type: ignore
         return cls
 
     if cls is not None:
-        cls.__deepcopy__ = True  # type: ignore
+        cls.__ipy_deepcopy__ = True  # type: ignore
         return cls
 
     return decorator

--- a/interactions/api/models/attrs_utils.py
+++ b/interactions/api/models/attrs_utils.py
@@ -19,14 +19,14 @@ class DictSerializerMixin:
     _extras: dict = attrs.field(init=False, repr=False)
     """A dict containing values that were not serialized from Discord."""
 
-    __ipy_deepcopy__ = False
-    """Should the kwargs be deepcopied for interactions.py or not?"""
+    __deepcopy_kwargs__ = False
+    """Should the kwargs be deepcopied or not?"""
 
     def __init__(self, kwargs_dict: dict = None, /, **other_kwargs):
         kwargs = kwargs_dict or other_kwargs
         client = kwargs.pop("_client", None)
 
-        if self.__ipy_deepcopy__:
+        if self.__deepcopy_kwargs__:
             kwargs = deepcopy(kwargs)
 
         self._json = kwargs.copy()
@@ -184,11 +184,11 @@ def deepcopy_kwargs(cls: Optional[type] = None):
     """
 
     def decorator(cls: type):
-        cls.__ipy_deepcopy__ = True  # type: ignore
+        cls.__deepcopy_kwargs__ = True  # type: ignore
         return cls
 
     if cls is not None:
-        cls.__ipy_deepcopy__ = True  # type: ignore
+        cls.__deepcopy_kwargs__ = True  # type: ignore
         return cls
 
     return decorator

--- a/interactions/api/models/attrs_utils.pyi
+++ b/interactions/api/models/attrs_utils.pyi
@@ -18,8 +18,8 @@ class DictSerializerMixin:
     _json: dict = attrs.field(init=False)
     _extras: dict = attrs.field(init=False)
     """A dict containing values that were not serialized from Discord."""
-    __ipy_deepcopy__: bool = attrs.field(init=False)
-    """Should the kwargs be deepcopied for interactions.py or not?"""
+    __deepcopy_kwargs__: bool = attrs.field(init=False)
+    """Should the kwargs be deepcopied or not?"""
     def __init__(self, kwargs_dict: dict = None, /, **other_kwargs): ...
 
 @attrs.define(eq=False, init=False, on_setattr=attrs.setters.NO_OP)

--- a/interactions/api/models/attrs_utils.pyi
+++ b/interactions/api/models/attrs_utils.pyi
@@ -18,8 +18,8 @@ class DictSerializerMixin:
     _json: dict = attrs.field(init=False)
     _extras: dict = attrs.field(init=False)
     """A dict containing values that were not serialized from Discord."""
-    __deepcopy__: bool = attrs.field(init=False)
-    """Should the kwargs be deepcopied or not?"""
+    __ipy_deepcopy__: bool = attrs.field(init=False)
+    """Should the kwargs be deepcopied for interactions.py or not?"""
     def __init__(self, kwargs_dict: dict = None, /, **other_kwargs): ...
 
 @attrs.define(eq=False, init=False, on_setattr=attrs.setters.NO_OP)


### PR DESCRIPTION
## About

This pull request fixes issues with using `deepcopy_kwargs` with objects that have lists or dicts of `DictSerializerMixin` by renaming `__deepcopy__` to `__deepcopy_kwargs__`. This avoids the *actual* `__deepcopy__` that objects usually had... and that I totally forgot normally had 😅.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [x] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [x] Breaking change (by technicality. Users should almost never actually touch this value, but there's also nothing stopping them.)
  - [ ] New feature/enhancement
  - [x] Bugfix
