### PR TITLE
docs: document `on_start` in more places

### DIFF
--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -66,7 +66,34 @@ portal and add the intent to your current intents when connecting:
 4.1.0 → 4.3.0
 ~~~~~~~~~~~~~~~
 
-A new big change in this release is the implementation of the ``get`` utility method.
+A new feature was added; an event called ``on_start``.
+Unlike ``on_ready``, this event is only dispatched when the bot is first started.
+
+Instead of using the ``on_ready`` event and a check to only run code once:
+
+.. code-block:: python
+
+    _ready: bool = False
+    bot = interactions.Client(...)
+
+    @bot.event
+    async def on_ready():
+        global _ready
+        if not _ready:
+            ... # do stuff
+            _ready = True
+
+You can now utilize the ``on_start`` event to achieve the same goal:
+
+.. code-block:: python
+
+    bot = interactions.Client(...)
+
+    @bot.event
+    async def on_start():
+        ... # do stuff
+
+Another big change in this release is the implementation of the ``get`` utility method.
 It allows you to no longer use ``**await bot._http...``.
 
 You can get more information by reading the `get-documentation`_.

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -60,6 +60,7 @@ class WebSocketClient:
     :ivar Optional[ClientPresence] __presence: The presence used in connection.
     :ivar Event ready: The ready state of the client as an ``asyncio.Event``.
     :ivar Task __task: The closing task for ending connections.
+    :ivar bool __started: Whether the client has started.
     :ivar Optional[str] session_id: The ID of the ongoing session.
     :ivar Optional[int] sequence: The sequence identifier of the ongoing session.
     :ivar float _last_send: The latest time of the last send_packet function call since connection creation, in seconds.


### PR DESCRIPTION
## About

This pull request documents the `on_start` event in more places, such as the docstring in `interactions.api.gateway.client.WebSocketClient` and `migration.rst`.
I forgot to do this in #927.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [ ] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- I've made this pull request for/as: (check all that apply)
  - [x] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [ ] Bugfix
