### PR TITLE
fix: add member's _client for message reactions

### DIFF
--- a/interactions/api/models/gw.py
+++ b/interactions/api/models/gw.py
@@ -777,7 +777,7 @@ class MessageDelete(DictSerializerMixin):
 
 
 @define()
-class MessageReaction(DictSerializerMixin):
+class MessageReaction(ClientSerializerMixin):
     """
     A class object representing the gateway event ``MESSAGE_REACTION_ADD`` and ``MESSAGE_REACTION_REMOVE``.
 
@@ -795,6 +795,9 @@ class MessageReaction(DictSerializerMixin):
     guild_id: Optional[Snowflake] = field(converter=Snowflake, default=None)
     member: Optional[Member] = field(converter=Member, default=None)
     emoji: Optional[Emoji] = field(converter=Emoji, default=None)
+
+    def __attrs_post_init__(self):
+        self.member._client = self._client
 
 
 class MessageReactionRemove(MessageReaction):

--- a/interactions/api/models/gw.py
+++ b/interactions/api/models/gw.py
@@ -793,11 +793,8 @@ class MessageReaction(ClientSerializerMixin):
     channel_id: Snowflake = field(converter=Snowflake)
     message_id: Snowflake = field(converter=Snowflake)
     guild_id: Optional[Snowflake] = field(converter=Snowflake, default=None)
-    member: Optional[Member] = field(converter=Member, default=None)
+    member: Optional[Member] = field(converter=Member, default=None, add_client=True)
     emoji: Optional[Emoji] = field(converter=Emoji, default=None)
-
-    def __attrs_post_init__(self):
-        self.member._client = self._client
 
 
 class MessageReactionRemove(MessageReaction):


### PR DESCRIPTION
## About

This pull request adds `_client` to the member attribute of a reaction object

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [ ] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues) (If existent):.
  - resolves #
- I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
