### PR TITLE
refactor: Refactor context edit/send/defer.

### DIFF
--- a/interactions/client/context.py
+++ b/interactions/client/context.py
@@ -363,6 +363,9 @@ class CommandContext(_Context):
                     )
                 except LibraryException as e:
                     log.warning(f"You can't edit hidden messages." f"({e.message}).")
+                    if e.code not in {10015, 10018}:
+                        # if its not ephemeral or some other thing.
+                        raise e
                 else:
                     self.message = msg = Message(**res, _client=self._client)
             else:
@@ -377,6 +380,9 @@ class CommandContext(_Context):
                     )
                 except LibraryException as e:
                     log.warning(f"You can't edit hidden messages." f"({e.message}).")
+                    if e.code not in {10015, 10018}:
+                        # if its not ephemeral or some other thing.
+                        raise e
                 else:
                     self.message = msg = Message(**res, _client=self._client)
         else:
@@ -386,6 +392,9 @@ class CommandContext(_Context):
                 )
             except LibraryException as e:
                 log.warning(f"You can't edit hidden messages." f"({e.message}).")
+                if e.code not in {10015, 10018}:
+                    # if its not ephemeral or some other thing.
+                    raise e
             else:
                 self.message = msg = Message(**res, _client=self._client)
 

--- a/interactions/client/context.py
+++ b/interactions/client/context.py
@@ -362,10 +362,11 @@ class CommandContext(_Context):
                         int(self.channel_id), int(self.message.id), payload=payload
                     )
                 except LibraryException as e:
-                    log.warning(f"You can't edit hidden messages." f"({e.message}).")
-                    if e.code not in {10015, 10018}:
+                    if e.code in {10015, 10018}:
+                        log.warning(f"You can't edit hidden messages." f"({e.message}).")
+                    else:
                         # if its not ephemeral or some other thing.
-                        raise e
+                        raise e from e
                 else:
                     self.message = msg = Message(**res, _client=self._client)
             else:
@@ -379,10 +380,11 @@ class CommandContext(_Context):
                         else "@original",
                     )
                 except LibraryException as e:
-                    log.warning(f"You can't edit hidden messages." f"({e.message}).")
-                    if e.code not in {10015, 10018}:
+                    if e.code in {10015, 10018}:
+                        log.warning(f"You can't edit hidden messages." f"({e.message}).")
+                    else:
                         # if its not ephemeral or some other thing.
-                        raise e
+                        raise e from e
                 else:
                     self.message = msg = Message(**res, _client=self._client)
         else:
@@ -391,10 +393,11 @@ class CommandContext(_Context):
                     token=self.token, application_id=str(self.application_id), data=payload
                 )
             except LibraryException as e:
-                log.warning(f"You can't edit hidden messages." f"({e.message}).")
-                if e.code not in {10015, 10018}:
+                if e.code in {10015, 10018}:
+                    log.warning(f"You can't edit hidden messages." f"({e.message}).")
+                else:
                     # if its not ephemeral or some other thing.
-                    raise e
+                    raise e from e
             else:
                 self.message = msg = Message(**res, _client=self._client)
 

--- a/interactions/client/context.py
+++ b/interactions/client/context.py
@@ -352,36 +352,41 @@ class CommandContext(_Context):
         msg = None
 
         if self.deferred:
-            if hasattr(self.message, "id") and self.message.id is not None:
+            if (
+                hasattr(self.message, "id")
+                and self.message.id is not None
+                and self.message.flags != 64
+            ):
                 res = await self._client.edit_message(
                     int(self.channel_id), int(self.message.id), payload=payload
                 )
-                self.message = msg = Message(**res, _client=self._client)
             else:
                 res = await self._client.edit_interaction_response(
                     token=self.token,
                     application_id=str(self.id),
-                    data={"type": self.callback.value, "data": payload},
-                    message_id=self.message.id if self.message else "@original",
+                    data=payload,
+                    message_id=self.message.id
+                    if self.message and self.message.flags != 64
+                    else "@original",
                 )
-                if res["flags"] == 64:
-                    log.warning("You can't edit hidden messages.")
-                else:
-                    await self._client.edit_message(
-                        int(self.channel_id), res["id"], payload=payload
-                    )
-                    self.message = msg = Message(**res, _client=self._client)
+            if not res.get("code"):
+                self.message = msg = Message(**res, _client=self._client)
+            elif res["code"] in {10008, 10015}:
+                log.warning(
+                    f"You can't edit hidden messages "
+                    f"(Unknown {'interactions' if res['code'] == 10015 else 'message'} reference)."
+                )
         else:
             res = await self._client.edit_interaction_response(
-                token=self.token,
-                application_id=str(self.application_id),
-                data={"type": self.callback.value, "data": payload},
+                token=self.token, application_id=str(self.application_id), data=payload
             )
-            if res["flags"] == 64:
-                log.warning("You can't edit hidden messages.")
-            else:
-                await self._client.edit_message(int(self.channel_id), res["id"], payload=payload)
+            if not res.get("code"):
                 self.message = msg = Message(**res, _client=self._client)
+            elif res["code"] in {10008, 10015}:
+                log.warning(
+                    f"You can't edit hidden messages "
+                    f"(Unknown {'interactions' if res['code'] == 10015 else 'message'} reference)."
+                )
 
         if msg is not None:
             return msg
@@ -395,15 +400,18 @@ class CommandContext(_Context):
         :param ephemeral?: Whether the deferred state is hidden or not.
         :type ephemeral: Optional[bool]
         """
-        self.deferred = True
-        _ephemeral: int = (1 << 6) if ephemeral else 0
-        self.callback = InteractionCallbackType.DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE
+        if not self.responded:
+            self.deferred = True
+            _ephemeral: int = (1 << 6) if ephemeral else 0
+            self.callback = InteractionCallbackType.DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE
 
-        await self._client.create_interaction_response(
-            token=self.token,
-            application_id=int(self.id),
-            data={"type": self.callback.value, "data": {"flags": _ephemeral}},
-        )
+            await self._client.create_interaction_response(
+                token=self.token,
+                application_id=int(self.id),
+                data={"type": self.callback.value, "data": {"flags": _ephemeral}},
+            )
+
+            self.responded = True
 
     async def send(self, content: Optional[str] = MISSING, **kwargs) -> Message:
         payload = await super().send(content, **kwargs)
@@ -414,20 +422,12 @@ class CommandContext(_Context):
         _payload: dict = {"type": self.callback.value, "data": payload}
 
         msg = None
-        if self.responded or self.deferred:
-            if self.deferred:
-                res = await self._client.edit_interaction_response(
-                    data=payload,
-                    token=self.token,
-                    application_id=str(self.application_id),
-                )
-                self.responded = True
-            else:
-                res = await self._client._post_followup(
-                    data=payload,
-                    token=self.token,
-                    application_id=str(self.application_id),
-                )
+        if self.responded:
+            res = await self._client._post_followup(
+                data=payload,
+                token=self.token,
+                application_id=str(self.application_id),
+            )
             self.message = msg = Message(**res, _client=self._client)
         else:
             await self._client.create_interaction_response(
@@ -435,19 +435,19 @@ class CommandContext(_Context):
                 application_id=int(self.id),
                 data=_payload,
             )
-            __newdata = await self._client.edit_interaction_response(
-                data={},
-                token=self.token,
-                application_id=str(self.application_id),
+
+            _msg = await self._client.get_original_interaction_response(
+                self.token, str(self.application_id)
             )
-            if not __newdata.get("code"):
+
+            if not _msg.get("code"):
                 # if sending message fails somehow
-                msg = Message(**__newdata, _client=self._client)
+                msg = Message(**_msg, _client=self._client)
                 self.message = msg
             self.responded = True
+
         if msg is not None:
             return msg
-
         return Message(
             **payload,
             _client=self._client,
@@ -531,6 +531,7 @@ class ComponentContext(_Context):
     async def edit(self, content: Optional[str] = MISSING, **kwargs) -> Message:
 
         payload = await super().edit(content, **kwargs)
+        msg = None
 
         if not self.deferred:
             self.callback = InteractionCallbackType.UPDATE_MESSAGE
@@ -539,20 +540,22 @@ class ComponentContext(_Context):
                 token=self.token,
                 application_id=int(self.id),
             )
-            payload = Message(**payload, _client=self._client)
-            for attr in payload.__slots__:
-                if getattr(self.message, attr, None) and not getattr(payload, attr, None):
-                    setattr(payload, attr, getattr(self.message, attr))
-                    payload._json[attr] = self.message._json[attr]
-            self.message = payload
+
+            _msg = await self._client.get_original_interaction_response(
+                self.token, str(self.application_id)
+            )
+
+            if not _msg.get("code"):
+                # if sending message fails somehow
+                msg = Message(**_msg, _client=self._client)
+                self.message = msg
             self.responded = True
         elif self.callback != InteractionCallbackType.DEFERRED_UPDATE_MESSAGE:
-            res = await self._client._post_followup(
+            await self._client._post_followup(
                 data=payload,
                 token=self.token,
                 application_id=str(self.application_id),
             )
-            self.message = Message(**res, _client=self._client)
         else:
             res = await self._client.edit_interaction_response(
                 data=payload,
@@ -560,12 +563,12 @@ class ComponentContext(_Context):
                 application_id=str(self.application_id),
             )
             self.responded = True
-            self.message = Message(**res, _client=self._client)
+            self.message = msg = Message(**res, _client=self._client)
 
-        if self.message is None:
-            self.message = Message(**payload, _client=self._client)
+        if msg is not None:
+            return msg
 
-        return self.message
+        return Message(**payload, _client=self._client)
 
     async def send(self, content: Optional[str] = MISSING, **kwargs) -> Message:
         payload = await super().send(content, **kwargs)
@@ -576,46 +579,33 @@ class ComponentContext(_Context):
         _payload: dict = {"type": self.callback.value, "data": payload}
 
         msg = None
-        if (
-            self.responded
-            or self.deferred
-            or self.callback == InteractionCallbackType.DEFERRED_UPDATE_MESSAGE
-        ):
-            if self.deferred:
-                res = await self._client.edit_interaction_response(
-                    data=payload,
-                    token=self.token,
-                    application_id=str(self.application_id),
-                )
-                self.responded = True
-            else:
-                res = await self._client._post_followup(
-                    data=payload,
-                    token=self.token,
-                    application_id=str(self.application_id),
-                )
+        if self.responded:
+            res = await self._client._post_followup(
+                data=payload,
+                token=self.token,
+                application_id=str(self.application_id),
+            )
             self.message = msg = Message(**res, _client=self._client)
-
         else:
             await self._client.create_interaction_response(
                 token=self.token,
                 application_id=int(self.id),
                 data=_payload,
             )
-            __newdata = await self._client.edit_interaction_response(
-                data={},
-                token=self.token,
-                application_id=str(self.application_id),
+
+            _msg = await self._client.get_original_interaction_response(
+                self.token, str(self.application_id)
             )
-            if not __newdata.get("code"):
+
+            if not _msg.get("code"):
                 # if sending message fails somehow
-                msg = Message(**__newdata, _client=self._client)
+                msg = Message(**_msg, _client=self._client)
                 self.message = msg
             self.responded = True
 
         if msg is not None:
             return msg
-        return Message(**payload)
+        return Message(**payload, _client=self._client)
 
     async def defer(
         self, ephemeral: Optional[bool] = False, edit_origin: Optional[bool] = False
@@ -629,20 +619,24 @@ class ComponentContext(_Context):
         :param edit_origin?: Whether you want to edit the original message or send a followup message
         :type edit_origin: Optional[bool]
         """
-        self.deferred = True
-        _ephemeral: int = (1 << 6) if bool(ephemeral) else 0
+        if not self.responded:
 
-        # ephemeral doesn't change callback typings. just data json
-        if edit_origin:
-            self.callback = InteractionCallbackType.DEFERRED_UPDATE_MESSAGE
-        else:
-            self.callback = InteractionCallbackType.DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE
+            self.deferred = True
+            _ephemeral: int = (1 << 6) if bool(ephemeral) else 0
 
-        await self._client.create_interaction_response(
-            token=self.token,
-            application_id=int(self.id),
-            data={"type": self.callback.value, "data": {"flags": _ephemeral}},
-        )
+            # ephemeral doesn't change callback typings. just data json
+            if edit_origin:
+                self.callback = InteractionCallbackType.DEFERRED_UPDATE_MESSAGE
+            else:
+                self.callback = InteractionCallbackType.DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE
+
+            await self._client.create_interaction_response(
+                token=self.token,
+                application_id=int(self.id),
+                data={"type": self.callback.value, "data": {"flags": _ephemeral}},
+            )
+
+            self.responded = True
 
     @property
     def custom_id(self) -> Optional[str]:


### PR DESCRIPTION
## About

This pull request refactors both `CommandContext` and `ComponentContext` to replace the legacy v3 black magic with something more uniform, utilising `self.responded` more and using the get original message endpoint.

(I've tested this on unstable and stable (with tweaks to stable of course for architecture reasons) but more testing is appreciated!)

## Checklist

- [X] I've ran `pre-commit` to format and lint the change(s) made.
- [X] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [X] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent): Fixes #870 (or at least, minimises the chance of it happening)
- [X] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [X] New feature/enhancement
  - [X] Bugfix
