### PR TITLE
fix(autocomplete dispatch): ID -> name 

### DIFF
--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -321,7 +321,7 @@ class WebSocketClient:
 
                     self._dispatch.dispatch("on_component", _context)
                 elif data["type"] == InteractionType.APPLICATION_COMMAND_AUTOCOMPLETE:
-                    _name = f"autocomplete_{_context.data.id}"
+                    _name = f"autocomplete_{_context.data.name}"
 
                     if _context.data._json.get("options"):
                         for option in _context.data.options:

--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -862,7 +862,8 @@ class Client:
             and command.type == ApplicationCommandType.CHAT_INPUT
         ):
             raise LibraryException(
-                11, message=f"Your command name ('{command.name}') does not match the regex for valid names ('{regex}')."
+                11,
+                message=f"Your command name ('{command.name}') does not match the regex for valid names ('{regex}').",
             )
         elif command.type == ApplicationCommandType.CHAT_INPUT and (
             command.description is MISSING or not command.description


### PR DESCRIPTION
This allows multi-guild usage when 2 or more scopes are used on a command since the command will have a different ID but the same name in different guilds. Reported [here](https://canary.discord.com/channels/789032594456576001/1006824593731887214/1006838362772078743)

## About

This pull request is about (X), which does (Y).

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues) (If existent):.
  - resolves #
- I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
