### PR TITLE
fix: fix incorrect ``guild_id`` in cache modifing

### DIFF
--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -403,7 +403,7 @@ class WebSocketClient:
 
                 def __modify_guild_cache():
                     if not (
-                        guild_id := data.get("guild_id")
+                        (guild_id := data.get("guild_id"))
                         and not isinstance(obj, Guild)
                         and "message" not in name
                     ):


### PR DESCRIPTION
## About

Without these brackets `guild_id` always is True

## Checklist

- [ ] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
