### PR TITLE
fix: remove bug with converting empty list to actionrow

### DIFF
--- a/interactions/client/models/component.py
+++ b/interactions/client/models/component.py
@@ -417,4 +417,4 @@ def _build_components(components) -> List[dict]:
     if _components:
         return _components
     else:
-        return __check_components()
+        return __check_components() if _components else _components

--- a/interactions/client/models/component.py
+++ b/interactions/client/models/component.py
@@ -411,6 +411,7 @@ def _build_components(components) -> List[dict]:
             raise LibraryException(
                 11, message="The specified components are invalid and could not be created!"
             )
+
     if not components:
         return components
 

--- a/interactions/client/models/component.py
+++ b/interactions/client/models/component.py
@@ -411,10 +411,12 @@ def _build_components(components) -> List[dict]:
             raise LibraryException(
                 11, message="The specified components are invalid and could not be created!"
             )
+    if not components:
+        return components
 
     _components = __check_action_row()
 
     if _components:
         return _components
     else:
-        return __check_components() if _components else _components
+        return __check_components()


### PR DESCRIPTION
## About

This pull request fixes bug which converts empty list to list with singe actionrow and then it raises error
```py
Invalid Form Body
Task exception was never retrieved
future: <Task finished name='Task-22' coro=<EmojiBoards.on_message_reaction_add() done, defined at C:\Users\User\OneDrive\python\discord bots\Asteroid\source\extensions\emoji_boards.py:26> exception=LibraryException('Invalid Form Body (code: 50035, severity 40)\nError at components.0.components: BASE_TYPE_REQUIRED - This field is required')>
Traceback (most recent call last):
  File "C:\Users\User\OneDrive\python\discord bots\Asteroid\source\extensions\emoji_boards.py", line 51, in on_message_reaction_add
    await self.__update_message(message, emoji_board, count)
  File "C:\Users\User\OneDrive\python\discord bots\Asteroid\source\extensions\emoji_boards.py", line 80, in __update_message
    await board_message.edit(f"{emoji_board.emoji} | {count}")
  File "d:\python_gh\library\interactions\api\models\message.py", line 929, in edit
    _dct = await self._client.edit_message(
  File "d:\python_gh\library\interactions\api\http\message.py", line 183, in edit_message
    return await self._req.request(
  File "d:\python_gh\library\interactions\api\http\request.py", line 174, in request
    raise LibraryException(
interactions.api.error.LibraryException: Invalid Form Body (code: 50035, severity 40)
Error at components.0.components: BASE_TYPE_REQUIRED - This field is required
```

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues) (If existent):.
  - resolves #
- I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
