### PR TITLE
fix: handle updates with no previous obj in cache

### DIFF
--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -405,11 +405,18 @@ class WebSocketClient:
 
                 elif "_update" in name and hasattr(obj, "id"):
                     old_obj = self._http.cache[model].get(id)
-                    copy = model(**old_obj._json)
-                    old_obj.update(**obj._json)
+
+                    if old_obj:
+                        before = model(**old_obj._json)
+                        old_obj.update(**obj._json)
+                    else:
+                        before = None
+                        old_obj = obj
+
                     _cache.add(old_obj, id)
+
                     self._dispatch.dispatch(
-                        f"on_{name}", copy, old_obj
+                        f"on_{name}", before, old_obj
                     )  # give previously stored and new one
                     return
 


### PR DESCRIPTION
## About

This pull request fixes scenarios where an update event is dispatched and the object isn't in the cache already. This can happen with, say, scheduled events, which aren't usually given out with guilds, and so already created events aren't usually cached before being updated.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [x] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
