### PR TITLE
refactor: move ``Emoji`` to own module

### DIFF
--- a/interactions/api/http/emoji.py
+++ b/interactions/api/http/emoji.py
@@ -1,7 +1,8 @@
 from typing import List, Optional
 
 from ...api.cache import Cache
-from ...api.models.guild import Emoji, Guild
+from ...api.models.emoji import Emoji
+from ...api.models.guild import Guild
 from ...api.models.misc import Snowflake
 from .request import _Request
 from .route import Route

--- a/interactions/api/http/emoji.py
+++ b/interactions/api/http/emoji.py
@@ -1,9 +1,9 @@
 from typing import List, Optional
 
 from ...api.cache import Cache
-from ...api.models.emoji import Emoji
-from ...api.models.guild import Guild
-from ...api.models.misc import Snowflake
+from ..models.emoji import Emoji
+from ..models.guild import Guild
+from ..models.misc import Snowflake
 from .request import _Request
 from .route import Route
 

--- a/interactions/api/http/invite.py
+++ b/interactions/api/http/invite.py
@@ -4,7 +4,8 @@ from ...api.cache import Cache
 from .request import _Request
 from .route import Route
 
-__all__ = ("InviteRequest", )
+__all__ = ("InviteRequest",)
+
 
 class InviteRequest:
     _req = _Request

--- a/interactions/api/http/invite.py
+++ b/interactions/api/http/invite.py
@@ -4,8 +4,7 @@ from ...api.cache import Cache
 from .request import _Request
 from .route import Route
 
-__all__ = ["InviteRequest"]
-
+__all__ = ("InviteRequest", )
 
 class InviteRequest:
     _req = _Request

--- a/interactions/api/http/member.py
+++ b/interactions/api/http/member.py
@@ -1,9 +1,9 @@
 from typing import List, Optional
 
 from ...api.cache import Cache
-from ...api.models.guild import Guild
-from ...api.models.member import Member
-from ...api.models.misc import Snowflake
+from ..models.guild import Guild
+from ..models.member import Member
+from ..models.misc import Snowflake
 from .request import _Request
 from .route import Route
 

--- a/interactions/api/models/__init__.py
+++ b/interactions/api/models/__init__.py
@@ -8,6 +8,7 @@ models for dispatched Gateway events.
 from .attrs_utils import *  # noqa: F401 F403
 from .audit_log import *  # noqa: F401 F403
 from .channel import *  # noqa: F401 F403
+from .emoji import *  # noqa: F401 F403
 from .flags import *  # noqa: F401 F403
 from .guild import *  # noqa: F401 F403
 from .gw import *  # noqa: F401 F403

--- a/interactions/api/models/emoji.py
+++ b/interactions/api/models/emoji.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from ..http import HTTPClient
     from .guild import Guild
 
-__all__ = ["Emoji"]
+__all__ = ("Emoji", )
 
 
 @define()

--- a/interactions/api/models/emoji.py
+++ b/interactions/api/models/emoji.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from ..http import HTTPClient
     from .guild import Guild
 
-__all__ = ("Emoji", )
+__all__ = ("Emoji",)
 
 
 @define()

--- a/interactions/api/models/emoji.py
+++ b/interactions/api/models/emoji.py
@@ -1,12 +1,7 @@
 from typing import TYPE_CHECKING, List, Optional, Union
 
 from ..error import LibraryException
-from .attrs_utils import (
-    ClientSerializerMixin,
-    convert_list,
-    define,
-    field,
-)
+from .attrs_utils import ClientSerializerMixin, convert_list, define, field
 from .misc import Snowflake
 from .role import Role
 from .user import User

--- a/interactions/api/models/emoji.py
+++ b/interactions/api/models/emoji.py
@@ -1,0 +1,124 @@
+from typing import TYPE_CHECKING, List, Optional, Union
+
+from ..error import LibraryException
+from .attrs_utils import (
+    ClientSerializerMixin,
+    convert_list,
+    define,
+    field,
+)
+from .misc import Snowflake
+from .role import Role
+from .user import User
+
+if TYPE_CHECKING:
+    from ..http import HTTPClient
+    from .guild import Guild
+
+__all__ = ["Emoji"]
+
+
+@define()
+class Emoji(ClientSerializerMixin):
+    """
+    A class objecting representing an emoji.
+
+    :ivar Optional[Snowflake] id?: Emoji id
+    :ivar Optional[str] name?: Emoji name.
+    :ivar Optional[List[Role]] roles?: Roles allowed to use this emoji
+    :ivar Optional[User] user?: User that created this emoji
+    :ivar Optional[bool] require_colons?: Status denoting of this emoji must be wrapped in colons
+    :ivar Optional[bool] managed?: Status denoting if this emoji is managed (by an integration)
+    :ivar Optional[bool] animated?: Status denoting if this emoji is animated
+    :ivar Optional[bool] available?: Status denoting if this emoji can be used. (Can be false via server boosting)
+    """
+
+    id: Optional[Snowflake] = field(converter=Snowflake, default=None)
+    name: Optional[str] = field(default=None)
+    roles: Optional[List[Role]] = field(converter=convert_list(Role), default=None)
+    user: Optional[User] = field(converter=User, default=None)
+    require_colons: Optional[bool] = field(default=None)
+    managed: Optional[bool] = field(default=None)
+    animated: Optional[bool] = field(default=None)
+    available: Optional[bool] = field(default=None)
+
+    @classmethod
+    async def get(
+        cls,
+        guild_id: Union[int, Snowflake, "Guild"],
+        emoji_id: Union[int, Snowflake],
+        client: "HTTPClient",
+    ) -> "Emoji":
+        """
+        Gets an emoji.
+
+        :param guild_id: The id of the guild of the emoji
+        :type guild_id: Union[int, Snowflake, "Guild"]
+        :param emoji_id: The id of the emoji
+        :type emoji_id: Union[int, Snowflake]
+        :param client: The HTTPClient of your bot. Equals to ``bot._http``
+        :type client: HTTPClient
+        :return: The Emoji as object
+        :rtype: Emoji
+        """
+
+        _guild_id = int(guild_id) if isinstance(guild_id, (int, Snowflake)) else int(guild_id.id)
+
+        res = await client.get_guild_emoji(guild_id=_guild_id, emoji_id=int(emoji_id))
+        return cls(**res, _client=client)
+
+    @classmethod
+    async def get_all_of_guild(
+        cls,
+        guild_id: Union[int, Snowflake, "Guild"],
+        client: "HTTPClient",
+    ) -> List["Emoji"]:
+        """
+        Gets all emoji of a guild.
+
+        :param guild_id: The id of the guild to get the emojis of
+        :type guild_id: Union[int, Snowflake, "Guild"]
+        :param client: The HTTPClient of your bot. Equals to ``bot._http``
+        :type client: HTTPClient
+        :return: The Emoji as list
+        :rtype: List[Emoji]
+        """
+
+        _guild_id = int(guild_id) if isinstance(guild_id, (int, Snowflake)) else int(guild_id.id)
+
+        res = await client.get_all_emoji(guild_id=_guild_id)
+        return [cls(**emoji, _client=client) for emoji in res]
+
+    async def delete(
+        self,
+        guild_id: Union[int, Snowflake, "Guild"],
+        reason: Optional[str] = None,
+    ) -> None:
+        """
+        Deletes the emoji.
+
+        :param guild_id: The guild id to delete the emoji from
+        :type guild_id: Union[int, Snowflake, "Guild"]
+        :param reason?: The reason of the deletion
+        :type reason?: Optional[str]
+        """
+        if not self._client:
+            raise LibraryException(code=13)
+
+        _guild_id = int(guild_id) if isinstance(guild_id, (int, Snowflake)) else int(guild_id.id)
+
+        return await self._client.delete_guild_emoji(
+            guild_id=_guild_id, emoji_id=int(self.id), reason=reason
+        )
+
+    @property
+    def url(self) -> str:
+        """
+        Returns the emoji's URL.
+
+        :return: URL of the emoji
+        :rtype: str
+        """
+        url = f"https://cdn.discordapp.com/emojis/{self.id}"
+        url += ".gif" if self.animated else ".png"
+        return url

--- a/interactions/api/models/emoji.py
+++ b/interactions/api/models/emoji.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING, List, Optional, Union
 from ..error import LibraryException
 from .attrs_utils import ClientSerializerMixin, convert_list, define, field
 from .misc import Snowflake
-from .role import Role
 from .user import User
 
 if TYPE_CHECKING:

--- a/interactions/api/models/emoji.py
+++ b/interactions/api/models/emoji.py
@@ -20,7 +20,7 @@ class Emoji(ClientSerializerMixin):
 
     :ivar Optional[Snowflake] id?: Emoji id
     :ivar Optional[str] name?: Emoji name.
-    :ivar Optional[List[Role]] roles?: Roles allowed to use this emoji
+    :ivar Optional[List[int]] roles?: Roles allowed to use this emoji
     :ivar Optional[User] user?: User that created this emoji
     :ivar Optional[bool] require_colons?: Status denoting of this emoji must be wrapped in colons
     :ivar Optional[bool] managed?: Status denoting if this emoji is managed (by an integration)
@@ -30,7 +30,7 @@ class Emoji(ClientSerializerMixin):
 
     id: Optional[Snowflake] = field(converter=Snowflake, default=None)
     name: Optional[str] = field(default=None)
-    roles: Optional[List[Role]] = field(converter=convert_list(Role), default=None)
+    roles: Optional[List[int]] = field(converter=convert_list(int), default=None)
     user: Optional[User] = field(converter=User, default=None)
     require_colons: Optional[bool] = field(default=None)
     managed: Optional[bool] = field(default=None)

--- a/interactions/api/models/guild.py
+++ b/interactions/api/models/guild.py
@@ -13,8 +13,9 @@ from .attrs_utils import (
 )
 from .audit_log import AuditLogEvents, AuditLogs
 from .channel import Channel, ChannelType, Thread, ThreadMember
+from .emoji import Emoji
 from .member import Member
-from .message import Emoji, Sticker
+from .message import Sticker
 from .misc import (
     AutoModAction,
     AutoModTriggerMetadata,

--- a/interactions/api/models/gw.py
+++ b/interactions/api/models/gw.py
@@ -12,9 +12,10 @@ from .attrs_utils import (
     field,
 )
 from .channel import Channel, ThreadMember
+from .emoji import Emoji
 from .guild import EventMetadata
 from .member import Member
-from .message import Embed, Emoji, Message, MessageInteraction, Sticker
+from .message import Embed, Message, MessageInteraction, Sticker
 from .misc import (
     AutoModAction,
     AutoModTriggerMetadata,

--- a/interactions/api/models/message.py
+++ b/interactions/api/models/message.py
@@ -15,16 +15,15 @@ from .attrs_utils import (
     field,
 )
 from .channel import Channel
+from .emoji import Emoji
 from .member import Member
 from .misc import File, IDMixin, Snowflake
-from .role import Role
 from .team import Application
 from .user import User
 
 if TYPE_CHECKING:
     from ...client.models.component import ActionRow, Button, Component, SelectMenu
     from ..http import HTTPClient
-    from .guild import Guild
 
 __all__ = (
     "MessageType",
@@ -39,7 +38,6 @@ __all__ = (
     "EmbedImageStruct",
     "EmbedField",
     "Attachment",
-    "Emoji",
     "EmbedFooter",
     "ReactionObject",
     "PartialSticker",
@@ -186,112 +184,6 @@ class ChannelMention(DictSerializerMixin, IDMixin):
     guild_id: Snowflake = field(converter=Snowflake)
     type: int = field()  # Replace with enum from Channel Type, another PR
     name: str = field()
-
-
-@define()
-class Emoji(ClientSerializerMixin):
-    """
-    A class objecting representing an emoji.
-
-    :ivar Optional[Snowflake] id?: Emoji id
-    :ivar Optional[str] name?: Emoji name.
-    :ivar Optional[List[Role]] roles?: Roles allowed to use this emoji
-    :ivar Optional[User] user?: User that created this emoji
-    :ivar Optional[bool] require_colons?: Status denoting of this emoji must be wrapped in colons
-    :ivar Optional[bool] managed?: Status denoting if this emoji is managed (by an integration)
-    :ivar Optional[bool] animated?: Status denoting if this emoji is animated
-    :ivar Optional[bool] available?: Status denoting if this emoji can be used. (Can be false via server boosting)
-    """
-
-    id: Optional[Snowflake] = field(converter=Snowflake, default=None)
-    name: Optional[str] = field(default=None)
-    roles: Optional[List[Role]] = field(converter=convert_list(Role), default=None)
-    user: Optional[User] = field(converter=User, default=None)
-    require_colons: Optional[bool] = field(default=None)
-    managed: Optional[bool] = field(default=None)
-    animated: Optional[bool] = field(default=None)
-    available: Optional[bool] = field(default=None)
-
-    @classmethod
-    async def get(
-        cls,
-        guild_id: Union[int, Snowflake, "Guild"],
-        emoji_id: Union[int, Snowflake],
-        client: "HTTPClient",
-    ) -> "Emoji":
-        """
-        Gets an emoji.
-
-        :param guild_id: The id of the guild of the emoji
-        :type guild_id: Union[int, Snowflake, "Guild"]
-        :param emoji_id: The id of the emoji
-        :type emoji_id: Union[int, Snowflake]
-        :param client: The HTTPClient of your bot. Equals to ``bot._http``
-        :type client: HTTPClient
-        :return: The Emoji as object
-        :rtype: Emoji
-        """
-
-        _guild_id = int(guild_id) if isinstance(guild_id, (int, Snowflake)) else int(guild_id.id)
-
-        res = await client.get_guild_emoji(guild_id=_guild_id, emoji_id=int(emoji_id))
-        return cls(**res, _client=client)
-
-    @classmethod
-    async def get_all_of_guild(
-        cls,
-        guild_id: Union[int, Snowflake, "Guild"],
-        client: "HTTPClient",
-    ) -> List["Emoji"]:
-        """
-        Gets all emoji of a guild.
-
-        :param guild_id: The id of the guild to get the emojis of
-        :type guild_id: Union[int, Snowflake, "Guild"]
-        :param client: The HTTPClient of your bot. Equals to ``bot._http``
-        :type client: HTTPClient
-        :return: The Emoji as list
-        :rtype: List[Emoji]
-        """
-
-        _guild_id = int(guild_id) if isinstance(guild_id, (int, Snowflake)) else int(guild_id.id)
-
-        res = await client.get_all_emoji(guild_id=_guild_id)
-        return [cls(**emoji, _client=client) for emoji in res]
-
-    async def delete(
-        self,
-        guild_id: Union[int, Snowflake, "Guild"],
-        reason: Optional[str] = None,
-    ) -> None:
-        """
-        Deletes the emoji.
-
-        :param guild_id: The guild id to delete the emoji from
-        :type guild_id: Union[int, Snowflake, "Guild"]
-        :param reason?: The reason of the deletion
-        :type reason?: Optional[str]
-        """
-        if not self._client:
-            raise LibraryException(code=13)
-
-        _guild_id = int(guild_id) if isinstance(guild_id, (int, Snowflake)) else int(guild_id.id)
-
-        return await self._client.delete_guild_emoji(
-            guild_id=_guild_id, emoji_id=int(self.id), reason=reason
-        )
-
-    @property
-    def url(self) -> str:
-        """
-        Returns the emoji's URL.
-
-        :return: URL of the emoji
-        :rtype: str
-        """
-        url = f"https://cdn.discordapp.com/emojis/{self.id}"
-        url += ".gif" if self.animated else ".png"
-        return url
 
 
 @define()

--- a/interactions/api/models/presence.py
+++ b/interactions/api/models/presence.py
@@ -2,9 +2,9 @@ import time
 from enum import IntEnum
 from typing import Any, List, Optional
 
-from ..models import StatusType
-from ..models.message import Emoji
 from .attrs_utils import DictSerializerMixin, convert_list, define, field
+from .emoji import Emoji
+from .flags import StatusType
 from .misc import Snowflake
 
 __all__ = (

--- a/interactions/client/get.py
+++ b/interactions/client/get.py
@@ -14,9 +14,10 @@ from sys import version_info
 
 from ..api.error import LibraryException
 from ..api.http.client import HTTPClient
+from ..api.models.emoji import Emoji
 from ..api.models.guild import Guild
 from ..api.models.member import Member
-from ..api.models.message import Emoji, Message
+from ..api.models.message import Message
 from ..api.models.misc import Snowflake
 from ..api.models.role import Role
 from .bot import Client

--- a/interactions/client/get.pyi
+++ b/interactions/client/get.pyi
@@ -7,7 +7,8 @@ from ..api.http.client import HTTPClient
 from ..api.models.channel import Channel
 from ..api.models.guild import Guild
 from ..api.models.member import Member
-from ..api.models.message import Emoji, Message, Sticker
+from ..api.models.message import Message, Sticker
+from ..api.models.emoji import Emoji
 from ..api.models.role import Role
 from ..api.models.user import User
 from ..api.models.webhook import Webhook

--- a/interactions/client/models/component.py
+++ b/interactions/client/models/component.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Union
 
 from ...api.error import LibraryException
 from ...api.models.attrs_utils import MISSING, DictSerializerMixin, convert_list, define, field
-from ...api.models.message import Emoji
+from ...api.models.emoji import Emoji
 from ..enums import ButtonStyle, ComponentType, TextStyleType
 
 __all__ = (


### PR DESCRIPTION
## About

This pull request moves ``Emoji`` class to own ``emoji.py`` module.
It need to solve recursive imports between ``component.py`` and ``message.py``.
Also changes imports and brackets

**Additional:**
- Fixes error when converter tries convert str to ``Role`` obj

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues) (If existent):.
  - resolves #
- I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
