### PR TITLE
feat!: Add converters to components

### DIFF
--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -372,14 +372,12 @@ class WebSocketClient:
                 elif data["type"] == InteractionType.MODAL_SUBMIT:
                     _name = f"modal_{_context.data.custom_id}"
 
-                    if _context.data._json.get("components"):
+                    if _context.data.components:
                         for component in _context.data.components:
-                            if component.get("components"):
+                            if component.components:
                                 __args.append(
-                                    [_value["value"] for _value in component["components"]][0]
+                                    [_value.value for _value in component.components][0]
                                 )
-                            else:
-                                __args.append([_value.value for _value in component.components][0])
 
                     self._dispatch.dispatch("on_modal", _context)
 

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -375,9 +375,7 @@ class WebSocketClient:
                     if _context.data.components:
                         for component in _context.data.components:
                             if component.components:
-                                __args.append(
-                                    [_value.value for _value in component.components][0]
-                                )
+                                __args.append([_value.value for _value in component.components][0])
 
                     self._dispatch.dispatch("on_modal", _context)
 

--- a/interactions/api/models/message.py
+++ b/interactions/api/models/message.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from enum import IntEnum
 from typing import TYPE_CHECKING, List, Optional, Union
 
+from ...client.models.component import ActionRow, Button, SelectMenu
 from ..error import LibraryException
 from .attrs_utils import (
     MISSING,
@@ -22,7 +23,6 @@ from .team import Application
 from .user import User
 
 if TYPE_CHECKING:
-    from ...client.models.component import ActionRow, Button, Component, SelectMenu
     from ..http import HTTPClient
 
 __all__ = (
@@ -731,7 +731,7 @@ class Message(ClientSerializerMixin, IDMixin):
     :ivar int flags: Message flags
     :ivar Optional[MessageInteraction] interaction?: Message interaction object, if the message is sent by an interaction.
     :ivar Optional[Channel] thread?: The thread that started from this message, if any, with a thread member object embedded.
-    :ivar Optional[Union[Component, List[Component]]] components?: Components associated with this message, if any.
+    :ivar Optional[List[ActionRow]] components?: Array of Action Rows associated with this message, if any.
     :ivar Optional[List[PartialSticker]] sticker_items?: An array of message sticker item objects, if sent with them.
     :ivar Optional[List[Sticker]] stickers?: Array of sticker objects sent with the message if any. Deprecated.
     :ivar Optional[int] position?: The approximate position of the message in a thread.
@@ -775,7 +775,7 @@ class Message(ClientSerializerMixin, IDMixin):
     )
     thread: Optional[Channel] = field(converter=Channel, default=None, add_client=True)
 
-    components: Optional[Union["Component", List["Component"]]] = field(default=None)
+    components: Optional[List["ActionRow"]] = field(converter=convert_list(ActionRow), default=None)
     sticker_items: Optional[List[PartialSticker]] = field(
         converter=convert_list(PartialSticker), default=None
     )

--- a/interactions/client/models/misc.py
+++ b/interactions/client/models/misc.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 
 from ...api.models.attrs_utils import DictSerializerMixin, convert_dict, convert_list, define, field
 from ...api.models.channel import Channel
@@ -9,6 +9,7 @@ from ...api.models.role import Role
 from ...api.models.user import User
 from ..enums import ApplicationCommandType, ComponentType, InteractionType, PermissionType
 from ..models.command import Option
+from .component import ActionRow
 
 __all__ = ("InteractionResolvedData", "InteractionData", "Interaction")
 
@@ -68,7 +69,7 @@ class InteractionData(DictSerializerMixin):
     component_type: Optional[ComponentType] = field(converter=ComponentType, default=None)
     values: Optional[List[str]] = field(default=None)
     target_id: Optional[Snowflake] = field(converter=Snowflake, default=None)
-    components: Any = field(default=None)  # todo check this type
+    components: List[ActionRow] = field(converter=convert_list(ActionRow), default=None)
 
 
 @define()

--- a/interactions/client/models/misc.py
+++ b/interactions/client/models/misc.py
@@ -56,7 +56,7 @@ class InteractionData(DictSerializerMixin):
     :ivar Optional[ComponentType] component_type?: The type of component from the interaction.
     :ivar Optional[List[str]] values?: The values of the selected options in the interaction.
     :ivar Optional[str] target_id?: The targeted ID of the interaction.
-    :ivar Optional[List[ActionRow]]: Array of Action Rows in modal.
+    :ivar Optional[List[ActionRow]] components?: Array of Action Rows in modal.
     """
 
     id: Snowflake = field(converter=Snowflake, default=None)

--- a/interactions/client/models/misc.py
+++ b/interactions/client/models/misc.py
@@ -56,6 +56,7 @@ class InteractionData(DictSerializerMixin):
     :ivar Optional[ComponentType] component_type?: The type of component from the interaction.
     :ivar Optional[List[str]] values?: The values of the selected options in the interaction.
     :ivar Optional[str] target_id?: The targeted ID of the interaction.
+    :ivar Optional[List[ActionRow]]: Array of Action Rows in modal.
     """
 
     id: Snowflake = field(converter=Snowflake, default=None)
@@ -69,7 +70,7 @@ class InteractionData(DictSerializerMixin):
     component_type: Optional[ComponentType] = field(converter=ComponentType, default=None)
     values: Optional[List[str]] = field(default=None)
     target_id: Optional[Snowflake] = field(converter=Snowflake, default=None)
-    components: List[ActionRow] = field(converter=convert_list(ActionRow), default=None)
+    components: Optional[List[ActionRow]] = field(converter=convert_list(ActionRow), default=None)
 
 
 @define()


### PR DESCRIPTION
## About

This pull request adds missed converters to ``Message.components`` (due to circular import) and ``_Context.data.components`` (solve todo)

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues) (If existent):.
  - resolves #
- I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [x] Breaking change
  - [x] New feature/enhancement
  - [ ] Bugfix
