### PR TITLE
docs: Fix description in ``set_rate_limit_per_user``

### DIFF
--- a/interactions/api/models/channel.py
+++ b/interactions/api/models/channel.py
@@ -487,7 +487,7 @@ class Channel(ClientSerializerMixin, IDMixin):
         reason: Optional[str] = None,
     ) -> "Channel":
         """
-        Sets the position of the channel.
+        Sets the amount of seconds a user has to wait before sending another message.
 
         :param rate_limit_per_user: The new rate_limit_per_user of the channel (0-21600)
         :type rate_limit_per_user: int


### PR DESCRIPTION
## About

This pull request is about fixing the typo of the function ``set_rate_limit_per_user`` inside ``Channel``.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [x] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent): https://github.com/interactions-py/library/issues/906
- [ ] I've made this pull request for/as: (check all that apply)
  - [x] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [ ] Bugfix
