### PR TITLE
fix: `ActionRow.new()` typehinting

### DIFF
--- a/interactions/client/models/component.py
+++ b/interactions/client/models/component.py
@@ -1,5 +1,5 @@
 import contextlib
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from ...api.error import LibraryException
 from ...api.models.attrs_utils import MISSING, DictSerializerMixin, convert_list, define, field

--- a/interactions/client/models/component.py
+++ b/interactions/client/models/component.py
@@ -297,12 +297,12 @@ class ActionRow(ComponentMixin):
             self._json["components"] = [component._json for component in self.components]
 
     @classmethod
-    def new(cls, *components: Component) -> "ActionRow":
+    def new(cls, *components: Union[Button, SelectMenu, TextInput]) -> "ActionRow":
         r"""
         A class method for creating a new ``ActionRow``.
 
         :param \*components: The components to add to the ``ActionRow``.
-        :type \*components: Component
+        :type \*components: Union[Button, SelectMenu, TextInput]
         :return: A new ``ActionRow``.
         :rtype: ActionRow
         """


### PR DESCRIPTION
## About

This pull request fixes `ActionRow.new()` typehinting.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
