### PR TITLE
feat: `on_start` event

### DIFF
--- a/docs/events.rst
+++ b/docs/events.rst
@@ -51,6 +51,7 @@ All events mentioned in this section have the exact naming as they must be put i
 There are several different internal events:
 
     - ``raw_socket_create``
+    - ``on_start``
     - ``on_interaction``
     - ``on_command``
     - ``on_component``
@@ -69,6 +70,15 @@ The function handling the event should take in one argument, the type of this ar
 The value of the argument will be the *raw* data sent from Discord, so it is not recommended to use that event
 as long as you don't absolutely need it.
 
+
+Event: ``on_start``
+^^^^^^^^^^^^^^^^^^^
+This event fires only when the bot is started.
+
+This function takes no arguments.
+
+.. attention::
+    Unlike ``on_ready``, this event will never be dispatched more than once.
 
 Event: ``on_interaction``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -80,6 +80,7 @@ class WebSocketClient:
         "__shard",
         "__presence",
         "__task",
+        "__started",
         "session_id",
         "sequence",
         "ready",
@@ -126,6 +127,7 @@ class WebSocketClient:
         self.__shard: Optional[List[Tuple[int]]] = None
         self.__presence: Optional[ClientPresence] = None
         self.__task: Optional[Task] = None
+        self.__started: bool = False
         self.session_id: Optional[str] = None if session_id is MISSING else session_id
         self.sequence: Optional[str] = None if sequence is MISSING else sequence
         self.ready: Event = Event(loop=self._loop) if version_info < (3, 10) else Event()
@@ -258,6 +260,9 @@ class WebSocketClient:
             self.session_id = data["session_id"]
             self.sequence = stream["s"]
             self._dispatch.dispatch("on_ready")
+            if not self.__started:
+                self.__started = True
+                self._dispatch.dispatch("on_start")
             log.debug(f"READY (session_id: {self.session_id}, seq: {self.sequence})")
             self.ready.set()
         else:


### PR DESCRIPTION
## About

This pull request adds the `on_start` event.

Previous method of executing code when the bot is started:
```py
started = False

@client.event
async def on_ready():
    global started
    if started:
        return
    started = True
    ...  # do stuff here
```
The PR implements this, which accomplishes the same thing:
```py
async def on_start():
    ...  # do stuff here
```
Justification: most users do not check if the bot had started in their `on_ready` functions.
This would lead to it being dispatched multiple times, even though the majority wouldn't want it to.
Adding the `on_start` event mitigates this issue without breaking any functionality.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [x] New feature/enhancement
  - [ ] Bugfix
