### PR TITLE
feat: Add command and option name in Exception message

### DIFF
--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -802,7 +802,7 @@ class Client:
             if not re.fullmatch(reg, _option.name):
                 raise LibraryException(
                     11,
-                    message=f"The option name does not match the regex for valid names ('{regex}')",
+                    message=f"The option name ('{_option.name}') does not match the regex for valid names ('{regex}').",
                 )
             if _option.description is MISSING or not _option.description:
                 raise LibraryException(
@@ -864,7 +864,7 @@ class Client:
             and command.type == ApplicationCommandType.CHAT_INPUT
         ):
             raise LibraryException(
-                11, message=f"Your command does not match the regex for valid names ('{regex}')"
+                11, message=f"Your command name ('{command.name}') does not match the regex for valid names ('{regex}')."
             )
         elif command.type == ApplicationCommandType.CHAT_INPUT and (
             command.description is MISSING or not command.description


### PR DESCRIPTION
## About

Hopefully this PR will help users to see where the error is coming from (I've encountered multiple times users who asked for help, probably they aren't aware of the regex naming).

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues) (If existent):.
  - resolves #
- I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [x] New feature/enhancement
  - [ ] Bugfix
