### PR TITLE
fix: Remove empty _client attribute in _json property

### DIFF
--- a/interactions/api/models/attrs_utils.py
+++ b/interactions/api/models/attrs_utils.py
@@ -48,17 +48,18 @@ class DictSerializerMixin:
 
                 if (value := kwargs.pop(discord_name, MISSING)) is not MISSING:
                     if value is not None and attrib.metadata.get("add_client"):
-                        if isinstance(value, list):
-                            for item in value:
-                                if isinstance(item, dict):
-                                    item["_client"] = client
-                                elif isinstance(item, DictSerializerMixin):
-                                    item._client = client
-                        else:
-                            if isinstance(value, dict):
-                                value["_client"] = client
-                            elif isinstance(value, DictSerializerMixin):
-                                value._client = client
+                        if client is not None:
+                            if isinstance(value, list):
+                                for item in value:
+                                    if isinstance(item, dict):
+                                        item["_client"] = client
+                                    elif isinstance(item, DictSerializerMixin):
+                                        item._client = client
+                            else:
+                                if isinstance(value, dict):
+                                    value["_client"] = client
+                                elif isinstance(value, DictSerializerMixin):
+                                    value._client = client
 
                     # make sure json is recursively handled
                     if isinstance(value, list):

--- a/interactions/api/models/attrs_utils.py
+++ b/interactions/api/models/attrs_utils.py
@@ -47,19 +47,22 @@ class DictSerializerMixin:
                     discord_name = attrib_name
 
                 if (value := kwargs.pop(discord_name, MISSING)) is not MISSING:
-                    if value is not None and attrib.metadata.get("add_client"):
-                        if client is not None:
-                            if isinstance(value, list):
-                                for item in value:
-                                    if isinstance(item, dict):
-                                        item["_client"] = client
-                                    elif isinstance(item, DictSerializerMixin):
-                                        item._client = client
-                            else:
-                                if isinstance(value, dict):
-                                    value["_client"] = client
-                                elif isinstance(value, DictSerializerMixin):
-                                    value._client = client
+                    if (
+                        value is not None
+                        and attrib.metadata.get("add_client")
+                        and client is not None
+                    ):
+                        if isinstance(value, list):
+                            for item in value:
+                                if isinstance(item, dict):
+                                    item["_client"] = client
+                                elif isinstance(item, DictSerializerMixin):
+                                    item._client = client
+                        else:
+                            if isinstance(value, dict):
+                                value["_client"] = client
+                            elif isinstance(value, DictSerializerMixin):
+                                value._client = client
 
                     # make sure json is recursively handled
                     if isinstance(value, list):


### PR DESCRIPTION
## About

This pull request removes the `_client` attribute in `_json` (and also subsequently does not add the attribute regularly) when it's None.

## Checklist

- [X] I've ran `pre-commit` to format and lint the change(s) made.
- [X] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues) (If existent):.
  - resolves #
- I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [X] Bugfix
