### PR TITLE
feat: Add support for sending stickers

### DIFF
--- a/interactions/api/http/message.py
+++ b/interactions/api/http/message.py
@@ -27,9 +27,9 @@ class MessageRequest:
         tts: bool = False,
         embeds: Optional[List[Embed]] = None,
         nonce: Union[int, str] = None,
-        allowed_mentions = None,  # don't know type
+        allowed_mentions=None,  # don't know type
         message_reference: Optional[Message] = None,
-        stickers: Optional[List[Sticker]] = None
+        stickers: Optional[List[Sticker]] = None,
     ) -> dict:
         """
         A higher level implementation of :meth:`create_message()` that handles the payload dict internally.

--- a/interactions/api/http/message.py
+++ b/interactions/api/http/message.py
@@ -56,7 +56,7 @@ class MessageRequest:
             payload["message_reference"] = message_reference
 
         if stickers:
-            payload["sticker_ids"] = [sticker.id for sticker in stickers]
+            payload["sticker_ids"] = [str(sticker.id) for sticker in stickers]
 
         # TODO: post-v4. add attachments to payload.
 

--- a/interactions/api/http/message.py
+++ b/interactions/api/http/message.py
@@ -4,7 +4,7 @@ from aiohttp import MultipartWriter
 
 from ...api.cache import Cache, Item
 from ..models.attrs_utils import MISSING
-from ..models.message import Embed, Message
+from ..models.message import Embed, Message, Sticker
 from ..models.misc import File, Snowflake
 from .request import _Request
 from .route import Route
@@ -27,8 +27,9 @@ class MessageRequest:
         tts: bool = False,
         embeds: Optional[List[Embed]] = None,
         nonce: Union[int, str] = None,
-        allowed_mentions=None,  # don't know type
+        allowed_mentions = None,  # don't know type
         message_reference: Optional[Message] = None,
+        stickers: Optional[List[Sticker]] = None
     ) -> dict:
         """
         A higher level implementation of :meth:`create_message()` that handles the payload dict internally.
@@ -53,6 +54,9 @@ class MessageRequest:
 
         if message_reference:
             payload["message_reference"] = message_reference
+
+        if stickers:
+            payload["sticker_ids"] = [sticker.id for sticker in stickers]
 
         # TODO: post-v4. add attachments to payload.
 

--- a/interactions/api/http/message.pyi
+++ b/interactions/api/http/message.pyi
@@ -1,7 +1,7 @@
 from typing import List, Optional, Union
 
 from ...api.cache import Cache
-from ..models.message import Embed, Message
+from ..models.message import Embed, Message, Sticker
 from ..models.attrs_utils import MISSING
 from ..models.misc import File, Snowflake
 from .request import _Request
@@ -21,6 +21,7 @@ class MessageRequest:
         nonce: Union[int, str] = None,
         allowed_mentions=None,  # don't know type
         message_reference: Optional[Message] = None,
+        stickers: Optional[List[Sticker]] = None,
     ) -> dict: ...
     async def create_message(
         self, payload: dict, channel_id: int, files: Optional[List[File]]

--- a/interactions/api/models/channel.py
+++ b/interactions/api/models/channel.py
@@ -182,7 +182,7 @@ class Channel(ClientSerializerMixin):
         files: Optional[Union[File, List[File]]] = MISSING,
         embeds: Optional[Union["Embed", List["Embed"]]] = MISSING,  # noqa
         allowed_mentions: Optional["MessageInteraction"] = MISSING,  # noqa
-        stickers: Optional[List["Sticker"]] = MISSING,
+        stickers: Optional[List["Sticker"]] = MISSING,  # noqa
         components: Optional[
             Union[
                 "ActionRow",  # noqa
@@ -219,7 +219,7 @@ class Channel(ClientSerializerMixin):
         if not self._client:
             raise LibraryException(code=13)
         from ...client.models.component import _build_components
-        from .message import Message, Sticker
+        from .message import Message
 
         _content: str = "" if content is MISSING else content
         _tts: bool = False if tts is MISSING else tts

--- a/interactions/api/models/channel.py
+++ b/interactions/api/models/channel.py
@@ -182,6 +182,7 @@ class Channel(ClientSerializerMixin):
         files: Optional[Union[File, List[File]]] = MISSING,
         embeds: Optional[Union["Embed", List["Embed"]]] = MISSING,  # noqa
         allowed_mentions: Optional["MessageInteraction"] = MISSING,  # noqa
+        stickers: Optional[List["Sticker"]] = MISSING,
         components: Optional[
             Union[
                 "ActionRow",  # noqa
@@ -208,6 +209,8 @@ class Channel(ClientSerializerMixin):
         :type embeds: Optional[Union[Embed, List[Embed]]]
         :param allowed_mentions?: The message interactions/mention limits that the message can refer to.
         :type allowed_mentions: Optional[MessageInteraction]
+        :param stickers?: A list of stickers to send with your message. You can send up to 3 stickers per message.
+        :type stickers: Optional[List[Sticker]]
         :param components?: A component, or list of components for the message.
         :type components: Optional[Union[ActionRow, Button, SelectMenu, List[Actionrow], List[Button], List[SelectMenu]]]
         :return: The sent message as an object.
@@ -216,12 +219,13 @@ class Channel(ClientSerializerMixin):
         if not self._client:
             raise LibraryException(code=13)
         from ...client.models.component import _build_components
-        from .message import Message
+        from .message import Message, Sticker
 
         _content: str = "" if content is MISSING else content
         _tts: bool = False if tts is MISSING else tts
         _attachments = [] if attachments is MISSING else [a._json for a in attachments]
         _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions
+        _sticker_ids: list = [] if stickers is MISSING else [str(sticker.id) for sticker in stickers]
         if not embeds or embeds is MISSING:
             _embeds: list = []
         elif isinstance(embeds, list):
@@ -251,6 +255,7 @@ class Channel(ClientSerializerMixin):
             embeds=_embeds,
             allowed_mentions=_allowed_mentions,
             components=_components,
+            sticker_ids=_sticker_ids
         )
 
         res = await self._client.create_message(

--- a/interactions/api/models/channel.py
+++ b/interactions/api/models/channel.py
@@ -225,7 +225,9 @@ class Channel(ClientSerializerMixin):
         _tts: bool = False if tts is MISSING else tts
         _attachments = [] if attachments is MISSING else [a._json for a in attachments]
         _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions
-        _sticker_ids: list = [] if stickers is MISSING else [str(sticker.id) for sticker in stickers]
+        _sticker_ids: list = (
+            [] if stickers is MISSING else [str(sticker.id) for sticker in stickers]
+        )
         if not embeds or embeds is MISSING:
             _embeds: list = []
         elif isinstance(embeds, list):
@@ -255,7 +257,7 @@ class Channel(ClientSerializerMixin):
             embeds=_embeds,
             allowed_mentions=_allowed_mentions,
             components=_components,
-            sticker_ids=_sticker_ids
+            sticker_ids=_sticker_ids,
         )
 
         res = await self._client.create_message(

--- a/interactions/api/models/channel.pyi
+++ b/interactions/api/models/channel.pyi
@@ -5,8 +5,9 @@ from typing import Any, Callable, List, Optional, Union
 from ... import ActionRow, Button, SelectMenu
 from .attrs_utils import ClientSerializerMixin, define
 from .guild import Invite, InviteTargetType
-from .message import Embed, Message, MessageInteraction
+from .message import Embed, Message, MessageInteraction, Sticker
 from .misc import File, Overwrite, Snowflake
+from .attrs_utils import MISSING
 from .user import User
 from .webhook import Webhook
 
@@ -80,6 +81,7 @@ class Channel(ClientSerializerMixin):
         embeds: Optional[Union[Embed, List[Embed]]] = ...,
         allowed_mentions: Optional[MessageInteraction] = ...,
         attachments: Optional[List["Attachment"]] = MISSING,  # noqa
+        stickers: Optional[List["Sticker"]] = MISSING,
         components: Optional[
             Union[
                 "ActionRow",

--- a/interactions/api/models/gw.py
+++ b/interactions/api/models/gw.py
@@ -394,7 +394,6 @@ class GuildMember(ClientSerializerMixin):
         files: Optional[Union[File, List[File]]] = MISSING,
         embeds: Optional[Union[Embed, List[Embed]]] = MISSING,
         allowed_mentions: Optional[MessageInteraction] = MISSING,
-        stickers: Optional[List[Sticker]] = MISSING,
     ) -> Message:
         """
         Sends a DM to the member.
@@ -411,8 +410,6 @@ class GuildMember(ClientSerializerMixin):
         :type embeds: Optional[Union[Embed, List[Embed]]]
         :param allowed_mentions?: The message interactions/mention limits that the message can refer to.
         :type allowed_mentions: Optional[MessageInteraction]
-        :param stickers?: A list of stickers to send with your message. You can send up to 3 stickers per message.
-        :type stickers: Optional[List[Sticker]]
         :return: The sent message as an object.
         :rtype: Message
         """
@@ -429,9 +426,6 @@ class GuildMember(ClientSerializerMixin):
             else ([embed._json for embed in embeds] if isinstance(embeds, list) else [embeds._json])
         )
         _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions
-        _sticker_ids: list = (
-            [] if stickers is MISSING else [str(sticker.id) for sticker in stickers]
-        )
         if not components or components is MISSING:
             _components = []
         else:
@@ -452,7 +446,6 @@ class GuildMember(ClientSerializerMixin):
             embeds=_embeds,
             components=_components,
             allowed_mentions=_allowed_mentions,
-            sticker_ids=_sticker_ids,
         )
 
         channel = Channel(

--- a/interactions/api/models/gw.py
+++ b/interactions/api/models/gw.py
@@ -394,6 +394,7 @@ class GuildMember(ClientSerializerMixin):
         files: Optional[Union[File, List[File]]] = MISSING,
         embeds: Optional[Union[Embed, List[Embed]]] = MISSING,
         allowed_mentions: Optional[MessageInteraction] = MISSING,
+        stickers: Optional[List[Sticker]] = MISSING,
     ) -> Message:
         """
         Sends a DM to the member.
@@ -410,6 +411,8 @@ class GuildMember(ClientSerializerMixin):
         :type embeds: Optional[Union[Embed, List[Embed]]]
         :param allowed_mentions?: The message interactions/mention limits that the message can refer to.
         :type allowed_mentions: Optional[MessageInteraction]
+        :param stickers?: A list of stickers to send with your message. You can send up to 3 stickers per message.
+        :type stickers: Optional[List[Sticker]]
         :return: The sent message as an object.
         :rtype: Message
         """
@@ -426,7 +429,9 @@ class GuildMember(ClientSerializerMixin):
             else ([embed._json for embed in embeds] if isinstance(embeds, list) else [embeds._json])
         )
         _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions
-
+        _sticker_ids: list = (
+            [] if stickers is MISSING else [str(sticker.id) for sticker in stickers]
+        )
         if not components or components is MISSING:
             _components = []
         else:
@@ -447,6 +452,7 @@ class GuildMember(ClientSerializerMixin):
             embeds=_embeds,
             components=_components,
             allowed_mentions=_allowed_mentions,
+            sticker_ids=_sticker_ids,
         )
 
         channel = Channel(

--- a/interactions/api/models/gw.pyi
+++ b/interactions/api/models/gw.pyi
@@ -112,7 +112,8 @@ class GuildMember(ClientSerializerMixin):
         tts: Optional[bool] = ...,
         files: Optional[Union[File, List[File]]] = ...,
         embeds: Optional[Union[Embed, List[Embed]]] = ...,
-        allowed_mentions: Optional[MessageInteraction] = ...
+        allowed_mentions: Optional[MessageInteraction] = ...,
+        stickers: Optional[List[Sticker]] = ...,
     ) -> Message: ...
     async def modify(
         self,

--- a/interactions/api/models/gw.pyi
+++ b/interactions/api/models/gw.pyi
@@ -113,7 +113,6 @@ class GuildMember(ClientSerializerMixin):
         files: Optional[Union[File, List[File]]] = ...,
         embeds: Optional[Union[Embed, List[Embed]]] = ...,
         allowed_mentions: Optional[MessageInteraction] = ...,
-        stickers: Optional[List[Sticker]] = ...,
     ) -> Message: ...
     async def modify(
         self,

--- a/interactions/api/models/member.py
+++ b/interactions/api/models/member.py
@@ -218,7 +218,6 @@ class Member(ClientSerializerMixin):
         files: Optional[Union[File, List[File]]] = MISSING,
         embeds: Optional[Union["Embed", List["Embed"]]] = MISSING,  # noqa
         allowed_mentions: Optional["MessageInteraction"] = MISSING,  # noqa
-        stickers: Optional[List["Sticker"]] = MISSING,  # noqa
     ) -> "Message":  # noqa
         """
         Sends a DM to the member.
@@ -237,8 +236,6 @@ class Member(ClientSerializerMixin):
         :type embeds: Optional[Union[Embed, List[Embed]]]
         :param allowed_mentions?: The message interactions/mention limits that the message can refer to.
         :type allowed_mentions: Optional[MessageInteraction]
-        :param stickers: A list of stickers to send with your message. You can send up to 3 stickers per message.
-        :type stickers: Optional[List[Sticker]]
         :return: The sent message as an object.
         :rtype: Message
         """
@@ -256,9 +253,6 @@ class Member(ClientSerializerMixin):
             else ([embed._json for embed in embeds] if isinstance(embeds, list) else [embeds._json])
         )
         _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions
-        _sticker_ids: list = (
-            [] if stickers is MISSING else [str(sticker.id) for sticker in stickers]
-        )
         if not components or components is MISSING:
             _components = []
         else:
@@ -281,9 +275,7 @@ class Member(ClientSerializerMixin):
             embeds=_embeds,
             components=_components,
             allowed_mentions=_allowed_mentions,
-            sticker_ids=_sticker_ids,
         )
-
         channel = Channel(**await self._client.create_dm(recipient_id=int(self.user.id)))
         res = await self._client.create_message(
             channel_id=int(channel.id), payload=payload, files=files

--- a/interactions/api/models/member.py
+++ b/interactions/api/models/member.py
@@ -218,7 +218,7 @@ class Member(ClientSerializerMixin):
         files: Optional[Union[File, List[File]]] = MISSING,
         embeds: Optional[Union["Embed", List["Embed"]]] = MISSING,  # noqa
         allowed_mentions: Optional["MessageInteraction"] = MISSING,  # noqa
-        stickers: Optional[List[Sticker]] = MISSING,  # noqa
+        stickers: Optional[List["Sticker"]] = MISSING,  # noqa
     ) -> "Message":  # noqa
         """
         Sends a DM to the member.

--- a/interactions/api/models/member.py
+++ b/interactions/api/models/member.py
@@ -218,6 +218,7 @@ class Member(ClientSerializerMixin):
         files: Optional[Union[File, List[File]]] = MISSING,
         embeds: Optional[Union["Embed", List["Embed"]]] = MISSING,  # noqa
         allowed_mentions: Optional["MessageInteraction"] = MISSING,  # noqa
+        stickers: Optional[List[Sticker]] = MISSING,  # noqa
     ) -> "Message":  # noqa
         """
         Sends a DM to the member.
@@ -236,6 +237,8 @@ class Member(ClientSerializerMixin):
         :type embeds: Optional[Union[Embed, List[Embed]]]
         :param allowed_mentions?: The message interactions/mention limits that the message can refer to.
         :type allowed_mentions: Optional[MessageInteraction]
+        :param stickers: A list of stickers to send with your message. You can send up to 3 stickers per message.
+        :type stickers: Optional[List[Sticker]]
         :return: The sent message as an object.
         :rtype: Message
         """
@@ -253,7 +256,9 @@ class Member(ClientSerializerMixin):
             else ([embed._json for embed in embeds] if isinstance(embeds, list) else [embeds._json])
         )
         _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions
-
+        _sticker_ids: list = (
+            [] if stickers is MISSING else [str(sticker.id) for sticker in stickers]
+        )
         if not components or components is MISSING:
             _components = []
         else:
@@ -276,6 +281,7 @@ class Member(ClientSerializerMixin):
             embeds=_embeds,
             components=_components,
             allowed_mentions=_allowed_mentions,
+            sticker_ids=_sticker_ids,
         )
 
         channel = Channel(**await self._client.create_dm(recipient_id=int(self.user.id)))

--- a/interactions/api/models/member.pyi
+++ b/interactions/api/models/member.pyi
@@ -4,7 +4,7 @@ from typing import Any, List, Optional, Union
 from ... import ActionRow, Button, SelectMenu
 from .attrs_utils import ClientSerializerMixin, define
 from .flags import Permissions as Permissions
-from .message import Embed, Message, MessageInteraction, Sticker
+from .message import Embed, Message, MessageInteraction
 from .misc import File, Snowflake
 from .role import Role as Role
 from .user import User as User
@@ -64,7 +64,6 @@ class Member(ClientSerializerMixin):
         files: Optional[Union[File, List[File]]] = ...,
         embeds: Optional[Union[Embed, List[Embed]]] = ...,
         allowed_mentions: Optional[MessageInteraction] = ...,
-        stickers: Optional[List[Sticker]] = ...,
     ) -> Message: ...
     async def modify(
         self,

--- a/interactions/api/models/member.pyi
+++ b/interactions/api/models/member.pyi
@@ -4,7 +4,7 @@ from typing import Any, List, Optional, Union
 from ... import ActionRow, Button, SelectMenu
 from .attrs_utils import ClientSerializerMixin, define
 from .flags import Permissions as Permissions
-from .message import Embed, Message, MessageInteraction
+from .message import Embed, Message, MessageInteraction, Sticker
 from .misc import File, Snowflake
 from .role import Role as Role
 from .user import User as User
@@ -63,7 +63,8 @@ class Member(ClientSerializerMixin):
         tts: Optional[bool] = ...,
         files: Optional[Union[File, List[File]]] = ...,
         embeds: Optional[Union[Embed, List[Embed]]] = ...,
-        allowed_mentions: Optional[MessageInteraction] = ...
+        allowed_mentions: Optional[MessageInteraction] = ...,
+        stickers: Optional[List[Sticker]] = ...,
     ) -> Message: ...
     async def modify(
         self,

--- a/interactions/api/models/message.py
+++ b/interactions/api/models/message.py
@@ -1033,6 +1033,7 @@ class Message(ClientSerializerMixin, IDMixin):
         files: Optional[Union[File, List[File]]] = MISSING,
         attachments: Optional[List["Attachment"]] = MISSING,
         allowed_mentions: Optional["MessageInteraction"] = MISSING,
+        stickers: Optional[List["Sticker"]] = MISSING,
         components: Optional[
             Union[
                 "ActionRow",  # noqa
@@ -1061,6 +1062,8 @@ class Message(ClientSerializerMixin, IDMixin):
         :type allowed_mentions: Optional[MessageInteraction]
         :param components?: A component, or list of components for the message.
         :type components: Optional[Union[ActionRow, Button, SelectMenu, List[ActionRow], List[Button], List[SelectMenu]]]
+        :param stickers?: A list of stickers to send with your message. You can send up to 3 stickers per message.
+        :type stickers: Optional[List[Sticker]]
         :return: The sent message as an object.
         :rtype: Message
         """
@@ -1094,6 +1097,9 @@ class Message(ClientSerializerMixin, IDMixin):
             files = [files]
 
         _files.extend(_attachments)
+        _sticker_ids: list = (
+            [] if stickers is MISSING else [str(sticker.id) for sticker in stickers]
+        )
 
         payload = dict(
             content=_content,
@@ -1103,6 +1109,7 @@ class Message(ClientSerializerMixin, IDMixin):
             message_reference=_message_reference,
             allowed_mentions=_allowed_mentions,
             components=_components,
+            sticker_ids=_sticker_ids,
         )
 
         res = await self._client.create_message(

--- a/interactions/api/models/message.pyi
+++ b/interactions/api/models/message.pyi
@@ -294,6 +294,7 @@ class Message(ClientSerializerMixin, IDMixin):
         embeds: Optional[Union[Embed, List[Embed]]] = MISSING,
         allowed_mentions: Optional[MessageInteraction] = MISSING,
         attachments: Optional[List["Attachment"]] = MISSING,  # noqa
+        stickers: Optional[List["Sticker"]] = MISSING,
         components: Optional[
             Union[
                 ActionRow,


### PR DESCRIPTION
## About

This pull request makes it possible for users to send stickers to a channel.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [x] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [x] I've made this pull request for/as: (check all that apply)
  - [x] Documentation
  - [ ] Breaking change
  - [x] New feature/enhancement
  - [ ] Bugfix
