### PR TITLE
fix: Add search_iterable() to __all__

### DIFF
--- a/interactions/client/models/utils.py
+++ b/interactions/client/models/utils.py
@@ -8,7 +8,7 @@ from .component import ActionRow, Button, SelectMenu
 if TYPE_CHECKING:
     from ..context import CommandContext
 
-__all__ = ("autodefer", "spread_to_rows")
+__all__ = ("autodefer", "spread_to_rows", "search_iterable")
 
 _T = TypeVar("_T")
 


### PR DESCRIPTION
## About

Cannot import the function otherwise, except by giving the entire path.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues) (If existent):.
  - resolves #
- I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
