### PR TITLE
feat:  Adding ``premium_progress_bar_enabled`` for ``Guild``

### DIFF
--- a/interactions/api/models/channel.py
+++ b/interactions/api/models/channel.py
@@ -487,7 +487,7 @@ class Channel(ClientSerializerMixin, IDMixin):
         reason: Optional[str] = None,
     ) -> "Channel":
         """
-        Sets the position of the channel.
+        Sets the amount of seconds a user has to wait before sending another message.
 
         :param rate_limit_per_user: The new rate_limit_per_user of the channel (0-21600)
         :type rate_limit_per_user: int

--- a/interactions/api/models/guild.py
+++ b/interactions/api/models/guild.py
@@ -328,6 +328,7 @@ class Guild(ClientSerializerMixin, IDMixin):
     )
     stickers: Optional[List[Sticker]] = field(converter=convert_list(Sticker), default=None)
     features: List[str] = field()
+    premium_progress_bar_enabled: Optional[bool] = field(default=None)
 
     # todo assign the correct type
 


### PR DESCRIPTION
## About

This pull request is about adding the ``premium_progrss_bar_enabled`` field in ``Guild`` which is somehow missing while the docstring does document it.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [x] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [x] New feature/enhancement
  - [ ] Bugfix
