### PR TITLE
fix: UnicodeEncodeError when logging events

### DIFF
--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -261,7 +261,7 @@ class WebSocketClient:
             log.debug(f"READY (session_id: {self.session_id}, seq: {self.sequence})")
             self.ready.set()
         else:
-            log.debug(f"{event}: {data}")
+            log.debug(f"{event}: {str(data).encode('utf-8')}")
             self._dispatch_event(event, data)
 
     async def wait_until_ready(self) -> None:


### PR DESCRIPTION
## About

This pull request fixes `UnicodeEncodeError` when logging events.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [x] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent): #904 
- I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
