### PR TITLE
fix: add missed logic to ``Embed.insert_field_at``

### DIFF
--- a/interactions/api/models/message.py
+++ b/interactions/api/models/message.py
@@ -563,7 +563,7 @@ class Embed(DictSerializerMixin):
         self.fields = []
 
     def insert_field_at(
-        self, index: int, name: str = None, value: str = None, inline: Optional[bool] = False
+        self, index: int, name: str, value: str, inline: Optional[bool] = False
     ) -> None:
         """
         Inserts a field in the embed at the specified index

--- a/interactions/api/models/message.py
+++ b/interactions/api/models/message.py
@@ -578,6 +578,17 @@ class Embed(DictSerializerMixin):
         :type inline?: Optional[bool]
         """
 
+        try:
+            fields = self.fields
+            fields.insert(index, EmbedField(name=name, value=value, inline=inline))
+            self.fields = fields
+
+        except AttributeError as e:
+            raise AttributeError("No fields found in Embed") from e
+
+        except IndexError as e:
+            raise IndexError("No fields at this index") from e
+
     def set_field_at(
         self, index: int, name: str, value: str, inline: Optional[bool] = False
     ) -> None:

--- a/interactions/api/models/message.py
+++ b/interactions/api/models/message.py
@@ -586,9 +586,6 @@ class Embed(DictSerializerMixin):
         except AttributeError as e:
             raise AttributeError("No fields found in Embed") from e
 
-        except IndexError as e:
-            raise IndexError("No fields at this index") from e
-
     def set_field_at(
         self, index: int, name: str, value: str, inline: Optional[bool] = False
     ) -> None:


### PR DESCRIPTION
## About

Adds missed logic to `Embed.insert_field_at` and makes `name` and `value` are required

## Checklist

- [ ] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
