### PR TITLE
feat: Suppress voice state console logs.

### DIFF
--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -390,7 +390,7 @@ class WebSocketClient:
                 log.warning(
                     "Context is being created for the interaction, but no type is specified. Skipping..."
                 )
-        elif event != "TYPING_START":
+        elif event not in {"TYPING_START", "VOICE_STATE_UPDATE", "VOICE_SERVER_UPDATE"}:
             name: str = event.lower()
             try:
 
@@ -501,7 +501,7 @@ class WebSocketClient:
                     self._dispatch.dispatch(f"on_{name}", obj)
 
             except AttributeError as error:
-                log.fatal(f"An error occured dispatching {name}: {error}")
+                log.fatal(f"An error occurred dispatching {name}: {error}")
 
     def __contextualize(self, data: dict) -> "_Context":
         """


### PR DESCRIPTION
## About

This pull request suppresses the console spam whenever someone joins/leaves a vc, and by extension does not dispatch the Voice-related events as there's no model for it in the core library (moreover relying on the voice ext to get the events, as it doesn't interfere with the extension).

## Checklist

- [X] I've ran `pre-commit` to format and lint the change(s) made.
- [X] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [X] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent): #966 
- I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [X] New feature/enhancement
  - [ ] Bugfix
