### PR TITLE
feat: Add member and channel permissions calculation functions

### DIFF
--- a/interactions/api/models/channel.py
+++ b/interactions/api/models/channel.py
@@ -11,7 +11,7 @@ from .attrs_utils import (
     define,
     field,
 )
-from .flags import Permissions, ALL_PERMISSIONS
+from .flags import ALL_PERMISSIONS, Permissions
 from .misc import File, IDMixin, Overwrite, Snowflake
 from .user import User
 from .webhook import Webhook
@@ -1223,6 +1223,7 @@ class Channel(ClientSerializerMixin, IDMixin):
         :rtype: Permissions
         """
         from .guild import Guild
+
         guild = Guild(**await self._client.get_guild(int(self.guild_id)), _client=self._client)
 
         permissions = await member.get_guild_permissions(guild)
@@ -1232,7 +1233,10 @@ class Channel(ClientSerializerMixin, IDMixin):
 
         # @everyone role overwrites
         from ...client.models.utils import search_iterable
-        overwrite_everyone = search_iterable(self.permission_overwrites, lambda overwrite: int(overwrite.id) == int(self.guild_id))
+
+        overwrite_everyone = search_iterable(
+            self.permission_overwrites, lambda overwrite: int(overwrite.id) == int(self.guild_id)
+        )
         if overwrite_everyone:
             permissions &= ~int(overwrite_everyone[0].deny)
             permissions |= int(overwrite_everyone[0].allow)
@@ -1241,7 +1245,9 @@ class Channel(ClientSerializerMixin, IDMixin):
         allow = 0
         deny = 0
         for role_id in member.roles:
-            overwrite_role = search_iterable(self.permission_overwrites, lambda overwrite: int(overwrite.id) == int(role_id))
+            overwrite_role = search_iterable(
+                self.permission_overwrites, lambda overwrite: int(overwrite.id) == int(role_id)
+            )
             if overwrite_role:
                 allow |= int(overwrite_role[0].allow)
                 deny |= int(overwrite_role[0].deny)
@@ -1252,7 +1258,9 @@ class Channel(ClientSerializerMixin, IDMixin):
             permissions |= int(allow)
 
         # Apply member specific overwrites
-        overwrite_member = search_iterable(self.permission_overwrites, lambda overwrite: int(overwrite.id) == int(member.id))
+        overwrite_member = search_iterable(
+            self.permission_overwrites, lambda overwrite: int(overwrite.id) == int(member.id)
+        )
         if overwrite_member:
             permissions &= ~int(overwrite_member[0].deny)
             permissions |= int(overwrite_member[0].allow)

--- a/interactions/api/models/channel.py
+++ b/interactions/api/models/channel.py
@@ -1222,6 +1222,9 @@ class Channel(ClientSerializerMixin, IDMixin):
         :return: Permissions of the member in this channel
         :rtype: Permissions
         """
+        if not self.guild_id:
+            return Permissions.DEFAULT
+
         from .guild import Guild
 
         guild = Guild(**await self._client.get_guild(int(self.guild_id)), _client=self._client)

--- a/interactions/api/models/channel.py
+++ b/interactions/api/models/channel.py
@@ -1215,7 +1215,7 @@ class Channel(ClientSerializerMixin, IDMixin):
         .. note::
             The permissions returned by this function take into account role and
             user overwrites that can be assigned to channels or categories. If you
-            don't need these overwrites, look into `Member.get_guild_permissions()` function.
+            don't need these overwrites, look into :meth:`.Member.get_guild_permissions`.
 
         :param member: The member to get the permissions from
         :type member: Member

--- a/interactions/api/models/channel.py
+++ b/interactions/api/models/channel.py
@@ -1245,8 +1245,7 @@ class Channel(ClientSerializerMixin, IDMixin):
             permissions |= int(overwrite_everyone[0].allow)
 
         # Apply role specific overwrites
-        allow = 0
-        deny = 0
+        allow, deny = 0, 0
         for role_id in member.roles:
             overwrite_role = search_iterable(
                 self.permission_overwrites, lambda overwrite: int(overwrite.id) == int(role_id)
@@ -1256,9 +1255,9 @@ class Channel(ClientSerializerMixin, IDMixin):
                 deny |= int(overwrite_role[0].deny)
 
         if deny:
-            permissions &= ~int(deny)
+            permissions &= ~deny
         if allow:
-            permissions |= int(allow)
+            permissions |= allow
 
         # Apply member specific overwrites
         overwrite_member = search_iterable(

--- a/interactions/api/models/channel.py
+++ b/interactions/api/models/channel.py
@@ -11,6 +11,7 @@ from .attrs_utils import (
     define,
     field,
 )
+from .flags import Permissions, ALL_PERMISSIONS
 from .misc import File, IDMixin, Overwrite, Snowflake
 from .user import User
 from .webhook import Webhook
@@ -1206,6 +1207,57 @@ class Channel(ClientSerializerMixin, IDMixin):
             raise LibraryException(message="The Channel you specified is not a thread!", code=12)
 
         await self._client.join_thread(int(self.id))
+
+    async def get_permissions_for(self, member: "Member") -> Permissions:
+        """
+        Returns the permissions of the member in this specific channel.
+
+        .. note::
+            The permissions returned by this function take into account role and
+            user overwrites that can be assigned to channels or categories. If you
+            don't need these overwrites, look into `Member.get_guild_permissions()` function.
+
+        :param member: The member to get the permissions from
+        :type member: Member
+        :return: Permissions of the member in this channel
+        :rtype: Permissions
+        """
+        from .guild import Guild
+        guild = Guild(**await self._client.get_guild(int(self.guild_id)), _client=self._client)
+
+        permissions = await member.get_guild_permissions(guild)
+
+        if permissions & Permissions.ADMINISTRATOR == Permissions.ADMINISTRATOR:
+            return ALL_PERMISSIONS
+
+        # @everyone role overwrites
+        from ...client.models.utils import search_iterable
+        overwrite_everyone = search_iterable(self.permission_overwrites, lambda overwrite: int(overwrite.id) == int(self.guild_id))
+        if overwrite_everyone:
+            permissions &= ~int(overwrite_everyone[0].deny)
+            permissions |= int(overwrite_everyone[0].allow)
+
+        # Apply role specific overwrites
+        allow = 0
+        deny = 0
+        for role_id in member.roles:
+            overwrite_role = search_iterable(self.permission_overwrites, lambda overwrite: int(overwrite.id) == int(role_id))
+            if overwrite_role:
+                allow |= int(overwrite_role[0].allow)
+                deny |= int(overwrite_role[0].deny)
+
+        if deny:
+            permissions &= ~int(deny)
+        if allow:
+            permissions |= int(allow)
+
+        # Apply member specific overwrites
+        overwrite_member = search_iterable(self.permission_overwrites, lambda overwrite: int(overwrite.id) == int(member.id))
+        if overwrite_member:
+            permissions &= ~int(overwrite_member[0].deny)
+            permissions |= int(overwrite_member[0].allow)
+
+        return Permissions(permissions)
 
 
 @define()

--- a/interactions/api/models/channel.py
+++ b/interactions/api/models/channel.py
@@ -11,7 +11,7 @@ from .attrs_utils import (
     define,
     field,
 )
-from .flags import ALL_PERMISSIONS, Permissions
+from .flags import Permissions
 from .misc import File, IDMixin, Overwrite, Snowflake
 from .user import User
 from .webhook import Webhook
@@ -1229,7 +1229,7 @@ class Channel(ClientSerializerMixin, IDMixin):
         permissions = await member.get_guild_permissions(guild)
 
         if permissions & Permissions.ADMINISTRATOR == Permissions.ADMINISTRATOR:
-            return ALL_PERMISSIONS
+            return Permissions.ALL
 
         # @everyone role overwrites
         from ...client.models.utils import search_iterable

--- a/interactions/api/models/flags.py
+++ b/interactions/api/models/flags.py
@@ -1,6 +1,6 @@
 from enum import Enum, IntFlag
 
-__all__ = ("Intents", "AppFlags", "StatusType", "UserFlags", "Permissions", "ALL_PERMISSIONS")
+__all__ = ("Intents", "AppFlags", "StatusType", "UserFlags", "Permissions")
 
 
 class Intents(IntFlag):
@@ -93,10 +93,52 @@ class Permissions(IntFlag):
     START_EMBEDDED_ACTIVITIES = 1 << 39
     MODERATE_MEMBERS = 1 << 40
 
-
-ALL_PERMISSIONS = Permissions(0)
-for perm in Permissions:
-    ALL_PERMISSIONS |= perm
+    DEFAULT = (
+        ADD_REACTIONS
+        | VIEW_CHANNEL
+        | SEND_MESSAGES
+        | EMBED_LINKS
+        | ATTACH_FILES
+        | READ_MESSAGE_HISTORY
+        | MENTION_EVERYONE
+        | USE_EXTERNAL_EMOJIS
+    )
+    ALL = (
+        DEFAULT
+        | CREATE_INSTANT_INVITE
+        | KICK_MEMBERS
+        | BAN_MEMBERS
+        | ADMINISTRATOR
+        | MANAGE_CHANNELS
+        | MANAGE_GUILD
+        | VIEW_AUDIT_LOG
+        | PRIORITY_SPEAKER
+        | STREAM
+        | SEND_TTS_MESSAGES
+        | MANAGE_MESSAGES
+        | VIEW_GUILD_INSIGHTS
+        | CONNECT
+        | SPEAK
+        | MUTE_MEMBERS
+        | DEAFEN_MEMBERS
+        | MOVE_MEMBERS
+        | USE_VAD
+        | CHANGE_NICKNAME
+        | MANAGE_NICKNAMES
+        | MANAGE_ROLES
+        | MANAGE_WEBHOOKS
+        | MANAGE_EMOJIS_AND_STICKERS
+        | USE_APPLICATION_COMMANDS
+        | REQUEST_TO_SPEAK
+        | MANAGE_EVENTS
+        | MANAGE_THREADS
+        | CREATE_PUBLIC_THREADS
+        | CREATE_PRIVATE_THREADS
+        | USE_EXTERNAL_STICKERS
+        | SEND_MESSAGES_IN_THREADS
+        | START_EMBEDDED_ACTIVITIES
+        | MODERATE_MEMBERS
+    )
 
 
 class UserFlags(IntFlag):

--- a/interactions/api/models/flags.py
+++ b/interactions/api/models/flags.py
@@ -1,6 +1,6 @@
 from enum import Enum, IntFlag
 
-__all__ = ("Intents", "AppFlags", "StatusType", "UserFlags", "Permissions")
+__all__ = ("Intents", "AppFlags", "StatusType", "UserFlags", "Permissions", "ALL_PERMISSIONS")
 
 
 class Intents(IntFlag):
@@ -92,6 +92,11 @@ class Permissions(IntFlag):
     SEND_MESSAGES_IN_THREADS = 1 << 38
     START_EMBEDDED_ACTIVITIES = 1 << 39
     MODERATE_MEMBERS = 1 << 40
+
+
+ALL_PERMISSIONS = Permissions(0)
+for perm in Permissions:
+    ALL_PERMISSIONS |= perm
 
 
 class UserFlags(IntFlag):

--- a/interactions/api/models/member.py
+++ b/interactions/api/models/member.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, List, Optional, Union
 from ..error import LibraryException
 from .attrs_utils import MISSING, ClientSerializerMixin, convert_int, convert_list, define, field
 from .channel import Channel
-from .flags import Permissions, ALL_PERMISSIONS
+from .flags import ALL_PERMISSIONS, Permissions
 from .misc import File, IDMixin, Snowflake
 from .role import Role
 from .user import User

--- a/interactions/api/models/member.py
+++ b/interactions/api/models/member.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, List, Optional, Union
 from ..error import LibraryException
 from .attrs_utils import MISSING, ClientSerializerMixin, convert_int, convert_list, define, field
 from .channel import Channel
-from .flags import ALL_PERMISSIONS, Permissions
+from .flags import Permissions
 from .misc import File, IDMixin, Snowflake
 from .role import Role
 from .user import User
@@ -410,7 +410,7 @@ class Member(ClientSerializerMixin, IDMixin):
         :rtype: Permissions
         """
         if int(guild.owner_id) == int(self.id):
-            return ALL_PERMISSIONS
+            return Permissions.ALL
 
         role_everyone = await guild.get_role(int(guild.id))
         permissions = int(role_everyone.permissions)
@@ -420,6 +420,6 @@ class Member(ClientSerializerMixin, IDMixin):
             permissions |= int(role.permissions)
 
         if permissions & Permissions.ADMINISTRATOR == Permissions.ADMINISTRATOR:
-            return ALL_PERMISSIONS
+            return Permissions.ALL
 
         return Permissions(permissions)

--- a/interactions/api/models/member.py
+++ b/interactions/api/models/member.py
@@ -380,6 +380,7 @@ class Member(ClientSerializerMixin, IDMixin):
     def get_avatar_url(self, guild_id: Union[int, Snowflake, "Guild"]) -> Optional[str]:
         """
         Returns the URL of the member's avatar for the specified guild.
+
         :param guild_id: The id of the guild to get the member's avatar from
         :type guild_id: Union[int, Snowflake, "Guild"]
         :return: URL of the members's avatar (None will be returned if no avatar is set)
@@ -401,7 +402,7 @@ class Member(ClientSerializerMixin, IDMixin):
         .. note::
             The permissions returned by this function will not take into account role and
             user overwrites that can be assigned to channels or categories. If you need
-            these overwrites, look into `Channel.get_permissions_for()` function.
+            these overwrites, look into :meth:`.Channel.get_permissions_for`.
 
         :param guild: The guild of the member
         :type guild: Guild


### PR DESCRIPTION
## About

This pull request adds functions to calculate base permissions for a member, as well as calculate the member's permissions in a given channel, using permissions overwrites.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [x] New feature/enhancement
  - [ ] Bugfix
