### PR TITLE
fix: properly typehint Storage.get/pop

### DIFF
--- a/interactions/api/cache.py
+++ b/interactions/api/cache.py
@@ -82,7 +82,15 @@ class Storage(Generic[_T]):
         """
         self.values.update(data)
 
-    def pop(self, key: "Key", default: Optional[_P] = None) -> Union[_T, _P]:
+    @overload
+    def pop(self, key: "Key") -> Optional[_T]:
+        ...
+
+    @overload
+    def pop(self, key: "Key", default: _P) -> Union[_T, _P]:
+        ...
+
+    def pop(self, key: "Key", default: Optional[_P] = None) -> Union[_T, _P, None]:
         try:
             return self.values.pop(key)
         except KeyError:

--- a/interactions/api/cache.py
+++ b/interactions/api/cache.py
@@ -1,5 +1,16 @@
 from collections import defaultdict
-from typing import TYPE_CHECKING, Dict, Generic, List, Optional, Tuple, Type, TypeVar, Union
+from typing import (
+    TYPE_CHECKING,
+    Dict,
+    Generic,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    overload,
+)
 
 if TYPE_CHECKING:
     from .models import Snowflake
@@ -41,7 +52,15 @@ class Storage(Generic[_T]):
         """
         self.values[id or item.id] = item
 
-    def get(self, id: "Key", default: Optional[_P] = None) -> Union[_T, _P]:
+    @overload
+    def get(self, id: "Key") -> Optional[_T]:
+        ...
+
+    @overload
+    def get(self, id: "Key", default: _P) -> Union[_T, _P]:
+        ...
+
+    def get(self, id: "Key", default: Optional[_P] = None) -> Union[_T, _P, None]:
         """
         Gets an item from the storage.
 


### PR DESCRIPTION
## About

This PR properly typehints `Storage.get` to actually respect defaults properly. Originally, the `get` function would refuse to consider `default` for its returning typehint, at least in Visual Studio Code.

EDIT: Turns out `Storage.pop` was also improperly typehinted in much of the same way. That has also been fixed.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [x] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
