### PR TITLE
docs: fix incorrect codeblocks

### DIFF
--- a/interactions/client/models/component.py
+++ b/interactions/client/models/component.py
@@ -266,7 +266,7 @@ class ActionRow(ComponentMixin):
         only.
 
     The structure for an action row:
-    ::
+    ..code-block:: python
         # "..." represents a component object.
         # Method 1:
         interactions.ActionRow(...)

--- a/interactions/client/models/component.py
+++ b/interactions/client/models/component.py
@@ -229,7 +229,6 @@ class TextInput(ComponentMixin):
 class Modal(ComponentMixin):
     """
     A class object representing a modal.
-
     The structure for a modal: ::
         interactions.Modal(
             title="Application Form",
@@ -266,7 +265,8 @@ class ActionRow(ComponentMixin):
         An ActionRow may also support only 1 text input component
         only.
 
-    The structure for an action row: ::
+    The structure for an action row:
+    ::
         # "..." represents a component object.
         # Method 1:
         interactions.ActionRow(...)

--- a/interactions/client/models/utils.py
+++ b/interactions/client/models/utils.py
@@ -74,7 +74,7 @@ def spread_to_rows(
     *components: Union[ActionRow, Button, SelectMenu], max_in_row: int = 5
 ) -> List[ActionRow]:
     r"""
-    A helper function that spreads components into :class:`ActionRow`s.
+    A helper function that spreads components into :class:`ActionRow` s.
 
     Example:
 


### PR DESCRIPTION
## About

This pull request fixes incorrect view of codeblocks in documentation

## Checklist

- [ ] I've ran `pre-commit` to format and lint the change(s) made.
- [ ] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues) (If existent):.
  - resolves #
- I've made this pull request for/as: (check all that apply)
  - [x] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [ ] Bugfix
