### PR TITLE
feat: on_command_error event

### DIFF
--- a/docs/events.rst
+++ b/docs/events.rst
@@ -54,6 +54,7 @@ There are several different internal events:
     - ``on_start``
     - ``on_interaction``
     - ``on_command``
+    - ``on_command_error``
     - ``on_component``
     - ``on_autocomplete``
     - ``on_modal``
@@ -98,6 +99,16 @@ The function takes in one argument of the type ``CommandContext``.
 
 Using this event, you will have to manually check everything, from name to whether the used commands have sub commands,
 options or anything else - everything will be in the raw context and you will have to search for it
+
+
+Event: ``on_command_error``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+This event fires when the following conditions are met:
+
+1. There is an error in the command (or subcommand within the command)
+2. There is no error callback assigned to that command
+
+The function takes in two arguments, one of the type ``CommandContext``, and the other contains the error.
 
 
 Event: ``on_component``

--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -456,9 +456,11 @@ class Client:
             if cmd.resolved:
                 continue
 
+            cmd.listener = self._websocket._dispatch
+
             if cmd.default_scope and self._default_scope:
                 cmd.scope = (
-                    cmd.scope.extend(cmd.default_scope)
+                    cmd.scope.extend(self._default_scope)
                     if isinstance(cmd.scope, list)
                     else self._default_scope
                 )

--- a/interactions/client/models/command.py
+++ b/interactions/client/models/command.py
@@ -15,6 +15,7 @@ from ...api.models.user import User
 from ..enums import ApplicationCommandType, Locale, OptionType, PermissionType
 
 if TYPE_CHECKING:
+    from ...api.dispatch import Listener
     from ..bot import Extension
     from ..context import CommandContext
 
@@ -392,7 +393,8 @@ class Command(DictSerializerMixin):
     :ivar Dict[str, Union[Callable[..., Awaitable], str]] autocompletions: The dictionary of autocompletions for the command.
     :ivar Optional[str] recent_group: The name of the group most recently utilized.
     :ivar bool resolved: Whether the command is synced. Defaults to ``False``.
-    :ivar Extension extension: The extension that the command belongs to, if any.
+    :ivar Optional[Extension] extension: The extension that the command belongs to, if any.
+    :ivar Optional[Listener] listener: The listener, used for dispatching command errors.
     """
 
     coro: Callable[..., Awaitable] = field()
@@ -415,7 +417,8 @@ class Command(DictSerializerMixin):
     recent_group: Optional[str] = field(default=None, init=False)
     error_callback: Optional[Callable[..., Awaitable]] = field(default=None, init=False)
     resolved: bool = field(default=False, init=False)
-    extension: "Extension" = field(default=None, init=False)
+    extension: Optional["Extension"] = field(default=None, init=False)
+    listener: Optional["Listener"] = field(default=None, init=False)
 
     def __attrs_post_init__(self) -> None:
         if self.name is MISSING:
@@ -833,17 +836,19 @@ class Command(DictSerializerMixin):
         except CancelledError:
             pass
         except Exception as e:
-            if not self.error_callback:
-                raise e
+            if self.error_callback:
+                num_params = len(signature(self.error_callback).parameters)
 
-            num_params = len(signature(self.error_callback).parameters)
-
-            if num_params == (3 if self.extension else 2):
-                await self.error_callback(ctx, e)
-            elif num_params == (4 if self.extension else 3):
-                await self.error_callback(ctx, e, _res)
+                if num_params == (3 if self.extension else 2):
+                    await self.error_callback(ctx, e)
+                elif num_params == (4 if self.extension else 3):
+                    await self.error_callback(ctx, e, _res)
+                else:
+                    await self.error_callback(ctx, e, _res, *args, **kwargs)
+            elif self.listener and "on_command_error" in self.listener.events:
+                self.listener.dispatch("on_command_error", ctx, e)
             else:
-                await self.error_callback(ctx, e, _res, *args, **kwargs)
+                raise e
 
             return StopCommand
 
@@ -884,15 +889,17 @@ class Command(DictSerializerMixin):
             except CancelledError:
                 pass
             except Exception as e:
-                if self.has_subcommands or not self.error_callback:
-                    raise e
+                if self.error_callback:
+                    num_params = len(signature(self.error_callback).parameters)
 
-                num_params = len(signature(self.error_callback).parameters)
-
-                if num_params == (3 if self.extension else 2):
-                    await self.error_callback(ctx, e)
+                    if num_params == (3 if self.extension else 2):
+                        await self.error_callback(ctx, e)
+                    else:
+                        await self.error_callback(ctx, e, *args, **kwargs)
+                elif self.listener and "on_command_error" in self.listener.events:
+                    self.listener.dispatch("on_command_error", ctx, e)
                 else:
-                    await self.error_callback(ctx, e, *args, **kwargs)
+                    raise e
 
                 return StopCommand
 


### PR DESCRIPTION
## About

This pull request implements an `on_command_error` event.

Usage:
```py
@bot.event
async def on_command_error(ctx: CommandContext, error: Exception):
    ...
```

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- I've made this pull request for/as: (check all that apply)
  - [x] Documentation
  - [ ] Breaking change
  - [x] New feature/enhancement
  - [ ] Bugfix
