### PR TITLE
fix: Fix more issues with guild objects when caching a gw event

### DIFF
--- a/interactions/api/cache.py
+++ b/interactions/api/cache.py
@@ -67,11 +67,12 @@ class Storage(Generic[_T]):
                 ):  # could be None
                     setattr(old_item, attrib, [])
                 if isinstance(getattr(old_item, attrib), list):
-                    for value in getattr(item, attrib):
-                        old_item_attrib = getattr(old_item, attrib)
-                        if value not in getattr(old_item, attrib):
-                            old_item_attrib.append(value)
-                        setattr(old_item, attrib, old_item_attrib)
+                    if _attrib := getattr(item, attrib):
+                        for value in _attrib:
+                            old_item_attrib = getattr(old_item, attrib)
+                            if value not in old_item_attrib:
+                                old_item_attrib.append(value)
+                            setattr(old_item, attrib, old_item_attrib)
                 else:
                     setattr(old_item, attrib, getattr(item, attrib))
 

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -412,17 +412,19 @@ class WebSocketClient:
                         and not isinstance(obj, Guild)
                         and "message" not in name
                     ):
-                        guild = self._http.cache[Guild].get(Snowflake(guild_id))
-                        model_name = model.__name__.lower()
-                        _obj = getattr(guild, f"{model_name}s", None)
-                        if _obj is not None:
-                            if isinstance(_obj, list):
-                                _obj.append(obj)
+                        if guild := self._http.cache[Guild].get(Snowflake(guild_id)):
+                            model_name = model.__name__.lower()
+                            if "guild" in model_name:
+                                model_name = model_name[5:]
+                            _obj = getattr(guild, f"{model_name}s", None)
+                            if _obj is not None:
+                                if isinstance(_obj, list):
+                                    _obj.append(obj)
+                                    setattr(guild, f"{model_name}s", _obj)
+                            else:
+                                _obj = [obj]
                                 setattr(guild, f"{model_name}s", _obj)
-                        else:
-                            _obj = [obj]
-                            setattr(guild, f"{model_name}s", _obj)
-                        self._http.cache[Guild].add(guild)
+                            self._http.cache[Guild].merge(guild)
                     self._dispatch.dispatch(f"on_{name}", obj)
 
                 elif "_update" in name and hasattr(obj, "id"):
@@ -446,21 +448,23 @@ class WebSocketClient:
                         and not isinstance(obj, Guild)
                         and "message" not in name
                     ):
-                        guild = self._http.cache[Guild].get(Snowflake(guild_id))
-                        model_name = model.__name__.lower()
-                        _obj = getattr(guild, f"{model_name}s", None)
-                        if _obj is not None:
-                            if isinstance(_obj, list):
-                                for __obj in _obj:
-                                    if __obj.id == obj.id:
-                                        _obj.remove(__obj)
-                                        break
-                                _obj.append(obj)
+                        if guild := self._http.cache[Guild].get(Snowflake(guild_id)):
+                            model_name = model.__name__.lower()
+                            if "guild" in model_name:
+                                model_name = model_name[5:]
+                            _obj = getattr(guild, f"{model_name}s", None)
+                            if _obj is not None:
+                                if isinstance(_obj, list):
+                                    for __obj in _obj:
+                                        if __obj.id == obj.id:
+                                            _obj.remove(__obj)
+                                            break
+                                    _obj.append(obj)
+                                    setattr(guild, f"{model_name}s", _obj)
+                            else:
+                                _obj = [obj]
                                 setattr(guild, f"{model_name}s", _obj)
-                        else:
-                            _obj = [obj]
-                            setattr(guild, f"{model_name}s", _obj)
-                        self._http.cache[Guild].add(guild)
+                            self._http.cache[Guild].add(guild)
 
                     self._dispatch.dispatch(
                         f"on_{name}", before, old_obj
@@ -475,17 +479,19 @@ class WebSocketClient:
                         and not isinstance(obj, Guild)
                         and "message" not in name
                     ):
-                        guild = self._http.cache[Guild].get(Snowflake(guild_id))
-                        model_name = model.__name__.lower()
-                        _obj = getattr(guild, f"{model_name}s", None)
-                        if _obj is not None:
-                            if isinstance(_obj, list):
-                                for __obj in _obj:
-                                    if __obj.id == obj.id:
-                                        _obj.remove(__obj)
-                                        break
-                                setattr(guild, f"{model_name}s", _obj)
-                        self._http.cache[Guild].add(guild)
+                        if guild := self._http.cache[Guild].get(Snowflake(guild_id)):
+                            model_name = model.__name__.lower()
+                            if "guild" in model_name:
+                                model_name = model_name[5:]
+                            _obj = getattr(guild, f"{model_name}s", None)
+                            if _obj is not None:
+                                if isinstance(_obj, list):
+                                    for __obj in _obj:
+                                        if __obj.id == obj.id:
+                                            _obj.remove(__obj)
+                                            break
+                                    setattr(guild, f"{model_name}s", _obj)
+                            self._http.cache[Guild].add(guild)
 
                     old_obj = _cache.pop(id)
                     self._dispatch.dispatch(f"on_{name}", old_obj)

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -393,6 +393,13 @@ class WebSocketClient:
             name: str = event.lower()
             try:
 
+                _event_path: list = [section.capitalize() for section in name.split("_")]
+                _name: str = _event_path[0] if len(_event_path) < 3 else "".join(_event_path[:-1])
+                model = getattr(__import__(path), _name)
+
+                data["_client"] = self._http
+                obj = model(**data)
+
                 def __modify_guild_cache():
                     if not (
                         guild_id := data.get("guild_id")
@@ -413,12 +420,6 @@ class WebSocketClient:
                             setattr(guild, f"{model_name}s", _obj)
                         self._http.cache[Guild].add(guild)
 
-                _event_path: list = [section.capitalize() for section in name.split("_")]
-                _name: str = _event_path[0] if len(_event_path) < 3 else "".join(_event_path[:-1])
-                model = getattr(__import__(path), _name)
-
-                data["_client"] = self._http
-                obj = model(**data)
                 _cache: "Storage" = self._http.cache[model]
 
                 if isinstance(obj, Member):


### PR DESCRIPTION
## About
Seen here: https://canary.discord.com/channels/789032594456576001/876490879815254097/997449315708588054

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
