### PR TITLE
feat!: Completely redo gateway process.

### DIFF
--- a/interactions/api/gateway/__init__.py
+++ b/interactions/api/gateway/__init__.py
@@ -6,3 +6,4 @@ handles all of the Gateway work.
 """
 from .client import *  # noqa: F401 F403
 from .heartbeat import *  # noqa: F401 F403
+from .ratelimit import *  # noqa: F401 F403

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -69,7 +69,7 @@ class WebSocketClient:
     :ivar Optional[List[Tuple[int]]] __shard: The shards used during connection.
     :ivar Optional[ClientPresence] __presence: The presence used in connection.
     :ivar Event ready: The ready state of the client as an ``asyncio.Event``.
-    :ivar Task __task: The task containing the heartbeat manager process.
+    :ivar Task _task: The task containing the heartbeat manager process.
     :ivar bool __started: Whether the client has started.
     :ivar Optional[str] session_id: The ID of the ongoing session.
     :ivar Optional[int] sequence: The sequence identifier of the ongoing session.
@@ -95,7 +95,7 @@ class WebSocketClient:
         "__heartbeater",
         "__shard",
         "__presence",
-        "__task",
+        "_task",
         "__heartbeat_event",
         "__started",
         "session_id",
@@ -154,7 +154,7 @@ class WebSocketClient:
         self.__shard: Optional[List[Tuple[int]]] = None
         self.__presence: Optional[ClientPresence] = None
 
-        self.__task: Optional[Task] = None
+        self._task: Optional[Task] = None
         self.__heartbeat_event = Event(loop=self._loop) if version_info < (3, 10) else Event()
         self.__started: bool = False
 
@@ -234,7 +234,7 @@ class WebSocketClient:
 
         self.__heartbeater.delay = data["d"]["heartbeat_interval"]
 
-        self.__task = create_task(self.run_heartbeat())
+        self._task = create_task(self.run_heartbeat())
 
         await self.__identify(self.__shard, self.__presence)
 
@@ -714,12 +714,12 @@ class WebSocketClient:
 
             self.__heartbeater.delay = data["d"]["heartbeat_interval"]
 
-            if self.__task:
-                self.__task.cancel()
+            if self._task:
+                self._task.cancel()
                 if self.__heartbeat_event.is_set():
                     self.__heartbeat_event.clear()  # Because we're hardresetting the process
 
-                self.__task = create_task(self.run_heartbeat())
+                self._task = create_task(self.run_heartbeat())
 
             if not to_resume:
                 await self.__identify(self.__shard, self.__presence)

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -194,7 +194,7 @@ class WebSocketClient:
             await self._manage_heartbeat()
         except Exception:
             self._closing_lock.set()
-            log.error("Heartbeater exception: ", exc_info=True)
+            log.exception("Heartbeater exception.")
 
     async def _manage_heartbeat(self) -> None:
         """Manages the heartbeat loop."""
@@ -690,7 +690,7 @@ class WebSocketClient:
 
     async def _reconnect(self, to_resume: bool, code: Optional[int] = 1012) -> None:
         """
-        Restart the client's connection and heartbeat with the Gateway.
+        Restarts the client's connection and heartbeat with the Gateway.
         """
 
         self._ready.clear()

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -748,10 +748,15 @@ class WebSocketClient:
             if packet.type == WSMsgType.CLOSE:
                 log.debug(f"Disconnecting from gateway = {packet.data}::{packet.extra}")
 
-                if packet.data >= 4000:
+                if (
+                    packet.data >= 4000 and packet.data != 4001
+                ):  # suppress 4001 because of weird presence errors
                     # This means that the error code is 4000+, which may signify Discord-provided error codes.
-                    raise LibraryException(packet.data)  # Works because gateway!!
-                    # We need to work on __aexit__ / __aentry__ though, since we're not using the ws request manager.
+
+                    # However, we suppress 4001 because of weird presence errors with change_presence
+                    # The payload is correct, and the presence object persists. /shrug
+
+                    raise LibraryException(packet.data)
 
                 if ignore_lock:
                     raise LibraryException(

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -807,8 +807,8 @@ class WebSocketClient:
             await self._ratelimiter.block()
 
         self._last_send = perf_counter()
-        await self._client.send_str(packet)
         log.debug(packet)
+        await self._client.send_str(packet)
 
     async def __identify(
         self, shard: Optional[List[Tuple[int]]] = None, presence: Optional[ClientPresence] = None

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -748,9 +748,7 @@ class WebSocketClient:
             if packet.type == WSMsgType.CLOSE:
                 log.debug(f"Disconnecting from gateway = {packet.data}::{packet.extra}")
 
-                if (
-                    packet.data >= 4000 and packet.data != 4001
-                ):  # suppress 4001 because of weird presence errors
+                if packet.data >= 4000:  # suppress 4001 because of weird presence errors
                     # This means that the error code is 4000+, which may signify Discord-provided error codes.
 
                     # However, we suppress 4001 because of weird presence errors with change_presence
@@ -807,7 +805,7 @@ class WebSocketClient:
         _data = dumps(data) if isinstance(data, dict) else data
         packet: str = _data.decode("utf-8") if isinstance(_data, bytes) else _data
 
-        if data["op"] != OpCodeType.HEARTBEAT:
+        if data["op"] != OpCodeType.HEARTBEAT.value:
             # This is because the ratelimiter limits already accounts for this.
             await self._ratelimiter.block()
 
@@ -829,7 +827,7 @@ class WebSocketClient:
         self.__shard = shard
         self.__presence = presence
         payload: dict = {
-            "op": OpCodeType.IDENTIFY,
+            "op": OpCodeType.IDENTIFY.value,
             "d": {
                 "token": self._http.token,
                 "intents": self._intents.value,
@@ -853,7 +851,7 @@ class WebSocketClient:
     async def __resume(self) -> None:
         """Sends a ``RESUME`` packet to the gateway."""
         payload: dict = {
-            "op": OpCodeType.RESUME,
+            "op": OpCodeType.RESUME.value,
             "d": {"token": self._http.token, "seq": self.sequence, "session_id": self.session_id},
         }
         log.debug(f"RESUMING: {payload}")
@@ -862,7 +860,7 @@ class WebSocketClient:
 
     async def __heartbeat(self) -> None:
         """Sends a ``HEARTBEAT`` packet to the gateway."""
-        payload: dict = {"op": OpCodeType.HEARTBEAT, "d": self.sequence}
+        payload: dict = {"op": OpCodeType.HEARTBEAT.value, "d": self.sequence}
         await self._send_packet(payload)
         log.debug("HEARTBEAT")
 
@@ -888,7 +886,7 @@ class WebSocketClient:
         :param presence: The presence to change the bot to on identify.
         :type presence: ClientPresence
         """
-        payload: dict = {"op": OpCodeType.PRESENCE, "d": presence._json}
+        payload: dict = {"op": OpCodeType.PRESENCE.value, "d": presence._json}
         await self._send_packet(payload)
         log.debug(f"UPDATE_PRESENCE: {presence._json}")
         self.__presence = presence

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -198,7 +198,7 @@ class WebSocketClient:
 
     async def _manage_heartbeat(self) -> None:
         """Manages the heartbeat loop."""
-        log.debug(f"Sending heartbeat every {self.__heartbeater.delay} seconds...")
+        log.debug(f"Sending heartbeat every {self.__heartbeater.delay / 1000} seconds...")
         while not self.__heartbeat_event.is_set():
 
             log.debug("Sending heartbeat...")

--- a/interactions/api/gateway/ratelimit.py
+++ b/interactions/api/gateway/ratelimit.py
@@ -1,0 +1,61 @@
+import asyncio
+import logging
+from sys import version_info
+from time import time
+from typing import Optional
+
+log = logging.getLogger("gateway.ratelimit")
+
+
+class WSRateLimit:
+    """
+    A class that controls Gateway ratelimits using locking and a timer.
+
+    .. note ::
+        While the docs state that the Gateway ratelimits are 120/60 (120 requests per 60 seconds),
+        this ratelimit offsets to 110 instead of 120 for room.
+
+    :ivar Lock lock: The gateway Lock object.
+    :ivar int max: The upper limit of the ratelimit. Defaults to `110` seconds.
+    :ivar int remaining: How many requests are left per ``per_second``. This is automatically decremented and reset.
+    :ivar float current_limit: When this cooldown session began. This is defined automatically.
+    :ivar float per_second: A constant denoting how many requests can be done per unit of seconds. (i.e., per 60 seconds, per 45, etc.)
+    """
+
+    def __init__(self, loop=Optional[asyncio.AbstractEventLoop]):
+        self.lock = asyncio.Lock(loop=loop) if version_info < (3, 10) else asyncio.Lock()
+        # To conserve timings, we need to do 110/60
+
+        self.max = self.remaining = 110
+        self.per_second = 60.0
+        self.current_limit = 0.0
+
+    def is_ratelimited(self):
+        current = time()
+        if current > self.current_limit + self.per_second:
+            return False
+        return self.remaining == 0
+
+    def get_delay(self):
+        current = time()
+
+        if current > self.current_limit + self.per_second:
+            self.remaining = self.max
+
+        if self.remaining == self.max:
+            self.current_limit = current
+
+        if self.remaining == 0:
+            return self.per_second - (current - self.current_limit)
+
+        self.remaining -= 1
+        if self.remaining == 0:
+            self.current_limit = current
+
+        return 0.0
+
+    async def block(self):
+        async with self.lock:
+            if delta := self.get_delay():
+                log.warning(f"We are ratelimited. Please wait {delta} seconds...")
+                await asyncio.sleep(delta)

--- a/interactions/api/gateway/ratelimit.py
+++ b/interactions/api/gateway/ratelimit.py
@@ -16,7 +16,7 @@ class WSRateLimit:
         this ratelimit offsets to 115 instead of 120 for room.
 
     :ivar Lock lock: The gateway Lock object.
-    :ivar int max: The upper limit of the ratelimit. Defaults to `115` seconds.
+    :ivar int max: The upper limit of the ratelimit in seconds. Defaults to `115`.
     :ivar int remaining: How many requests are left per ``per_second``. This is automatically decremented and reset.
     :ivar float current_limit: When this cooldown session began. This is defined automatically.
     :ivar float per_second: A constant denoting how many requests can be done per unit of seconds. (i.e., per 60 seconds, per 45, etc.)
@@ -31,11 +31,12 @@ class WSRateLimit:
         self.per_second = 60.0
         self.current_limit = 0.0
 
-    def is_ratelimited(self) -> bool:
+    @property
+    def ratelimited(self) -> bool:
         """
-        A function that's called whenever the websocket ratelimiter is ratelimited.
+        An attribute that reflects whenever the websocket ratelimiter is rate-limited.
 
-        :return: Whether it's ratelimited or not.
+        :return: Whether it's rate-limited or not.
         :rtype: bool
         """
         current = time()
@@ -43,7 +44,8 @@ class WSRateLimit:
             return False
         return self.remaining == 0
 
-    def get_delay(self) -> float:
+    @property
+    def delay(self) -> float:
         """
         A function that calculates how long we need to wait for ratelimit to pass, if any.
 
@@ -72,6 +74,6 @@ class WSRateLimit:
         A function that uses the internal Lock to check for rate-limits and cooldown whenever necessary.
         """
         async with self.lock:
-            if delta := self.get_delay():
-                log.warning(f"We are ratelimited. Please wait {delta} seconds...")
+            if delta := self.delay:
+                log.warning(f"We are rate-limited. Please wait {round(delta, 2)} seconds...")
                 await asyncio.sleep(delta)

--- a/interactions/api/gateway/ratelimit.py
+++ b/interactions/api/gateway/ratelimit.py
@@ -22,21 +22,34 @@ class WSRateLimit:
     :ivar float per_second: A constant denoting how many requests can be done per unit of seconds. (i.e., per 60 seconds, per 45, etc.)
     """
 
-    def __init__(self, loop=Optional[asyncio.AbstractEventLoop]):
+    def __init__(self, loop: Optional[asyncio.AbstractEventLoop] = None):
         self.lock = asyncio.Lock(loop=loop) if version_info < (3, 10) else asyncio.Lock()
         # To conserve timings, we need to do 115/60
+        # Also, credit to d.py for their ratelimiter inspiration
 
         self.max = self.remaining = 115
         self.per_second = 60.0
         self.current_limit = 0.0
 
-    def is_ratelimited(self):
+    def is_ratelimited(self) -> bool:
+        """
+        A function that's called whenever the websocket ratelimiter is ratelimited.
+
+        :return: Whether it's ratelimited or not.
+        :rtype: bool
+        """
         current = time()
         if current > self.current_limit + self.per_second:
             return False
         return self.remaining == 0
 
-    def get_delay(self):
+    def get_delay(self) -> float:
+        """
+        A function that calculates how long we need to wait for ratelimit to pass, if any.
+
+        :return: How long to wait in seconds, if any. Defaults to ``0.0``.
+        :rtype: float
+        """
         current = time()
 
         if current > self.current_limit + self.per_second:
@@ -54,7 +67,10 @@ class WSRateLimit:
 
         return 0.0
 
-    async def block(self):
+    async def block(self) -> None:
+        """
+        A function that uses the internal Lock to check for rate-limits and cooldown whenever necessary.
+        """
         async with self.lock:
             if delta := self.get_delay():
                 log.warning(f"We are ratelimited. Please wait {delta} seconds...")

--- a/interactions/api/gateway/ratelimit.py
+++ b/interactions/api/gateway/ratelimit.py
@@ -13,10 +13,10 @@ class WSRateLimit:
 
     .. note ::
         While the docs state that the Gateway ratelimits are 120/60 (120 requests per 60 seconds),
-        this ratelimit offsets to 110 instead of 120 for room.
+        this ratelimit offsets to 115 instead of 120 for room.
 
     :ivar Lock lock: The gateway Lock object.
-    :ivar int max: The upper limit of the ratelimit. Defaults to `110` seconds.
+    :ivar int max: The upper limit of the ratelimit. Defaults to `115` seconds.
     :ivar int remaining: How many requests are left per ``per_second``. This is automatically decremented and reset.
     :ivar float current_limit: When this cooldown session began. This is defined automatically.
     :ivar float per_second: A constant denoting how many requests can be done per unit of seconds. (i.e., per 60 seconds, per 45, etc.)
@@ -24,9 +24,9 @@ class WSRateLimit:
 
     def __init__(self, loop=Optional[asyncio.AbstractEventLoop]):
         self.lock = asyncio.Lock(loop=loop) if version_info < (3, 10) else asyncio.Lock()
-        # To conserve timings, we need to do 110/60
+        # To conserve timings, we need to do 115/60
 
-        self.max = self.remaining = 110
+        self.max = self.remaining = 115
         self.per_second = 60.0
         self.current_limit = 0.0
 

--- a/interactions/api/gateway/ratelimit.py
+++ b/interactions/api/gateway/ratelimit.py
@@ -47,7 +47,7 @@ class WSRateLimit:
     @property
     def delay(self) -> float:
         """
-        A function that calculates how long we need to wait for ratelimit to pass, if any.
+        An attribute that reflects how long we need to wait for ratelimit to pass, if any.
 
         :return: How long to wait in seconds, if any. Defaults to ``0.0``.
         :rtype: float

--- a/interactions/api/models/presence.py
+++ b/interactions/api/models/presence.py
@@ -181,3 +181,6 @@ class ClientPresence(DictSerializerMixin):
             # If since is not provided by the developer...
             self.since = int(time.time() * 1000) if self.status == "idle" else 0
             self._json["since"] = self.since
+        if not self._json.get("afk"):
+            self.afk = False
+            self._json["afk"] = False

--- a/interactions/api/models/presence.py
+++ b/interactions/api/models/presence.py
@@ -182,5 +182,6 @@ class ClientPresence(DictSerializerMixin):
             self.since = int(time.time() * 1000) if self.status == "idle" else 0
             self._json["since"] = self.since
         if not self._json.get("afk"):
-            self.afk = False
-            self._json["afk"] = False
+            self.afk = self._json["afk"] = False
+        if not self._json.get("activities"):
+            self.activities = self._json["activities"] = []

--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -412,13 +412,13 @@ class Client:
                 # signal for closing.
 
                 try:
-                    if self._websocket.__task is not None:
+                    if self._websocket._task is not None:
                         self._websocket.__heartbeat_event.set()
                         try:
                             # Wait for the keep-alive handler to finish so we can discard it gracefully
-                            await self._websocket.__task
+                            await self._websocket._task
                         finally:
-                            self._websocket.__task = None
+                            self._websocket._task = None
                 finally:  # then the overall WS client
                     if self._websocket._client is not None:
                         # This needs to be properly closed

--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -393,8 +393,6 @@ class Client:
 
     async def _login(self) -> None:
         """Makes a login with the Discord API."""
-        # while not self._websocket._closed:
-        #     await self._websocket._establish_connection(self._shards, self._presence)
 
         try:
             await self._websocket.run()
@@ -408,7 +406,8 @@ class Client:
                     if self._websocket.__task is not None:
                         self._websocket.__heartbeat_event.set()
                         try:
-                            await self._websocket.__task  # Wait for the keep-alive handler to finish so we can discard it gracefully
+                            # Wait for the keep-alive handler to finish so we can discard it gracefully
+                            await self._websocket.__task
                         finally:
                             self._websocket.__task = None
                 finally:  # then the overall WS client

--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -405,8 +405,8 @@ class Client:
 
         try:
             await self._websocket.run()
-        except Exception as e:
-            log.exception(f"Websocket have raised an exception, closing because of: {e}")
+        except Exception:
+            log.exception("Websocket have raised an exception, closing.")
 
             if self._websocket._closing_lock.is_set():
                 # signal for closing.


### PR DESCRIPTION
## About

This pull request essentially:

- Implements a Gateway ratelimiter (because we're lacking one)
- Completely redoes the gateway process because of past issues involving hanging connections
- Implements WS resume url *and* caches the current URL.

More testing from others is appreciated :)

## Checklist

- [X] I've ran `pre-commit` to format and lint the change(s) made.
- [X] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [X] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues) (If existent):.
  - resolves #979 
- I've made this pull request for/as: (check all that apply)
  - [X] Documentation
  - [X] Breaking change
  - [X] New feature/enhancement
  - [X] Bugfix
