### PR TITLE
refactor: Remove py2 style classes

### DIFF
--- a/interactions/api/cache.py
+++ b/interactions/api/cache.py
@@ -8,7 +8,7 @@ __all__ = (
 )
 
 
-class Item(object):
+class Item:
     """
     A class representing the defined item in a stored dataset.
 

--- a/interactions/api/cache.pyi
+++ b/interactions/api/cache.pyi
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 from typing import Any, List, Optional, Type
 
-class Item(object):
+class Item:
     id: str
     value: Any
     type: Type

--- a/interactions/api/models/misc.py
+++ b/interactions/api/models/misc.py
@@ -67,7 +67,7 @@ class ClientStatus(DictSerializerMixin):
     web: Optional[str] = field(default=None)
 
 
-class Snowflake(object):
+class Snowflake:
     """
     The Snowflake object.
 
@@ -225,7 +225,7 @@ class AutoModTriggerMetadata(DictSerializerMixin):
     presets: Optional[List[str]] = field(default=None)
 
 
-class Color(object):
+class Color:
     """
     An object representing Discord branding colors.
 
@@ -276,7 +276,7 @@ class Color(object):
         return 0x000000
 
 
-class File(object):
+class File:
     """
     A File object to be sent as an attachment along with a message.
 
@@ -309,7 +309,7 @@ class File(object):
         return {"id": id, "description": self._description, "filename": self._filename}
 
 
-class Image(object):
+class Image:
     """
     This class object allows you to upload Images to the Discord API.
 


### PR DESCRIPTION
## About

This pull request removes all the Python 2 style class definitions. In short, every `ClassName(object):...` has been turned into `ClassName:...`

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [x] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [x] New feature/enhancement
  - [ ] Bugfix
