### PR TITLE
feat: Add support for message_delete_bulk event

### DIFF
--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -412,7 +412,8 @@ class WebSocketClient:
                         "GuildBan",
                         "ChannelPins",
                         "MessageReaction",
-                        "MessageReactionRemove",
+                        "MessageReactionRemove"
+                        "MessageDelete",
                         # Extend this for everything that should not be cached
                     ]:
                         id = None
@@ -487,6 +488,8 @@ class WebSocketClient:
                     if id:
                         old_obj = _cache.pop(id)
                         self._dispatch.dispatch(f"on_{name}", old_obj)
+                    elif "_delete_bulk" in name:
+                        self._dispatch.dispatch(f"on_{name}", obj)
 
                 else:
                     self._dispatch.dispatch(f"on_{name}", obj)

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -412,7 +412,7 @@ class WebSocketClient:
                         "GuildBan",
                         "ChannelPins",
                         "MessageReaction",
-                        "MessageReactionRemove"
+                        "MessageReactionRemove",
                         "MessageDelete",
                         # Extend this for everything that should not be cached
                     ]:

--- a/interactions/api/models/gw.py
+++ b/interactions/api/models/gw.py
@@ -39,6 +39,7 @@ __all__ = (
     "ChannelPins",
     "ThreadMembers",
     "ThreadList",
+    "MessageDelete",
     "MessageReactionRemove",
     "MessageReaction",
     "GuildIntegrations",
@@ -758,6 +759,21 @@ class Presence(ClientSerializerMixin):
     status: str = field()
     activities: List[PresenceActivity] = field(converter=convert_list(PresenceActivity))
     client_status: ClientStatus = field(converter=ClientStatus)
+
+
+@define()
+class MessageDelete(DictSerializerMixin):
+    """
+    A class object representing the gateway event ``MESSAGE_DELETE_BULK``.
+
+    :ivar List[Snowflake] ids: The message IDs of the event.
+    :ivar Snowflake channel_id: The channel ID of the event.
+    :ivar Optional[Snowflake] guild_id?: The guild ID of the event.
+    """
+
+    ids: List[Snowflake] = field(converter=convert_list(Snowflake))
+    channel_id: Snowflake = field(converter=Snowflake)
+    guild_id: Optional[Snowflake] = field(converter=Snowflake, default=None)
 
 
 @define()


### PR DESCRIPTION
## About

Previously, `MESSAGE_DELETE_BULK` event was not taken into account by the library as it did not have its proper class. This PR adds the class and makes sure that the event is well dispatched.
Please tell me if anything is missing, it's my first time working on the dispatcher source code.

## Checklist

- [ ] I've ran `pre-commit` to format and lint the change(s) made.
- [ ] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues) (If existent):.
  - resolves #
- I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [ ] Bugfix
