### PR TITLE
feat: add download helper method for Attachments

### DIFF
--- a/interactions/api/models/message.py
+++ b/interactions/api/models/message.py
@@ -1,6 +1,7 @@
 import contextlib
 from datetime import datetime
 from enum import IntEnum
+from io import BytesIO
 from typing import TYPE_CHECKING, List, Optional, Union
 
 from ...client.models.component import ActionRow, Button, SelectMenu
@@ -147,6 +148,22 @@ class Attachment(ClientSerializerMixin, IDMixin):
     height: Optional[int] = field(default=None)
     width: Optional[int] = field(default=None)
     ephemeral: Optional[bool] = field(default=None)
+
+    async def download(self) -> BytesIO:
+        """
+        Downloads the attachment.
+
+        :returns: The attachment's bytes as BytesIO object
+        :rtype: BytesIO
+        """
+
+        if not self._client:
+            raise LibraryException(code=13)
+
+        async with self._client._req._session.get(self.url) as response:
+            _bytes: bytes = await response.content.read()
+
+        return BytesIO(_bytes)
 
 
 @define()


### PR DESCRIPTION
## About

This pull request adds a download method for attachments

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues) (If existent):.
  - resolves #
- I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [x] New feature/enhancement
  - [ ] Bugfix
