### PR TITLE
refactor: turn MISSING into a more proper sentinel

### DIFF
--- a/interactions/api/models/attrs_utils.py
+++ b/interactions/api/models/attrs_utils.py
@@ -8,7 +8,7 @@ __all__ = ("MISSING", "DictSerializerMixin", "ClientSerializerMixin")
 
 
 class _Missing:
-    """A pseudosentinel based from an empty object. This is now more compliant with PEP"""
+    """A sentinel object for places where None is a valid value"""
 
     _instance: ClassVar["_Missing"] = None
 

--- a/interactions/api/models/attrs_utils.py
+++ b/interactions/api/models/attrs_utils.py
@@ -1,16 +1,36 @@
 from copy import deepcopy
 from functools import wraps
-from typing import Dict, Mapping, Optional, Tuple
+from typing import ClassVar, Dict, Mapping, Optional, Tuple
 
 import attrs
 
 __all__ = ("MISSING", "DictSerializerMixin", "ClientSerializerMixin")
 
 
-class MISSING:
-    """A pseudosentinel based from an empty object. This does violate PEP, but, I don't care."""
+class _Missing:
+    """A pseudosentinel based from an empty object. This is now more compliant with PEP"""
 
-    ...
+    _instance: ClassVar["_Missing"] = None
+
+    def __new__(cls):
+        if not isinstance(cls._instance, cls):
+            cls._instance = object.__new__(cls)
+        return cls._instance
+
+    def __eq__(self, other):
+        return self.__class__ is other.__class__
+
+    def __repr__(self):
+        return "<interactions.MISSING>"
+
+    def __hash__(self):
+        return 0
+
+    def __bool__(self):
+        return False
+
+
+MISSING = _Missing()
 
 
 @attrs.define(eq=False, init=False, on_setattr=attrs.setters.NO_OP)
@@ -74,7 +94,7 @@ class DictSerializerMixin:
 
                     passed_kwargs[attrib_name] = value
 
-                elif attrib.default:
+                elif attrib.default is not attrs.NOTHING:
                     # handle defaults like attrs does
                     default = attrib.default
                     if isinstance(default, attrs.Factory):  # type: ignore

--- a/interactions/api/models/attrs_utils.pyi
+++ b/interactions/api/models/attrs_utils.pyi
@@ -1,5 +1,5 @@
 from functools import wraps
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar, Union, overload
+from typing import Any, Callable, ClassVar, Dict, List, Optional, Tuple, Type, TypeVar, Union, overload
 
 import attrs
 
@@ -8,10 +8,22 @@ from interactions.api.http.client import HTTPClient
 _T = TypeVar("_T")
 _P = TypeVar("_P")
 
-class MISSING:
-    """A pseudosentinel based from an empty object. This does violate PEP, but, I don't care."""
 
-    ...
+class _Missing:
+    """A pseudosentinel based from an empty object. This is now more compliant with PEP"""
+    _instance: ClassVar["_Missing"] = None
+
+    def __eq__(self, other): ...
+
+    def __repr__(self): ...
+
+    def __hash__(self): ...
+
+    def __bool__(self): ...
+
+
+MISSING = _Missing()
+
 
 @attrs.define(eq=False, init=False, on_setattr=attrs.setters.NO_OP)
 class DictSerializerMixin:
@@ -20,7 +32,9 @@ class DictSerializerMixin:
     """A dict containing values that were not serialized from Discord."""
     __deepcopy_kwargs__: bool = attrs.field(init=False)
     """Should the kwargs be deepcopied or not?"""
+
     def __init__(self, kwargs_dict: dict = None, /, **other_kwargs): ...
+
 
 @attrs.define(eq=False, init=False, on_setattr=attrs.setters.NO_OP)
 class ClientSerializerMixin(DictSerializerMixin):

--- a/interactions/api/models/attrs_utils.pyi
+++ b/interactions/api/models/attrs_utils.pyi
@@ -10,7 +10,7 @@ _P = TypeVar("_P")
 
 
 class _Missing:
-    """A pseudosentinel based from an empty object. This is now more compliant with PEP"""
+    """A sentinel object for places where None is a valid value"""
     _instance: ClassVar["_Missing"] = None
 
     def __eq__(self, other): ...


### PR DESCRIPTION
## About

This pull request converts MISSING into a class instance, which allows for things like `__repr__`, `__bool__`, and other similar things to be added

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues) (If existent):.
  - resolves #
- I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [x] New feature/enhancement
  - [ ] Bugfix
