### PR TITLE
feat: add info from guilds to cache

### DIFF
--- a/interactions/api/models/guild.py
+++ b/interactions/api/models/guild.py
@@ -338,8 +338,6 @@ class Guild(ClientSerializerMixin, IDMixin):
             if self.channels:
                 self._client.cache[Channel].update({c.id: c for c in self.channels})
             if self.threads:
-                # threads are channels, yet threads are also cached seperately
-                self._client.cache[Channel].update({t.id: Channel(**t._json) for t in self.threads})
                 self._client.cache[Thread].update({t.id: t for t in self.threads})
             if self.roles:
                 self._client.cache[Role].update({r.id: r for r in self.roles})

--- a/interactions/api/models/guild.py
+++ b/interactions/api/models/guild.py
@@ -331,6 +331,21 @@ class Guild(ClientSerializerMixin, IDMixin):
 
     # todo assign the correct type
 
+    def __attrs_post_init__(self):  # sourcery skip: last-if-guard
+        if self._client:
+            # update the cache to include info found from guilds
+            # these values wouldn't be "found out" until an update for them happened otherwise
+            if self.channels:
+                self._client.cache[Channel].update({c.id: c for c in self.channels})
+            if self.threads:
+                # threads are channels, yet threads are also cached seperately
+                self._client.cache[Channel].update({t.id: t for t in self.threads})
+                self._client.cache[Thread].update({t.id: t for t in self.threads})
+            if self.roles:
+                self._client.cache[Role].update({r.id: r for r in self.roles})
+            if self.members:
+                self._client.cache[Member].update({(self.id, m.id): m for m in self.members})
+
     def __repr__(self) -> str:
         return self.name
 

--- a/interactions/api/models/guild.py
+++ b/interactions/api/models/guild.py
@@ -339,7 +339,7 @@ class Guild(ClientSerializerMixin, IDMixin):
                 self._client.cache[Channel].update({c.id: c for c in self.channels})
             if self.threads:
                 # threads are channels, yet threads are also cached seperately
-                self._client.cache[Channel].update({t.id: t for t in self.threads})
+                self._client.cache[Channel].update({t.id: Channel(**t._json) for t in self.threads})
                 self._client.cache[Thread].update({t.id: t for t in self.threads})
             if self.roles:
                 self._client.cache[Role].update({r.id: r for r in self.roles})


### PR DESCRIPTION
## About

This pull request makes it so `Guild`s, if they have a `_client`, will add special information they carry (like `Channel`s, `Role`s, and `Member`s) to the cache. These would never otherwise be cached, at least not until they're updated.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [x] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [x] New feature/enhancement
  - [ ] Bugfix
