### PR TITLE
fix: properly typehint deepcopy_kwargs

### DIFF
--- a/interactions/api/models/attrs_utils.pyi
+++ b/interactions/api/models/attrs_utils.pyi
@@ -1,5 +1,5 @@
 from functools import wraps
-from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union, Type
+from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union, Type, overload
 
 import attrs
 
@@ -66,7 +66,15 @@ def convert_dict(
 ) -> Callable[[Dict[Any, Any]], Dict[_T, _P]]:
     """A helper function to convert the keys and values of a dictionary with the specified converters"""
 
-def deepcopy_kwargs(cls: Optional[Type[_T]] = None) -> Callable[[Any], _T]:
+@overload
+def deepcopy_kwargs() -> Callable[[_T], _T]:
+    ...
+
+@overload
+def deepcopy_kwargs(cls: _T) -> _T:
+    ...
+
+def deepcopy_kwargs(cls: Optional[_T] = None) -> Union[Callable[[_T], _T], _T]:
     """
     A decorator to make the DictSerializerMixin deepcopy the kwargs before processing them.
     This can help avoid weird bugs with some objects, though will error out in others.


### PR DESCRIPTION
## About

This pull request fixes the type hints of objects that use `deepcopy_kwargs`. It seems like the type hints were incorrect, so with a bit of overloading, the two actual ways `deepcopy_kwargs` can be used have been represented.

This fixes issues with `Embed`'s typehintings.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [x] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
