### PR TITLE
fix: wrong sequence in getting channel overwrites

### DIFF
--- a/interactions/api/models/channel.py
+++ b/interactions/api/models/channel.py
@@ -363,11 +363,11 @@ class Channel(ClientSerializerMixin, IDMixin):
         )
         _nsfw = self.nsfw if nsfw is MISSING else nsfw
         _permission_overwrites = (
-            [overwrite._json for overwrite in self.permission_overwrites]
+            [overwrite._json for overwrite in permission_overwrites]
+            if permission_overwrites is not MISSING
+            else [overwrite._json for overwrite in self.permission_overwrites]
             if self.permission_overwrites
             else None
-            if permission_overwrites is MISSING
-            else [overwrite._json for overwrite in permission_overwrites]
         )
         _type = self.type
 


### PR DESCRIPTION
## About

This pull request fixes bug with wrong sequence of processing channel `permission_overwrites`

## Checklist

- [ ] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues) (If existent):.
  - resolves #
- I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
