### PR TITLE
refactor(bot, gateway, http): Remove any unclosed client session messages

### DIFF
--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -773,3 +773,4 @@ class WebSocketClient:
         """
         if self._client:
             await self._client.close()
+        self._closed = True

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -112,7 +112,7 @@ class WebSocketClient:
         except RuntimeError:
             self._loop = new_event_loop()
         self._dispatch: Listener = Listener()
-        self._http: HTTPClient = HTTPClient(token)
+        self._http: HTTPClient = token
         self._client: Optional["ClientWebSocketResponse"] = None
         self._closed: bool = False
         self._options: dict = {
@@ -173,6 +173,9 @@ class WebSocketClient:
         :param presence: The presence to carry with. Defaults to ``None``.
         :type presence: Optional[ClientPresence]
         """
+        if isinstance(self._http, str):
+            self._http = HTTPClient(self._http)
+
         self._client = None
         self.__heartbeater.delay = 0.0
         self._closed = False
@@ -763,3 +766,10 @@ class WebSocketClient:
         await self._send_packet(payload)
         log.debug(f"UPDATE_PRESENCE: {presence._json}")
         self.__presence = presence
+
+    async def close(self) -> None:
+        """
+        Closes the current connection.
+        """
+        if self._client:
+            await self._client.close()

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -229,7 +229,6 @@ class WebSocketClient:
         if isinstance(self._http, str):
             self._http = HTTPClient(self._http)
 
-
         url = await self._http.get_gateway()
         self.ws_url = url
         self._client = await self._http._req._session.ws_connect(url, **self._options)

--- a/interactions/api/http/request.py
+++ b/interactions/api/http/request.py
@@ -18,7 +18,6 @@ from .route import Route
 
 __all__ = ("_Request",)
 log: Logger = get_logger("http")
-_session: ClientSession = ClientSession()
 
 
 class _Request:
@@ -48,7 +47,6 @@ class _Request:
     ratelimits: Dict[str, Limiter]  # bucket: Limiter
     buckets: Dict[str, str]  # endpoint: shared_bucket
     _headers: dict
-    _session: ClientSession
     _global_lock: Limiter
 
     def __init__(self, token: str) -> None:
@@ -69,7 +67,7 @@ class _Request:
             f"Python/{version_info[0]}.{version_info[1]} "
             f"aiohttp/{http_version}",
         }
-        self._session = _session
+        self._session = ClientSession()
         self._global_lock = (
             Limiter(lock=Lock(loop=self._loop)) if version_info < (3, 10) else Limiter(lock=Lock())
         )

--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -89,7 +89,6 @@ class Client:
         self.__global_commands = {}
         self.__guild_commands = {}
 
-
         self.me: Application = None
         self.__id_autocomplete = {}
         if self._default_scope:

--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -861,7 +861,8 @@ class Client:
             and command.type == ApplicationCommandType.CHAT_INPUT
         ):
             raise LibraryException(
-                11, message=f"Your command name ('{command.name}') does not match the regex for valid names ('{regex}')."
+                11,
+                message=f"Your command name ('{command.name}') does not match the regex for valid names ('{regex}').",
             )
         elif command.type == ApplicationCommandType.CHAT_INPUT and (
             command.description is MISSING or not command.description

--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -1502,10 +1502,6 @@ class Client:
         await self._websocket.close()
         await self._http._req.close()
 
-    def stop(self) -> None:
-        self._websocket._closed = True
-        self._loop.run_until_complete(self._logout())
-
 
 # TODO: Implement the rest of cog behaviour when possible.
 class Extension:

--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -1502,6 +1502,7 @@ class Client:
         await self._http._req.close()
 
     def stop(self) -> None:
+        self._websocket._closed = True
         self._loop.run_until_complete(self._logout())
 
 

--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -66,7 +66,7 @@ class Client:
     :ivar Optional[ClientPresence] _presence: The RPC-like presence shown on an application once connected.
     :ivar str _token: The token of the application used for authentication when connecting.
     :ivar Optional[Dict[str, ModuleType]] _extensions: The "extensions" or cog equivalence registered to the main client.
-    :ivar Application me: The application representation of the client.
+    :ivar Application me?: The application representation of the client.
     """
 
     def __init__(
@@ -89,7 +89,7 @@ class Client:
         self.__global_commands = {}
         self.__guild_commands = {}
 
-        self.me: Application = None
+        self.me: Optional[Application] = None
         self.__id_autocomplete = {}
         if self._default_scope:
             if not isinstance(self._default_scope, list):

--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -131,6 +131,7 @@ class Client:
 
         data = self._loop.run_until_complete(self._http.get_current_bot_information())
         self.me = Application(**data, _client=self._http)
+
         try:
             self._loop.run_until_complete(self._ready())
         except (CancelledError, Exception) as e:
@@ -138,8 +139,8 @@ class Client:
             raise e from e
         except KeyboardInterrupt:
             log.error("KeyboardInterrupt detected, shutting down the bot.")
-
-        self._loop.run_until_complete(self._logout())
+        finally:
+            self._loop.run_until_complete(self._logout())
 
     def __register_events(self) -> None:
         """Registers all raw gateway events to the known events."""


### PR DESCRIPTION
## About

This pull request aims to stop "unclosed client session" messages to appear after stopping the bot

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues) (If existent):.
  - resolves #
- I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [ ] Bugfix
