### PR TITLE
fix: get() erroring when requesting anything other than role or emoji

### DIFF
--- a/interactions/client/get.py
+++ b/interactions/client/get.py
@@ -258,7 +258,7 @@ async def _http_request(
             return await _func(**kwargs)
 
         _func = getattr(http, _name)
-        _obj = await _func
+        _obj = await _func(**kwargs)
         return obj(**_obj, _client=http)
 
     if not isinstance(request, list):


### PR DESCRIPTION
## About

This pull request is about fixing get() function, which does not work.

## Checklist

- [ ] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
