### PR TITLE
revert!: revert removed fixes for attrs

### DIFF
--- a/interactions/api/models/attrs_utils.py
+++ b/interactions/api/models/attrs_utils.py
@@ -50,10 +50,17 @@ class DictSerializerMixin:
                     if value is not None and attrib.metadata.get("add_client"):
                         if isinstance(value, list):
                             for item in value:
-                                item["_client"] = client
+                                if isinstance(item, dict):
+                                    item["_client"] = client
+                                elif isinstance(item, DictSerializerMixin):
+                                    item._client = client
                         else:
-                            value["_client"] = client
+                            if isinstance(value, dict):
+                                value["_client"] = client
+                            elif isinstance(value, DictSerializerMixin):
+                                value._client = client
 
+                    # make sure json is recursively handled
                     if isinstance(value, list):
                         self._json[attrib_name] = [
                             i._json if hasattr(i, "_json") else i for i in value

--- a/interactions/api/models/attrs_utils.py
+++ b/interactions/api/models/attrs_utils.py
@@ -63,9 +63,9 @@ class DictSerializerMixin:
                     # make sure json is recursively handled
                     if isinstance(value, list):
                         self._json[attrib_name] = [
-                            i._json if hasattr(i, "_json") else i for i in value
+                            i._json if isinstance(item, DictSerializerMixin) else i for i in value
                         ]
-                    elif hasattr(value, "_json"):
+                    elif isinstance(item, DictSerializerMixin):
                         self._json[attrib_name] = value._json  # type: ignore
 
                     passed_kwargs[attrib_name] = value

--- a/interactions/api/models/attrs_utils.py
+++ b/interactions/api/models/attrs_utils.py
@@ -54,6 +54,13 @@ class DictSerializerMixin:
                         else:
                             value["_client"] = client
 
+                    if isinstance(value, list):
+                        self._json[attrib_name] = [
+                            i._json if hasattr(i, "_json") else i for i in value
+                        ]
+                    elif hasattr(value, "_json"):
+                        self._json[attrib_name] = value._json  # type: ignore
+
                     passed_kwargs[attrib_name] = value
 
                 elif attrib.default:

--- a/interactions/api/models/attrs_utils.py
+++ b/interactions/api/models/attrs_utils.py
@@ -63,9 +63,9 @@ class DictSerializerMixin:
                     # make sure json is recursively handled
                     if isinstance(value, list):
                         self._json[attrib_name] = [
-                            i._json if isinstance(item, DictSerializerMixin) else i for i in value
+                            i._json if isinstance(i, DictSerializerMixin) else i for i in value
                         ]
-                    elif isinstance(item, DictSerializerMixin):
+                    elif isinstance(value, DictSerializerMixin):
                         self._json[attrib_name] = value._json  # type: ignore
 
                     passed_kwargs[attrib_name] = value


### PR DESCRIPTION
## About

This pull request partially reverts #948

PR #948 removes fixes which converts Models to json in the list (line 64)
Also it returns back Delta fix because ``TypeError 'Thread' object does not support item assignment``. It's similar for case with ``Role`` but ``Role`` was fixed in ``update`` method.

This pr does not reverts fix in ``update`` method and changes in `gateway/client.py`

## Checklist

- [ ] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues) (If existent):.
  - resolves #
- I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [x] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
