### PR TITLE
fix: fix some bugs with cache

### DIFF
--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -429,7 +429,7 @@ class WebSocketClient:
                                 else Snowflake(_data["id"])
                             )
                         elif hasattr(obj, f"{model_name}_id"):
-                            id = getattr(obj, f"{model_name}_id")
+                            id = getattr(obj, f"{model_name}_id", None)
 
                 def __modify_guild_cache():
                     if not (

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -440,7 +440,6 @@ class WebSocketClient:
                     ):
                         return
                     if guild := self._http.cache[Guild].get(Snowflake(guild_id)):
-                        model_name: str = model.__name__.lower()
                         model_name: str = model.__name__
                         if "guild" in model_name:
                             model_name = model_name[5:]

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -417,12 +417,11 @@ class WebSocketClient:
                         "ChannelPins",
                         "MessageReaction",
                         "MessageReactionRemove",
-                        "GuildEmojis"
                         # Extend this for everything that should not be cached
                     ]:
                         id = None
                     elif model.__name__.startswith("Guild"):
-                        model_name = model.__name__[5:].lower()
+                        model_name = model.__name__[5:]
                         if _data := getattr(obj, model_name, None):
                             id = (
                                 getattr(_data, "id")
@@ -442,11 +441,12 @@ class WebSocketClient:
                         return
                     if guild := self._http.cache[Guild].get(Snowflake(guild_id)):
                         model_name: str = model.__name__.lower()
+                        model_name: str = model.__name__
                         if "guild" in model_name:
                             model_name = model_name[5:]
                         elif model_name == "threadmembers":
                             return
-                        _obj = getattr(guild, f"{model_name}s", None)
+                        _obj = getattr(guild, f"{model_name.lower()}s", None)
                         if _obj is not None and isinstance(_obj, list):
                             if "_create" in name or "_add" in name:
                                 _obj.append(obj)

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -430,8 +430,6 @@ class WebSocketClient:
                             )
                         elif hasattr(obj, f"{model_name}_id"):
                             id = getattr(obj, f"{model_name}_id")
-                        else:
-                            id = None
 
                 def __modify_guild_cache():
                     if not (

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -416,12 +416,13 @@ class WebSocketClient:
                         "GuildBan",
                         "ChannelPins",
                         "MessageReaction",
-                        "MessageReactionRemove"
+                        "MessageReactionRemove",
+                        "GuildEmojis"
                         # Extend this for everything that should not be cached
                     ]:
                         id = None
                     elif model.__name__.startswith("Guild"):
-                        model_name = model.__name__[5:]
+                        model_name = model.__name__[5:].lower()
                         if _data := getattr(obj, model_name, None):
                             id = (
                                 getattr(_data, "id")
@@ -440,12 +441,12 @@ class WebSocketClient:
                     ):
                         return
                     if guild := self._http.cache[Guild].get(Snowflake(guild_id)):
-                        model_name: str = model.__name__
+                        model_name: str = model.__name__.lower()
                         if "guild" in model_name:
                             model_name = model_name[5:]
                         elif model_name == "threadmembers":
                             return
-                        _obj = getattr(guild, f"{model_name.lower()}s", None)
+                        _obj = getattr(guild, f"{model_name}s", None)
                         if _obj is not None and isinstance(_obj, list):
                             if "_create" in name or "_add" in name:
                                 _obj.append(obj)

--- a/interactions/api/models/gw.py
+++ b/interactions/api/models/gw.py
@@ -38,7 +38,7 @@ __all__ = (
     "ChannelPins",
     "ThreadMembers",
     "ThreadList",
-    "ReactionRemove",
+    "MessageReactionRemove",
     "MessageReaction",
     "GuildIntegrations",
     "GuildBan",
@@ -762,7 +762,7 @@ class Presence(ClientSerializerMixin):
 @define()
 class MessageReaction(DictSerializerMixin):
     """
-    A class object representing the gateway event ``MESSAGE_REACTION_ADD``.
+    A class object representing the gateway event ``MESSAGE_REACTION_ADD`` and ``MESSAGE_REACTION_REMOVE``.
 
     :ivar Optional[Snowflake] user_id?: The user ID of the event.
     :ivar Snowflake channel_id: The channel ID of the event.
@@ -780,9 +780,9 @@ class MessageReaction(DictSerializerMixin):
     emoji: Optional[Emoji] = field(converter=Emoji, default=None)
 
 
-class ReactionRemove(MessageReaction):
+class MessageReactionRemove(MessageReaction):
     """
-    A class object representing the gateway events ``MESSAGE_REACTION_REMOVE``, ``MESSAGE_REACTION_REMOVE_ALL`` and ``MESSAGE_REACTION_REMOVE_EMOJI``.
+    A class object representing the gateway events ``MESSAGE_REACTION_REMOVE_ALL`` and ``MESSAGE_REACTION_REMOVE_EMOJI``.
 
     .. note::
         This class inherits the already existing attributes of :class:`interactions.api.models.gw.Reaction`.


### PR DESCRIPTION
## About

This pull request fixes these bugs:
- `An error occured dispatching channel_update: 'NoneType' object has no attribute 'id'`
- `on_message_update(before, after)` before always is None When you edit a message which not in cache
- Wrong getting id of models

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
