### PR TITLE
REVERT: Remove Restful API ext

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -162,7 +162,6 @@ Those are (at the moment):
 - `enhanced`_ which enhances the DX in general
 - A `paginator`_ for paginating embeds on messages using components
 - `persistence`_ - for storing data inside your custom IDs (as an alternative to ``wait_for``)
-- `rest`_ for connecting to a ``RESTful API``
 - And a `boilerplate`_
 
 Below are a few unofficial exts (for the time being) which implement some functionality similar to what d.py had:

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -319,4 +319,3 @@ Please join our `Discord Server`_ for any further support regarding our library 
 .. _Molter: https://github.com/interactions-py/molter
 .. _boilerplate: https://github.com/interactions-py/boilerplate
 .. _get: https://github.com/EdVraz/interactions-get
-.. _rest: https://github.com/V3ntus/interactions-rest


### PR DESCRIPTION
## About

This PR removes an ext added to the faq before the... *internal thing*... happened.

## Checklist

- [ ] I've ran `pre-commit` to format and lint the change(s) made.
- [ ] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [ ] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [ ] Bugfix
