### PR TITLE
fix: make ``Member.get_avatar_url`` return ``None`` when no guild avatar exists

### DIFF
--- a/interactions/api/models/member.py
+++ b/interactions/api/models/member.py
@@ -490,7 +490,7 @@ class Member(ClientSerializerMixin, IDMixin):
         :return: URL of the members's avatar (None will be returned if no avatar is set)
         :rtype: str
         """
-        if not self.avatar:
+        if not self.avatar or self.avatar == self.user.avatar:
             return None
 
         if guild_id is MISSING:


### PR DESCRIPTION
## About

Addresses #1034 

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [x] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues) (If existent):.
  - resolves #1034 
- I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
