### PR TITLE
fix: don't lose fields on item update for cache

### DIFF
--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -405,9 +405,9 @@ class WebSocketClient:
 
                 elif "_update" in name and hasattr(obj, "id"):
                     old_obj = self._http.cache[model].get(id)
-                    _cache.add(obj, id)
                     copy = model(**old_obj._json)
                     old_obj.update(**obj._json)
+                    _cache.add(old_obj, id)
                     self._dispatch.dispatch(
                         f"on_{name}", copy, old_obj
                     )  # give previously stored and new one


### PR DESCRIPTION
## About

This pull request adjusts the cache updating logic so that it uses the old object with updated fields rather than solely the payload. This is ideal when Discord doesn't send the full update payload (like with message updates sometimes).

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [x] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
