### PR TITLE
refactor: extract `search_iterable` out from `get` and optimize it

### DIFF
--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -66,7 +66,7 @@ portal and add the intent to your current intents when connecting:
 4.1.0 → 4.3.0
 ~~~~~~~~~~~~~~~
 
-A new big change in this release is the implementation of the ``get` utility method.
+A new big change in this release is the implementation of the ``get`` utility method.
 It allows you to no longer use ``**await bot._http...``.
 
 You can get more information by reading the `get-documentation`_.

--- a/interactions/client/get.py
+++ b/interactions/client/get.py
@@ -1,6 +1,6 @@
 from asyncio import sleep
 from enum import Enum
-from inspect import isawaitable, isfunction
+from inspect import isawaitable
 from logging import getLogger
 from typing import Coroutine, Iterable, List, Optional, Type, TypeVar, Union, get_args
 
@@ -271,9 +271,6 @@ def get(*args, **kwargs):
         else:
             return _http_request(obj=obj, http=client._http, _name=http_name, **kwargs)
 
-    elif len(args) == 1:
-        return _search_iterable(*args, **kwargs)
-
 
 async def _http_request(
     obj: Type[_T],
@@ -337,40 +334,6 @@ def _get_cache(
 
         _obj = client._http.cache[_object].get(_values)
     return _obj
-
-
-def _search_iterable(items: Iterable[_T], **kwargs) -> Optional[_T]:
-    if not isinstance(items, Iterable):
-        raise LibraryException(message="The specified items must be an iterable!", code=12)
-
-    if not kwargs:
-        raise LibraryException(
-            message="You have to specify either a custom check or a keyword argument to check against!",
-            code=12,
-        )
-
-    if len(list(kwargs)) > 1:
-        raise LibraryException(
-            message="Only one keyword argument to check against is allowed!", code=12
-        )
-
-    _arg = str(list(kwargs)[0])
-    kwarg = kwargs.get(_arg)
-    kwarg_is_function: bool = isfunction(kwarg)
-
-    __obj = next(
-        (
-            item
-            for item in items
-            if (
-                str(getattr(item, _arg, None)) == str(kwarg)
-                if not kwarg_is_function
-                else kwarg(item)
-            )
-        ),
-        None,
-    )
-    return __obj
 
 
 def _resolve_kwargs(obj, **kwargs):

--- a/interactions/client/get.pyi
+++ b/interactions/client/get.pyi
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Awaitable, Coroutine, Iterable, List, Literal, Optional, Type, TypeVar, Union, overload
+from typing import Awaitable, Coroutine, List, Literal, Optional, Type, TypeVar, Union, overload
 
 from interactions.client.bot import Client
 from ..api.http.client import HTTPClient
@@ -96,7 +96,6 @@ def get(
 # Having a not-overloaded definition stops showing a warning/complaint from the IDE if wrong arguments are put in,
 # so we'll leave that out
 
-def _search_iterable(item: Iterable[_T], **kwargs) -> Optional[_T]:...
 def _get_cache(
     _object: Type[_T], client: Client, kwarg_name: str, _list: bool = False, **kwargs
 ) -> Union[Optional[_T], List[Optional[_T]]]:...

--- a/interactions/client/get.pyi
+++ b/interactions/client/get.pyi
@@ -1,15 +1,15 @@
-from typing import overload, Type, TypeVar, List, Iterable, Optional, Callable, Awaitable, Literal, Coroutine, Union
+from enum import Enum
+from typing import Awaitable, Coroutine, Iterable, List, Literal, Optional, Type, TypeVar, Union, overload
 
 from interactions.client.bot import Client
-from enum import Enum
+from ..api.http.client import HTTPClient
 from ..api.models.channel import Channel
 from ..api.models.guild import Guild
 from ..api.models.member import Member
-from ..api.models.message import Message, Emoji, Sticker
+from ..api.models.message import Emoji, Message, Sticker
+from ..api.models.role import Role
 from ..api.models.user import User
 from ..api.models.webhook import Webhook
-from ..api.models.role import Role
-from ..api.http.client import HTTPClient
 
 _SA = TypeVar("_SA", Channel, Guild, Webhook, User, Sticker)
 _MA = TypeVar("_MA", Member, Emoji, Role, Message)
@@ -24,11 +24,6 @@ class Force(str, Enum):
     CACHE: str
     HTTP: str
 
-# not API-object related
-@overload
-def get(
-    items: Iterable[_T], /, *, id: Optional[int] = None, name: Optional[str] = None, check: Callable[..., bool], **kwargs
-) -> Optional[_T]: ...
 
 # API-object related
 

--- a/interactions/client/models/utils.py
+++ b/interactions/client/models/utils.py
@@ -1,6 +1,6 @@
 from asyncio import Task, get_running_loop, sleep
 from functools import wraps
-from typing import TYPE_CHECKING, Awaitable, Callable, Iterable, List, TypeVar, Union
+from typing import TYPE_CHECKING, Awaitable, Callable, Iterable, List, Optional, TypeVar, Union
 
 from ...api.error import LibraryException
 from .component import ActionRow, Button, SelectMenu
@@ -142,7 +142,7 @@ def spread_to_rows(
 
 
 def search_iterable(
-    iterable: Iterable[_T], check: Callable[[_T], bool] = None, /, **kwargs
+    iterable: Iterable[_T], check: Optional[Callable[[_T], bool]] = None, /, **kwargs
 ) -> List[_T]:
     """
     Searches through an iterable for items that:

--- a/interactions/client/models/utils.py
+++ b/interactions/client/models/utils.py
@@ -1,6 +1,6 @@
 from asyncio import Task, get_running_loop, sleep
 from functools import wraps
-from typing import TYPE_CHECKING, Awaitable, Callable, List, Union
+from typing import TYPE_CHECKING, Awaitable, Callable, Iterable, List, TypeVar, Union
 
 from ...api.error import LibraryException
 from .component import ActionRow, Button, SelectMenu
@@ -8,8 +8,9 @@ from .component import ActionRow, Button, SelectMenu
 if TYPE_CHECKING:
     from ..context import CommandContext
 
-
 __all__ = ("autodefer", "spread_to_rows")
+
+_T = TypeVar("_T")
 
 
 def autodefer(
@@ -138,3 +139,32 @@ def spread_to_rows(
         raise LibraryException(code=12, message="Number of rows exceeds 5.")
 
     return rows
+
+
+def search_iterable(
+    iterable: Iterable[_T], check: Callable[[_T], bool] = None, /, **kwargs
+) -> List[_T]:
+    """
+    Searches through an iterable for items that:
+    - Are True for the check, if one is given
+    - Have attributes that match the keyword arguments (e.x. passing `id=your_id` will only return objects with that id)
+
+    :param iterable: The iterable to search through
+    :type iterable: Iterable
+    :param check: The check that items will be checked against
+    :type check: Callable[[Any], bool]
+    :param kwargs: Any attributes the items should have
+    :type kwargs: Any
+    :return: All items that match the check and keywords
+    :rtype: list
+    """
+    if check:
+        iterable = filter(check, iterable)
+
+    if kwargs:
+        iterable = filter(
+            lambda item: all(getattr(item, attr) == value for attr, value in kwargs.items()),
+            iterable,
+        )
+
+    return list(iterable)


### PR DESCRIPTION
## About

This pull request extracts out `search_iterable` from `get` into it's own function, which helps reduce complexity and makes it easier to spot bugs (such as the one in #919)


## Checklist

- [ ] I've ran `pre-commit` to format and lint the change(s) made.
- [ ] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [ ] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [ ] Bugfix
