### PR TITLE
feat: Implement ``AllowedMentions`` object

### DIFF
--- a/interactions/api/http/message.py
+++ b/interactions/api/http/message.py
@@ -4,8 +4,8 @@ from aiohttp import MultipartWriter
 
 from ...api.cache import Cache
 from ..models.attrs_utils import MISSING
-from ..models.message import Embed, Message, MessageInteraction, Sticker
-from ..models.misc import File, Snowflake, AllowedMentions
+from ..models.message import Embed, Message, Sticker
+from ..models.misc import AllowedMentions, File, Snowflake
 from .request import _Request
 from .route import Route
 

--- a/interactions/api/http/message.py
+++ b/interactions/api/http/message.py
@@ -26,7 +26,7 @@ class MessageRequest:
         tts: bool = False,
         embeds: Optional[List[Embed]] = None,
         nonce: Union[int, str] = None,
-        allowed_mentions: Optional[AllowedMentions] = None,
+        allowed_mentions: Optional[Union[AllowedMentions, dict]] = None,
         message_reference: Optional[Message] = None,
         stickers: Optional[List[Sticker]] = None,
     ) -> dict:
@@ -49,7 +49,7 @@ class MessageRequest:
             payload["nonce"] = nonce
 
         if allowed_mentions:
-            payload["allowed_mentions"] = allowed_mentions._json
+            payload["allowed_mentions"] = allowed_mentions._json if isinstance(allowed_mentions, AllowedMentions) else allowed_mentions
 
         if message_reference:
             payload["message_reference"] = message_reference

--- a/interactions/api/http/message.py
+++ b/interactions/api/http/message.py
@@ -49,7 +49,11 @@ class MessageRequest:
             payload["nonce"] = nonce
 
         if allowed_mentions:
-            payload["allowed_mentions"] = allowed_mentions._json if isinstance(allowed_mentions, AllowedMentions) else allowed_mentions
+            payload["allowed_mentions"] = (
+                allowed_mentions._json
+                if isinstance(allowed_mentions, AllowedMentions)
+                else allowed_mentions
+            )
 
         if message_reference:
             payload["message_reference"] = message_reference

--- a/interactions/api/http/message.py
+++ b/interactions/api/http/message.py
@@ -5,7 +5,7 @@ from aiohttp import MultipartWriter
 from ...api.cache import Cache
 from ..models.attrs_utils import MISSING
 from ..models.message import Embed, Message, MessageInteraction, Sticker
-from ..models.misc import File, Snowflake
+from ..models.misc import File, Snowflake, AllowedMentions
 from .request import _Request
 from .route import Route
 
@@ -26,7 +26,7 @@ class MessageRequest:
         tts: bool = False,
         embeds: Optional[List[Embed]] = None,
         nonce: Union[int, str] = None,
-        allowed_mentions: Optional[MessageInteraction] = None,  # don't know type
+        allowed_mentions: Optional[AllowedMentions] = None,
         message_reference: Optional[Message] = None,
         stickers: Optional[List[Sticker]] = None,
     ) -> dict:
@@ -49,7 +49,7 @@ class MessageRequest:
             payload["nonce"] = nonce
 
         if allowed_mentions:
-            payload["allowed_mentions"] = allowed_mentions
+            payload["allowed_mentions"] = allowed_mentions._json
 
         if message_reference:
             payload["message_reference"] = message_reference

--- a/interactions/api/models/channel.py
+++ b/interactions/api/models/channel.py
@@ -12,7 +12,7 @@ from .attrs_utils import (
     field,
 )
 from .flags import Permissions
-from .misc import File, IDMixin, Overwrite, Snowflake
+from .misc import File, IDMixin, Overwrite, Snowflake, AllowedMentions
 from .user import User
 from .webhook import Webhook
 
@@ -198,7 +198,7 @@ class Channel(ClientSerializerMixin, IDMixin):
         attachments: Optional[List["Attachment"]] = MISSING,
         files: Optional[Union[File, List[File]]] = MISSING,
         embeds: Optional[Union["Embed", List["Embed"]]] = MISSING,
-        allowed_mentions: Optional["MessageInteraction"] = MISSING,
+        allowed_mentions: Optional[AllowedMentions] = MISSING,
         stickers: Optional[List["Sticker"]] = MISSING,
         components: Optional[
             Union[
@@ -224,8 +224,8 @@ class Channel(ClientSerializerMixin, IDMixin):
         :type attachments?: Optional[List[Attachment]]
         :param embeds?: An embed, or list of embeds for the message.
         :type embeds?: Optional[Union[Embed, List[Embed]]]
-        :param allowed_mentions?: The message interactions/mention limits that the message can refer to.
-        :type allowed_mentions?: Optional[MessageInteraction]
+        :param allowed_mentions?: The allowed mentions for the message.
+        :type allowed_mentions?: Optional[AllowedMentions]
         :param stickers?: A list of stickers to send with your message. You can send up to 3 stickers per message.
         :type stickers?: Optional[List[Sticker]]
         :param components?: A component, or list of components for the message.
@@ -241,7 +241,7 @@ class Channel(ClientSerializerMixin, IDMixin):
         _content: str = "" if content is MISSING else content
         _tts: bool = False if tts is MISSING else tts
         _attachments = [] if attachments is MISSING else [a._json for a in attachments]
-        _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions
+        _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions._json
         _sticker_ids: list = (
             [] if stickers is MISSING else [str(sticker.id) for sticker in stickers]
         )

--- a/interactions/api/models/channel.py
+++ b/interactions/api/models/channel.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from ...client.models.component import ActionRow, Button, SelectMenu
     from .guild import Invite, InviteTargetType
     from .member import Member
-    from .message import Attachment, Embed, Message, MessageInteraction, Sticker
+    from .message import Attachment, Embed, Message, Sticker
 
 __all__ = (
     "ChannelType",

--- a/interactions/api/models/channel.py
+++ b/interactions/api/models/channel.py
@@ -198,7 +198,7 @@ class Channel(ClientSerializerMixin, IDMixin):
         attachments: Optional[List["Attachment"]] = MISSING,
         files: Optional[Union[File, List[File]]] = MISSING,
         embeds: Optional[Union["Embed", List["Embed"]]] = MISSING,
-        allowed_mentions: Optional[AllowedMentions] = MISSING,
+        allowed_mentions: Optional[Union[AllowedMentions, dict]] = MISSING,
         stickers: Optional[List["Sticker"]] = MISSING,
         components: Optional[
             Union[
@@ -225,7 +225,7 @@ class Channel(ClientSerializerMixin, IDMixin):
         :param embeds?: An embed, or list of embeds for the message.
         :type embeds?: Optional[Union[Embed, List[Embed]]]
         :param allowed_mentions?: The allowed mentions for the message.
-        :type allowed_mentions?: Optional[AllowedMentions]
+        :type allowed_mentions?: Optional[Union[AllowedMentions, dict]]
         :param stickers?: A list of stickers to send with your message. You can send up to 3 stickers per message.
         :type stickers?: Optional[List[Sticker]]
         :param components?: A component, or list of components for the message.
@@ -241,7 +241,7 @@ class Channel(ClientSerializerMixin, IDMixin):
         _content: str = "" if content is MISSING else content
         _tts: bool = False if tts is MISSING else tts
         _attachments = [] if attachments is MISSING else [a._json for a in attachments]
-        _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions._json
+        _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions._json if isinstance(allowed_mentions, AllowedMentions) else allowed_mentions
         _sticker_ids: list = (
             [] if stickers is MISSING else [str(sticker.id) for sticker in stickers]
         )

--- a/interactions/api/models/channel.py
+++ b/interactions/api/models/channel.py
@@ -12,7 +12,7 @@ from .attrs_utils import (
     field,
 )
 from .flags import Permissions
-from .misc import File, IDMixin, Overwrite, Snowflake, AllowedMentions
+from .misc import AllowedMentions, File, IDMixin, Overwrite, Snowflake
 from .user import User
 from .webhook import Webhook
 
@@ -241,7 +241,13 @@ class Channel(ClientSerializerMixin, IDMixin):
         _content: str = "" if content is MISSING else content
         _tts: bool = False if tts is MISSING else tts
         _attachments = [] if attachments is MISSING else [a._json for a in attachments]
-        _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions._json if isinstance(allowed_mentions, AllowedMentions) else allowed_mentions
+        _allowed_mentions: dict = (
+            {}
+            if allowed_mentions is MISSING
+            else allowed_mentions._json
+            if isinstance(allowed_mentions, AllowedMentions)
+            else allowed_mentions
+        )
         _sticker_ids: list = (
             [] if stickers is MISSING else [str(sticker.id) for sticker in stickers]
         )

--- a/interactions/api/models/gw.py
+++ b/interactions/api/models/gw.py
@@ -17,6 +17,7 @@ from .guild import EventMetadata
 from .member import Member
 from .message import Embed, Message, Sticker
 from .misc import (
+    AllowedMentions,
     AutoModAction,
     AutoModTriggerMetadata,
     AutoModTriggerType,
@@ -24,7 +25,6 @@ from .misc import (
     File,
     IDMixin,
     Snowflake,
-    AllowedMentions
 )
 from .presence import PresenceActivity
 from .role import Role

--- a/interactions/api/models/gw.py
+++ b/interactions/api/models/gw.py
@@ -15,7 +15,7 @@ from .channel import Channel, ThreadMember
 from .emoji import Emoji
 from .guild import EventMetadata
 from .member import Member
-from .message import Embed, Message, MessageInteraction, Sticker
+from .message import Embed, Message, Sticker
 from .misc import (
     AutoModAction,
     AutoModTriggerMetadata,
@@ -24,6 +24,7 @@ from .misc import (
     File,
     IDMixin,
     Snowflake,
+    AllowedMentions
 )
 from .presence import PresenceActivity
 from .role import Role
@@ -417,7 +418,7 @@ class GuildMember(ClientSerializerMixin):
         tts: Optional[bool] = MISSING,
         files: Optional[Union[File, List[File]]] = MISSING,
         embeds: Optional[Union[Embed, List[Embed]]] = MISSING,
-        allowed_mentions: Optional[MessageInteraction] = MISSING,
+        allowed_mentions: Optional[AllowedMentions] = MISSING,
     ) -> Message:
         """
         Sends a DM to the member.
@@ -432,8 +433,8 @@ class GuildMember(ClientSerializerMixin):
         :type files?: Optional[Union[File, List[File]]]
         :param embeds?: An embed, or list of embeds for the message.
         :type embeds?: Optional[Union[Embed, List[Embed]]]
-        :param allowed_mentions?: The message interactions/mention limits that the message can refer to.
-        :type allowed_mentions?: Optional[MessageInteraction]
+        :param allowed_mentions?: The allowed mentions for the message.
+        :type allowed_mentions?: Optional[AllowedMentions]
         :return: The sent message as an object.
         :rtype: Message
         """
@@ -449,7 +450,7 @@ class GuildMember(ClientSerializerMixin):
             if not embeds or embeds is MISSING
             else ([embed._json for embed in embeds] if isinstance(embeds, list) else [embeds._json])
         )
-        _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions
+        _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions._json
         if not components or components is MISSING:
             _components = []
         else:

--- a/interactions/api/models/gw.py
+++ b/interactions/api/models/gw.py
@@ -418,7 +418,7 @@ class GuildMember(ClientSerializerMixin):
         tts: Optional[bool] = MISSING,
         files: Optional[Union[File, List[File]]] = MISSING,
         embeds: Optional[Union[Embed, List[Embed]]] = MISSING,
-        allowed_mentions: Optional[AllowedMentions] = MISSING,
+        allowed_mentions: Optional[Union[AllowedMentions, dict]] = MISSING,
     ) -> Message:
         """
         Sends a DM to the member.
@@ -434,7 +434,7 @@ class GuildMember(ClientSerializerMixin):
         :param embeds?: An embed, or list of embeds for the message.
         :type embeds?: Optional[Union[Embed, List[Embed]]]
         :param allowed_mentions?: The allowed mentions for the message.
-        :type allowed_mentions?: Optional[AllowedMentions]
+        :type allowed_mentions?: Optional[Union[AllowedMentions, dict]]
         :return: The sent message as an object.
         :rtype: Message
         """
@@ -450,7 +450,7 @@ class GuildMember(ClientSerializerMixin):
             if not embeds or embeds is MISSING
             else ([embed._json for embed in embeds] if isinstance(embeds, list) else [embeds._json])
         )
-        _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions._json
+        _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions._json if isinstance(allowed_mentions, AllowedMentions) else allowed_mentions
         if not components or components is MISSING:
             _components = []
         else:

--- a/interactions/api/models/gw.py
+++ b/interactions/api/models/gw.py
@@ -450,7 +450,13 @@ class GuildMember(ClientSerializerMixin):
             if not embeds or embeds is MISSING
             else ([embed._json for embed in embeds] if isinstance(embeds, list) else [embeds._json])
         )
-        _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions._json if isinstance(allowed_mentions, AllowedMentions) else allowed_mentions
+        _allowed_mentions: dict = (
+            {}
+            if allowed_mentions is MISSING
+            else allowed_mentions._json
+            if isinstance(allowed_mentions, AllowedMentions)
+            else allowed_mentions
+        )
         if not components or components is MISSING:
             _components = []
         else:

--- a/interactions/api/models/member.py
+++ b/interactions/api/models/member.py
@@ -257,7 +257,13 @@ class Member(ClientSerializerMixin, IDMixin):
             if not embeds or embeds is MISSING
             else ([embed._json for embed in embeds] if isinstance(embeds, list) else [embeds._json])
         )
-        _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions._json if isinstance(allowed_mentions, AllowedMentions) else allowed_mentions
+        _allowed_mentions: dict = (
+            {}
+            if allowed_mentions is MISSING
+            else allowed_mentions._json
+            if isinstance(allowed_mentions, AllowedMentions)
+            else allowed_mentions
+        )
         if not components or components is MISSING:
             _components = []
         else:

--- a/interactions/api/models/member.py
+++ b/interactions/api/models/member.py
@@ -5,14 +5,14 @@ from ..error import LibraryException
 from .attrs_utils import MISSING, ClientSerializerMixin, convert_int, convert_list, define, field
 from .channel import Channel
 from .flags import Permissions
-from .misc import File, IDMixin, Snowflake
+from .misc import File, IDMixin, Snowflake, AllowedMentions
 from .role import Role
 from .user import User
 
 if TYPE_CHECKING:
     from ...client.models.component import ActionRow, Button, SelectMenu
     from .guild import Guild
-    from .message import Attachment, Embed, Message, MessageInteraction
+    from .message import Attachment, Embed, Message
 
 __all__ = ("Member",)
 
@@ -222,7 +222,7 @@ class Member(ClientSerializerMixin, IDMixin):
         attachments: Optional[List["Attachment"]] = MISSING,
         files: Optional[Union[File, List[File]]] = MISSING,
         embeds: Optional[Union["Embed", List["Embed"]]] = MISSING,
-        allowed_mentions: Optional["MessageInteraction"] = MISSING,
+        allowed_mentions: Optional[AllowedMentions] = MISSING,
     ) -> "Message":
         """
         Sends a DM to the member.
@@ -239,8 +239,8 @@ class Member(ClientSerializerMixin, IDMixin):
         :type files?: Optional[Union[File, List[File]]]
         :param embeds?: An embed, or list of embeds for the message.
         :type embeds?: Optional[Union[Embed, List[Embed]]]
-        :param allowed_mentions?: The message interactions/mention limits that the message can refer to.
-        :type allowed_mentions?: Optional[MessageInteraction]
+        :param allowed_mentions?: The allowed mentions for the message.
+        :type allowed_mentions?: Optional[AllowedMentions]
         :return: The sent message as an object.
         :rtype: Message
         """
@@ -257,7 +257,7 @@ class Member(ClientSerializerMixin, IDMixin):
             if not embeds or embeds is MISSING
             else ([embed._json for embed in embeds] if isinstance(embeds, list) else [embeds._json])
         )
-        _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions
+        _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions._json
         if not components or components is MISSING:
             _components = []
         else:

--- a/interactions/api/models/member.py
+++ b/interactions/api/models/member.py
@@ -5,7 +5,7 @@ from ..error import LibraryException
 from .attrs_utils import MISSING, ClientSerializerMixin, convert_int, convert_list, define, field
 from .channel import Channel
 from .flags import Permissions
-from .misc import File, IDMixin, Snowflake, AllowedMentions
+from .misc import AllowedMentions, File, IDMixin, Snowflake
 from .role import Role
 from .user import User
 

--- a/interactions/api/models/member.py
+++ b/interactions/api/models/member.py
@@ -222,7 +222,7 @@ class Member(ClientSerializerMixin, IDMixin):
         attachments: Optional[List["Attachment"]] = MISSING,
         files: Optional[Union[File, List[File]]] = MISSING,
         embeds: Optional[Union["Embed", List["Embed"]]] = MISSING,
-        allowed_mentions: Optional[AllowedMentions] = MISSING,
+        allowed_mentions: Optional[Union[AllowedMentions, dict]] = MISSING,
     ) -> "Message":
         """
         Sends a DM to the member.
@@ -240,7 +240,7 @@ class Member(ClientSerializerMixin, IDMixin):
         :param embeds?: An embed, or list of embeds for the message.
         :type embeds?: Optional[Union[Embed, List[Embed]]]
         :param allowed_mentions?: The allowed mentions for the message.
-        :type allowed_mentions?: Optional[AllowedMentions]
+        :type allowed_mentions?: Optional[Union[AllowedMentions, dict]]
         :return: The sent message as an object.
         :rtype: Message
         """
@@ -257,7 +257,7 @@ class Member(ClientSerializerMixin, IDMixin):
             if not embeds or embeds is MISSING
             else ([embed._json for embed in embeds] if isinstance(embeds, list) else [embeds._json])
         )
-        _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions._json
+        _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions._json if isinstance(allowed_mentions, AllowedMentions) else allowed_mentions
         if not components or components is MISSING:
             _components = []
         else:

--- a/interactions/api/models/message.py
+++ b/interactions/api/models/message.py
@@ -19,7 +19,7 @@ from .attrs_utils import (
 from .channel import Channel
 from .emoji import Emoji
 from .member import Member
-from .misc import File, IDMixin, Snowflake, AllowedMentions
+from .misc import AllowedMentions, File, IDMixin, Snowflake
 from .team import Application
 from .user import User
 

--- a/interactions/api/models/message.py
+++ b/interactions/api/models/message.py
@@ -921,7 +921,13 @@ class Message(ClientSerializerMixin, IDMixin):
             else []
         )
 
-        _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions._json if isinstance(allowed_mentions, AllowedMentions) else allowed_mentions
+        _allowed_mentions: dict = (
+            {}
+            if allowed_mentions is MISSING
+            else allowed_mentions._json
+            if isinstance(allowed_mentions, AllowedMentions)
+            else allowed_mentions
+        )
         _message_reference: dict = {} if message_reference is MISSING else message_reference._json
         if not components:
             _components = []
@@ -1008,7 +1014,13 @@ class Message(ClientSerializerMixin, IDMixin):
             if not embeds or embeds is MISSING
             else ([embed._json for embed in embeds] if isinstance(embeds, list) else [embeds._json])
         )
-        _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions._json if isinstance(allowed_mentions, AllowedMentions) else allowed_mentions
+        _allowed_mentions: dict = (
+            {}
+            if allowed_mentions is MISSING
+            else allowed_mentions._json
+            if isinstance(allowed_mentions, AllowedMentions)
+            else allowed_mentions
+        )
         _message_reference = MessageReference(message_id=int(self.id))._json
         _attachments = [] if attachments is MISSING else [a._json for a in attachments]
         if not components or components is MISSING:

--- a/interactions/api/models/message.py
+++ b/interactions/api/models/message.py
@@ -845,7 +845,7 @@ class Message(ClientSerializerMixin, IDMixin):
         files: Optional[Union[File, List[File]]] = MISSING,
         embeds: Optional[Union["Embed", List["Embed"]]] = MISSING,
         suppress_embeds: Optional[bool] = MISSING,
-        allowed_mentions: Optional[AllowedMentions] = MISSING,
+        allowed_mentions: Optional[Union[AllowedMentions, dict]] = MISSING,
         message_reference: Optional[MessageReference] = MISSING,
         attachments: Optional[List["Attachment"]] = MISSING,
         components: Optional[
@@ -873,7 +873,7 @@ class Message(ClientSerializerMixin, IDMixin):
         :param suppress_embeds?: Whether to suppress embeds in the message.
         :type suppress_embeds?: Optional[bool]
         :param allowed_mentions?: The allowed mentions for the message.
-        :type allowed_mentions?: Optional[AllowedMentions]
+        :type allowed_mentions?: Optional[Union[AllowedMentions, dict]]
         :param attachments?: The attachments to attach to the message. Needs to be uploaded to the CDN first
         :type attachments?: Optional[List[Attachment]]
         :param components?: A component, or list of components for the message. If `[]` the components will be removed
@@ -921,7 +921,7 @@ class Message(ClientSerializerMixin, IDMixin):
             else []
         )
 
-        _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions._json
+        _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions._json if isinstance(allowed_mentions, AllowedMentions) else allowed_mentions
         _message_reference: dict = {} if message_reference is MISSING else message_reference._json
         if not components:
             _components = []
@@ -960,7 +960,7 @@ class Message(ClientSerializerMixin, IDMixin):
         embeds: Optional[Union["Embed", List["Embed"]]] = MISSING,
         files: Optional[Union[File, List[File]]] = MISSING,
         attachments: Optional[List["Attachment"]] = MISSING,
-        allowed_mentions: Optional[AllowedMentions] = MISSING,
+        allowed_mentions: Optional[Union[AllowedMentions, dict]] = MISSING,
         stickers: Optional[List["Sticker"]] = MISSING,
         components: Optional[
             Union[
@@ -987,7 +987,7 @@ class Message(ClientSerializerMixin, IDMixin):
         :param embeds?: An embed, or list of embeds for the message.
         :type embeds?: Optional[Union[Embed, List[Embed]]]
         :param allowed_mentions?: The allowed mentions for the message.
-        :type allowed_mentions?: Optional[AllowedMentions]
+        :type allowed_mentions?: Optional[Union[AllowedMentions, dict]]
         :param components?: A component, or list of components for the message.
         :type components?: Optional[Union[ActionRow, Button, SelectMenu, List[ActionRow], List[Button], List[SelectMenu]]]
         :param stickers?: A list of stickers to send with your message. You can send up to 3 stickers per message.
@@ -1008,7 +1008,7 @@ class Message(ClientSerializerMixin, IDMixin):
             if not embeds or embeds is MISSING
             else ([embed._json for embed in embeds] if isinstance(embeds, list) else [embeds._json])
         )
-        _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions._json
+        _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions._json if isinstance(allowed_mentions, AllowedMentions) else allowed_mentions
         _message_reference = MessageReference(message_id=int(self.id))._json
         _attachments = [] if attachments is MISSING else [a._json for a in attachments]
         if not components or components is MISSING:

--- a/interactions/api/models/message.py
+++ b/interactions/api/models/message.py
@@ -19,7 +19,7 @@ from .attrs_utils import (
 from .channel import Channel
 from .emoji import Emoji
 from .member import Member
-from .misc import File, IDMixin, Snowflake
+from .misc import File, IDMixin, Snowflake, AllowedMentions
 from .team import Application
 from .user import User
 
@@ -846,7 +846,7 @@ class Message(ClientSerializerMixin, IDMixin):
         files: Optional[Union[File, List[File]]] = MISSING,
         embeds: Optional[Union["Embed", List["Embed"]]] = MISSING,
         suppress_embeds: Optional[bool] = MISSING,
-        allowed_mentions: Optional["MessageInteraction"] = MISSING,
+        allowed_mentions: Optional[AllowedMentions] = MISSING,
         message_reference: Optional[MessageReference] = MISSING,
         attachments: Optional[List["Attachment"]] = MISSING,
         components: Optional[
@@ -873,8 +873,8 @@ class Message(ClientSerializerMixin, IDMixin):
         :type embeds?: Optional[Union[Embed, List[Embed]]]
         :param suppress_embeds?: Whether to suppress embeds in the message.
         :type suppress_embeds?: Optional[bool]
-        :param allowed_mentions?: The message interactions/mention limits that the message can refer to.
-        :type allowed_mentions?: Optional[MessageInteraction]
+        :param allowed_mentions?: The allowed mentions for the message.
+        :type allowed_mentions?: Optional[AllowedMentions]
         :param attachments?: The attachments to attach to the message. Needs to be uploaded to the CDN first
         :type attachments?: Optional[List[Attachment]]
         :param components?: A component, or list of components for the message. If `[]` the components will be removed
@@ -922,7 +922,7 @@ class Message(ClientSerializerMixin, IDMixin):
             else []
         )
 
-        _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions
+        _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions._json
         _message_reference: dict = {} if message_reference is MISSING else message_reference._json
         if not components:
             _components = []

--- a/interactions/api/models/message.py
+++ b/interactions/api/models/message.py
@@ -744,7 +744,6 @@ class Message(ClientSerializerMixin, IDMixin):
     :ivar Optional[MessageActivity] activity?: Message activity object that's sent by Rich Presence
     :ivar Optional[Application] application?: Application object that's sent by Rich Presence
     :ivar Optional[MessageReference] message_reference?: Data showing the source of a message (crosspost, channel follow, add, pin, or replied message)
-    :ivar Optional[Any] allowed_mentions: The allowed mentions of roles attached in the message.
     :ivar int flags: Message flags
     :ivar Optional[MessageInteraction] interaction?: Message interaction object, if the message is sent by an interaction.
     :ivar Optional[Channel] thread?: The thread that started from this message, if any, with a thread member object embedded.
@@ -961,7 +960,7 @@ class Message(ClientSerializerMixin, IDMixin):
         embeds: Optional[Union["Embed", List["Embed"]]] = MISSING,
         files: Optional[Union[File, List[File]]] = MISSING,
         attachments: Optional[List["Attachment"]] = MISSING,
-        allowed_mentions: Optional["MessageInteraction"] = MISSING,
+        allowed_mentions: Optional[AllowedMentions] = MISSING,
         stickers: Optional[List["Sticker"]] = MISSING,
         components: Optional[
             Union[
@@ -987,8 +986,8 @@ class Message(ClientSerializerMixin, IDMixin):
         :type files?: Optional[Union[File, List[File]]]
         :param embeds?: An embed, or list of embeds for the message.
         :type embeds?: Optional[Union[Embed, List[Embed]]]
-        :param allowed_mentions?: The message interactions/mention limits that the message can refer to.
-        :type allowed_mentions?: Optional[MessageInteraction]
+        :param allowed_mentions?: The allowed mentions for the message.
+        :type allowed_mentions?: Optional[AllowedMentions]
         :param components?: A component, or list of components for the message.
         :type components?: Optional[Union[ActionRow, Button, SelectMenu, List[ActionRow], List[Button], List[SelectMenu]]]
         :param stickers?: A list of stickers to send with your message. You can send up to 3 stickers per message.
@@ -1009,7 +1008,7 @@ class Message(ClientSerializerMixin, IDMixin):
             if not embeds or embeds is MISSING
             else ([embed._json for embed in embeds] if isinstance(embeds, list) else [embeds._json])
         )
-        _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions
+        _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions._json
         _message_reference = MessageReference(message_id=int(self.id))._json
         _attachments = [] if attachments is MISSING else [a._json for a in attachments]
         if not components or components is MISSING:

--- a/interactions/api/models/misc.py
+++ b/interactions/api/models/misc.py
@@ -24,6 +24,8 @@ __all__ = (
     "AutoModMetaData",
     "AutoModAction",
     "AutoModTriggerMetadata",
+    "AllowedMentionType",
+    "AllowedMentions",
     "Snowflake",
     "Color",
     "ClientStatus",

--- a/interactions/api/models/misc.py
+++ b/interactions/api/models/misc.py
@@ -7,7 +7,7 @@
 
 import datetime
 from base64 import b64encode
-from enum import IntEnum
+from enum import Enum, IntEnum
 from io import FileIO, IOBase
 from logging import Logger
 from math import floor
@@ -16,7 +16,7 @@ from typing import List, Optional, Union
 
 from ...base import get_logger
 from ..error import LibraryException
-from .attrs_utils import MISSING, DictSerializerMixin, define, field
+from .attrs_utils import MISSING, DictSerializerMixin, define, field, convert_list
 
 __all__ = (
     "AutoModKeywordPresetTypes",

--- a/interactions/api/models/misc.py
+++ b/interactions/api/models/misc.py
@@ -370,3 +370,30 @@ class Image:
         Returns the name of the file.
         """
         return self._name.split("/")[-1].split(".")[0]
+
+
+class AllowedMentionType(str, Enum):
+    """
+    An enumerable object representing the allowed mention types
+    """
+    EVERYONE = "everyone"
+    USERS = "users"
+    ROLES = "roles"
+
+
+@define()
+class AllowedMentions(DictSerializerMixin):
+    """
+    A class object representing the allowed mentions object
+
+    :ivar parse?: Optional[List[AllowedMentionType]]: An array of allowed mention types to parse from the content.
+    :ivar users?: Optional[list]: An array of user ids to mention.
+    :ivar roles?: Optional[list]: An array of role ids to mention.
+    :ivar replied_user?: Optional[bool]: For replies, whether to mention the author of the message being replied to.
+    """
+
+    parse: Optional[List[AllowedMentionType]] = field(converter=convert_list(AllowedMentionType), default=None)
+    users: Optional[list] = field(default=None)
+    roles: Optional[list] = field(default=None)
+    replied_user: Optional[bool] = field(default=None)
+

--- a/interactions/api/models/misc.py
+++ b/interactions/api/models/misc.py
@@ -16,7 +16,7 @@ from typing import List, Optional, Union
 
 from ...base import get_logger
 from ..error import LibraryException
-from .attrs_utils import MISSING, DictSerializerMixin, define, field, convert_list
+from .attrs_utils import MISSING, DictSerializerMixin, convert_list, define, field
 
 __all__ = (
     "AutoModKeywordPresetTypes",
@@ -378,6 +378,7 @@ class AllowedMentionType(str, Enum):
     """
     An enumerable object representing the allowed mention types
     """
+
     EVERYONE = "everyone"
     USERS = "users"
     ROLES = "roles"
@@ -394,8 +395,9 @@ class AllowedMentions(DictSerializerMixin):
     :ivar replied_user?: Optional[bool]: For replies, whether to mention the author of the message being replied to.
     """
 
-    parse: Optional[List[AllowedMentionType]] = field(converter=convert_list(AllowedMentionType), default=None)
+    parse: Optional[List[AllowedMentionType]] = field(
+        converter=convert_list(AllowedMentionType), default=None
+    )
     users: Optional[list] = field(default=None)
     roles: Optional[list] = field(default=None)
     replied_user: Optional[bool] = field(default=None)
-

--- a/interactions/api/models/misc.py
+++ b/interactions/api/models/misc.py
@@ -390,14 +390,14 @@ class AllowedMentions(DictSerializerMixin):
     A class object representing the allowed mentions object
 
     :ivar parse?: Optional[List[AllowedMentionType]]: An array of allowed mention types to parse from the content.
-    :ivar users?: Optional[list]: An array of user ids to mention.
-    :ivar roles?: Optional[list]: An array of role ids to mention.
+    :ivar users?: Optional[List[int]]: An array of user ids to mention.
+    :ivar roles?: Optional[List[int]]: An array of role ids to mention.
     :ivar replied_user?: Optional[bool]: For replies, whether to mention the author of the message being replied to.
     """
 
     parse: Optional[List[AllowedMentionType]] = field(
         converter=convert_list(AllowedMentionType), default=None
     )
-    users: Optional[list] = field(default=None)
-    roles: Optional[list] = field(default=None)
+    users: Optional[List[int]] = field(default=None)
+    roles: Optional[List[int]] = field(default=None)
     replied_user: Optional[bool] = field(default=None)

--- a/interactions/api/models/webhook.py
+++ b/interactions/api/models/webhook.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Any, List, Optional, Union
 
 from ..error import LibraryException
 from .attrs_utils import MISSING, ClientSerializerMixin, define, field
-from .misc import File, IDMixin, Image, Snowflake
+from .misc import File, IDMixin, Image, Snowflake, AllowedMentions
 from .user import User
 
 if TYPE_CHECKING:
@@ -180,7 +180,7 @@ class Webhook(ClientSerializerMixin, IDMixin):
         avatar_url: Optional[str] = MISSING,
         tts: Optional[bool] = MISSING,
         embeds: Optional[Union["Embed", List["Embed"]]] = MISSING,
-        allowed_mentions: Any = MISSING,
+        allowed_mentions: Optional[AllowedMentions] = MISSING,
         attachments: Optional[List["Attachment"]] = MISSING,
         components: Optional[
             Union[
@@ -213,8 +213,8 @@ class Webhook(ClientSerializerMixin, IDMixin):
         :type attachments?: Optional[List[Attachment]]
         :param embeds: embedded ``rich`` content
         :type embeds: Union[Embed, List[Embed]]
-        :param allowed_mentions: allowed mentions for the message
-        :type allowed_mentions: dict
+        :param allowed_mentions?: The allowed mentions for the message.
+        :type allowed_mentions?: Optional[AllowedMentions]
         :param components: the components to include with the message
         :type components: Union[ActionRow, Button, SelectMenu, List[ActionRow], List[Button], List[SelectMenu]]
         :param files: The files to attach to the message
@@ -240,7 +240,7 @@ class Webhook(ClientSerializerMixin, IDMixin):
             if not embeds or embeds is MISSING
             else ([embed._json for embed in embeds] if isinstance(embeds, list) else [embeds._json])
         )
-        _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions
+        _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions._json
 
         if not components or components is MISSING:
             _components = []

--- a/interactions/api/models/webhook.py
+++ b/interactions/api/models/webhook.py
@@ -180,7 +180,7 @@ class Webhook(ClientSerializerMixin, IDMixin):
         avatar_url: Optional[str] = MISSING,
         tts: Optional[bool] = MISSING,
         embeds: Optional[Union["Embed", List["Embed"]]] = MISSING,
-        allowed_mentions: Optional[AllowedMentions] = MISSING,
+        allowed_mentions: Optional[Union[AllowedMentions, dict]] = MISSING,
         attachments: Optional[List["Attachment"]] = MISSING,
         components: Optional[
             Union[
@@ -214,7 +214,7 @@ class Webhook(ClientSerializerMixin, IDMixin):
         :param embeds: embedded ``rich`` content
         :type embeds: Union[Embed, List[Embed]]
         :param allowed_mentions?: The allowed mentions for the message.
-        :type allowed_mentions?: Optional[AllowedMentions]
+        :type allowed_mentions?: Optional[Union[AllowedMentions, dict]]
         :param components: the components to include with the message
         :type components: Union[ActionRow, Button, SelectMenu, List[ActionRow], List[Button], List[SelectMenu]]
         :param files: The files to attach to the message
@@ -240,7 +240,7 @@ class Webhook(ClientSerializerMixin, IDMixin):
             if not embeds or embeds is MISSING
             else ([embed._json for embed in embeds] if isinstance(embeds, list) else [embeds._json])
         )
-        _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions._json
+        _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions._json if isinstance(allowed_mentions, AllowedMentions) else allowed_mentions
 
         if not components or components is MISSING:
             _components = []

--- a/interactions/api/models/webhook.py
+++ b/interactions/api/models/webhook.py
@@ -240,7 +240,13 @@ class Webhook(ClientSerializerMixin, IDMixin):
             if not embeds or embeds is MISSING
             else ([embed._json for embed in embeds] if isinstance(embeds, list) else [embeds._json])
         )
-        _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions._json if isinstance(allowed_mentions, AllowedMentions) else allowed_mentions
+        _allowed_mentions: dict = (
+            {}
+            if allowed_mentions is MISSING
+            else allowed_mentions._json
+            if isinstance(allowed_mentions, AllowedMentions)
+            else allowed_mentions
+        )
 
         if not components or components is MISSING:
             _components = []

--- a/interactions/api/models/webhook.py
+++ b/interactions/api/models/webhook.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Any, List, Optional, Union
 
 from ..error import LibraryException
 from .attrs_utils import MISSING, ClientSerializerMixin, define, field
-from .misc import File, IDMixin, Image, Snowflake, AllowedMentions
+from .misc import AllowedMentions, File, IDMixin, Image, Snowflake
 from .user import User
 
 if TYPE_CHECKING:

--- a/interactions/client/context.py
+++ b/interactions/client/context.py
@@ -9,7 +9,7 @@ from ..api.models.flags import Permissions
 from ..api.models.guild import Guild
 from ..api.models.member import Member
 from ..api.models.message import Attachment, Embed, Message, MessageInteraction, MessageReference
-from ..api.models.misc import Snowflake
+from ..api.models.misc import Snowflake, AllowedMentions
 from ..api.models.user import User
 from ..base import get_logger
 from .enums import InteractionCallbackType, InteractionType
@@ -109,7 +109,7 @@ class _Context(ClientSerializerMixin):
         tts: Optional[bool] = MISSING,
         attachments: Optional[List[Attachment]] = MISSING,
         embeds: Optional[Union[Embed, List[Embed]]] = MISSING,
-        allowed_mentions: Optional[MessageInteraction] = MISSING,
+        allowed_mentions: Optional[AllowedMentions] = MISSING,
         components: Optional[
             Union[ActionRow, Button, SelectMenu, List[ActionRow], List[Button], List[SelectMenu]]
         ] = MISSING,
@@ -127,8 +127,8 @@ class _Context(ClientSerializerMixin):
         :type attachments?: Optional[List[Attachment]]
         :param embeds?: An embed, or list of embeds for the message.
         :type embeds?: Optional[Union[Embed, List[Embed]]]
-        :param allowed_mentions?: The message interactions/mention limits that the message can refer to.
-        :type allowed_mentions?: Optional[MessageInteraction]
+        :param allowed_mentions?: The allowed mentions for the message.
+        :type allowed_mentions?: Optional[AllowedMentions]
         :param components?: A component, or list of components for the message.
         :type components?: Optional[Union[ActionRow, Button, SelectMenu, List[Union[ActionRow, Button, SelectMenu]]]]
         :param ephemeral?: Whether the response is hidden or not.
@@ -157,7 +157,7 @@ class _Context(ClientSerializerMixin):
             if not embeds or embeds is MISSING
             else ([embed._json for embed in embeds] if isinstance(embeds, list) else [embeds._json])
         )
-        _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions
+        _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions._json
 
         if components is not MISSING and components:
             # components could be not missing but an empty list
@@ -198,7 +198,7 @@ class _Context(ClientSerializerMixin):
         tts: Optional[bool] = MISSING,
         attachments: Optional[List[Attachment]] = MISSING,
         embeds: Optional[Union[Embed, List[Embed]]] = MISSING,
-        allowed_mentions: Optional[MessageInteraction] = MISSING,
+        allowed_mentions: Optional[AllowedMentions] = MISSING,
         message_reference: Optional[MessageReference] = MISSING,
         components: Optional[
             Union[ActionRow, Button, SelectMenu, List[ActionRow], List[Button], List[SelectMenu]]
@@ -247,7 +247,7 @@ class _Context(ClientSerializerMixin):
 
             payload["attachments"] = _attachments
 
-        _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions
+        _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions._json
         _message_reference: dict = {} if message_reference is MISSING else message_reference._json
 
         payload["allowed_mentions"] = _allowed_mentions

--- a/interactions/client/context.py
+++ b/interactions/client/context.py
@@ -109,7 +109,7 @@ class _Context(ClientSerializerMixin):
         tts: Optional[bool] = MISSING,
         attachments: Optional[List[Attachment]] = MISSING,
         embeds: Optional[Union[Embed, List[Embed]]] = MISSING,
-        allowed_mentions: Optional[AllowedMentions] = MISSING,
+        allowed_mentions: Optional[Union[AllowedMentions, dict]] = MISSING,
         components: Optional[
             Union[ActionRow, Button, SelectMenu, List[ActionRow], List[Button], List[SelectMenu]]
         ] = MISSING,
@@ -128,7 +128,7 @@ class _Context(ClientSerializerMixin):
         :param embeds?: An embed, or list of embeds for the message.
         :type embeds?: Optional[Union[Embed, List[Embed]]]
         :param allowed_mentions?: The allowed mentions for the message.
-        :type allowed_mentions?: Optional[AllowedMentions]
+        :type allowed_mentions?: Optional[Union[AllowedMentions, dict]]
         :param components?: A component, or list of components for the message.
         :type components?: Optional[Union[ActionRow, Button, SelectMenu, List[Union[ActionRow, Button, SelectMenu]]]]
         :param ephemeral?: Whether the response is hidden or not.
@@ -157,7 +157,7 @@ class _Context(ClientSerializerMixin):
             if not embeds or embeds is MISSING
             else ([embed._json for embed in embeds] if isinstance(embeds, list) else [embeds._json])
         )
-        _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions._json
+        _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions._json if isinstance(allowed_mentions, AllowedMentions) else allowed_mentions
 
         if components is not MISSING and components:
             # components could be not missing but an empty list
@@ -198,7 +198,7 @@ class _Context(ClientSerializerMixin):
         tts: Optional[bool] = MISSING,
         attachments: Optional[List[Attachment]] = MISSING,
         embeds: Optional[Union[Embed, List[Embed]]] = MISSING,
-        allowed_mentions: Optional[AllowedMentions] = MISSING,
+        allowed_mentions: Optional[Union[AllowedMentions, dict]] = MISSING,
         message_reference: Optional[MessageReference] = MISSING,
         components: Optional[
             Union[ActionRow, Button, SelectMenu, List[ActionRow], List[Button], List[SelectMenu]]
@@ -247,7 +247,7 @@ class _Context(ClientSerializerMixin):
 
             payload["attachments"] = _attachments
 
-        _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions._json
+        _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions._json if isinstance(allowed_mentions, AllowedMentions) else allowed_mentions
         _message_reference: dict = {} if message_reference is MISSING else message_reference._json
 
         payload["allowed_mentions"] = _allowed_mentions

--- a/interactions/client/context.py
+++ b/interactions/client/context.py
@@ -8,8 +8,8 @@ from ..api.models.channel import Channel
 from ..api.models.flags import Permissions
 from ..api.models.guild import Guild
 from ..api.models.member import Member
-from ..api.models.message import Attachment, Embed, Message, MessageInteraction, MessageReference
-from ..api.models.misc import Snowflake, AllowedMentions
+from ..api.models.message import Attachment, Embed, Message, MessageReference
+from ..api.models.misc import AllowedMentions, Snowflake
 from ..api.models.user import User
 from ..base import get_logger
 from .enums import InteractionCallbackType, InteractionType

--- a/interactions/client/context.py
+++ b/interactions/client/context.py
@@ -157,7 +157,13 @@ class _Context(ClientSerializerMixin):
             if not embeds or embeds is MISSING
             else ([embed._json for embed in embeds] if isinstance(embeds, list) else [embeds._json])
         )
-        _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions._json if isinstance(allowed_mentions, AllowedMentions) else allowed_mentions
+        _allowed_mentions: dict = (
+            {}
+            if allowed_mentions is MISSING
+            else allowed_mentions._json
+            if isinstance(allowed_mentions, AllowedMentions)
+            else allowed_mentions
+        )
 
         if components is not MISSING and components:
             # components could be not missing but an empty list
@@ -247,7 +253,13 @@ class _Context(ClientSerializerMixin):
 
             payload["attachments"] = _attachments
 
-        _allowed_mentions: dict = {} if allowed_mentions is MISSING else allowed_mentions._json if isinstance(allowed_mentions, AllowedMentions) else allowed_mentions
+        _allowed_mentions: dict = (
+            {}
+            if allowed_mentions is MISSING
+            else allowed_mentions._json
+            if isinstance(allowed_mentions, AllowedMentions)
+            else allowed_mentions
+        )
         _message_reference: dict = {} if message_reference is MISSING else message_reference._json
 
         payload["allowed_mentions"] = _allowed_mentions


### PR DESCRIPTION
## About

This pull request adds ``AllowedMentions`` and ``AllowedMentionTypes`` objects to work with ``allowed_mentions``

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues) (If existent):.
  - resolves #
- I've made this pull request for/as: (check all that apply)
  - [x] Documentation
  - [x] Breaking change
  - [x] New feature/enhancement
  - [ ] Bugfix
