### PR TITLE
feat: Remove PresenceButton object.

### DIFF
--- a/interactions/api/models/presence.py
+++ b/interactions/api/models/presence.py
@@ -14,7 +14,6 @@ __all__ = (
     "PresenceTimestamp",
     "PresenceActivity",
     "PresenceActivityType",
-    "PresenceButtons",
     "ClientPresence",
 )
 
@@ -65,19 +64,6 @@ class PresenceSecrets(DictSerializerMixin):
 
 
 @define()
-class PresenceButtons(DictSerializerMixin):
-    """
-    A class object representing the buttons of a presence.
-
-    :ivar str label: Text of the button
-    :ivar str url: URL of the button
-    """
-
-    label: str = field()
-    url: str = field()
-
-
-@define()
 class PresenceTimestamp(DictSerializerMixin):
     """
     A class object representing the timestamp data of a presence.
@@ -109,8 +95,11 @@ class PresenceActivity(DictSerializerMixin):
     A class object representing the current activity data of a presence.
 
     .. note::
-        When using this model to instantiate alongside the client, if you provide a type 1 ( or PresenceActivityType.STREAMING ), then
-        the ``url`` attribute is necessary.
+        When using this model to instantiate alongside the client, if you provide a type 1 ( or PresenceActivityType.STREAMING ),
+        then the ``url`` attribute is necessary.
+
+        The ``button`` attribute technically contains an object denoting Presence buttons. However, the gateway dispatches these
+        as strings (of button labels) as bots don't read the button URLs.
 
     :ivar str name: The activity name
     :ivar Union[int, PresenceActivityType] type: The activity type
@@ -126,7 +115,7 @@ class PresenceActivity(DictSerializerMixin):
     :ivar Optional[PresenceSecrets] secrets?: for RPC join/spectate
     :ivar Optional[bool] instance?: A status denoting if the activity is a game session
     :ivar Optional[int] flags?: activity flags
-    :ivar Optional[List[PresenceButtons]] buttons?: Custom buttons shown in the RPC.
+    :ivar Optional[List[str]] buttons?: Custom button labels shown in the status, if any.
     """
 
     name: str = field()
@@ -143,9 +132,7 @@ class PresenceActivity(DictSerializerMixin):
     secrets: Optional[PresenceSecrets] = field(converter=PresenceSecrets, default=None)
     instance: Optional[bool] = field(default=None)
     flags: Optional[int] = field(default=None)
-    buttons: Optional[List[PresenceButtons]] = field(
-        converter=convert_list(PresenceButtons), default=None
-    )
+    buttons: Optional[List[str]] = field(default=None)
     # TODO: document/investigate what these do.
     user: Optional[Any] = field(default=None)
     users: Optional[Any] = field(default=None)


### PR DESCRIPTION
## About

This pull request removes the PresenceButton object because its not dispatched as an object when the bot runs.
Not sure why this wasn't shown in earlier versions of the library though.

## Checklist

- [X] I've ran `pre-commit` to format and lint the change(s) made.
- [X] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [X] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent): #933 
- I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [] New feature/enhancement
  - [X] Bugfix
