### PR TITLE
docs: Repoint old rtd links to new domain.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ interactions.py
 
 .. image:: https://img.shields.io/pypi/v/discord-py-interactions.svg
 
-.. image:: https://readthedocs.org/projects/discord-interactions/badge/?version=latest
+.. image:: https://readthedocs.org/projects/interactionspy/badge/?version=latest
 
 .. image:: https://discord.com/api/guilds/789032594456576001/embed.png
 
@@ -87,7 +87,7 @@ I think I'm all ready!
 ^^^^^^^^^^^^^^^^^^^^^^
 Feel free to begin making `Pull Requests`_ and `Issues`_ on our GitHub!
 
-.. _quickstart guide: https://discord-interactions.rtfd.io/en/latest/quickstart.html
+.. _quickstart guide: https://interactionspy.rtfd.io/en/latest/quickstart.html
 .. _contribution requirements: https://github.com/interactions-py/library/blob/stable/CONTRIBUTING.rst
 .. _MIT License: https://github.com/goverfl0w/interactions-py/library/blob/stable/LICENSE
 .. _Pull Requests: https://github.com/interactions-py/library/pulls

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -448,6 +448,6 @@ Here's an example of a guild-only command:
 Likewise, setting ``dm_permission`` to ``True`` makes it usable in DMs. Just to note that this argument's mainly used for
 global commands. Guild commands with this argument will have no effect.
 
-.. _Client: https://discord-interactions.rtfd.io/en/stable/client.html
-.. _find these component types: https://discord-interactions.readthedocs.io/en/stable/models.component.html
+.. _Client: https://interactionspy.rtfd.io/en/stable/client.html
+.. _find these component types: https://interactionspy.readthedocs.io/en/stable/models.component.html
 .. _discord applications page: https://discord.com/developers/applications


### PR DESCRIPTION
## About

This pull request switches domain references from the old RTD docs to the new one (The new one's updated more, but the old one will still persist for the foreseeable future).

## Checklist

- [X] I've ran `pre-commit` to format and lint the change(s) made.
- [X] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [X] I've made this pull request for/as: (check all that apply)
  - [X] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [ ] Bugfix
