### PR TITLE
refactor(cache): optimize caching and dispatching behaviour

### DIFF
--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -441,7 +441,6 @@ class WebSocketClient:
                 model = getattr(__import__(path), _name)
                 obj = model(**data)
 
-                # I don't like this but idk what i should do then
                 guild_obj = guild_model = None
                 if model is GuildRole:
                     guild_obj = Role(**role_data) if (role_data := data.get("role")) else None
@@ -452,7 +451,6 @@ class WebSocketClient:
 
                 _cache: "Storage" = self._http.cache[model]
                 _guild_cache: "Storage" = self._http.cache[guild_model]
-                # in _guild_cache stores 'Role' and 'Member' objects
 
                 ids = None
                 id = self.__get_object_id(data, obj, model)
@@ -473,6 +471,7 @@ class WebSocketClient:
 
                 elif "_update" in name:
                     self._dispatch.dispatch(f"on_raw_{name}", obj)
+
                     if not id and ids is None:
                         return self._dispatch.dispatch(f"on_{name}", obj)
 
@@ -480,11 +479,11 @@ class WebSocketClient:
                         name, data, guild_model or model, guild_obj or obj, id, ids
                     )
                     if ids is not None:
-                        # Not cached but it needed for events guild_emojis_update and guild_stickers_update
-                        self._dispatch.dispatch(f"on_{name}", obj)
-                        return
+                        # Not cached but it needed for guild_emojis_update and guild_stickers_update events
+                        return self._dispatch.dispatch(f"on_{name}", obj)
                     if id is None:
                         return
+
                     if guild_obj:
                         old_guild_obj = _guild_cache.get(id)
                         if old_guild_obj:

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -516,7 +516,9 @@ class WebSocketClient:
 
                     elif ids and "message" in name:
                         # currently only message has '_delete_bulk' event but ig better keep this condition for future.
-                        self.__delete_message_cache(ids)
+                        _message_cache: "Storage" = self._http.cache[Message]
+                        for message_id in ids:
+                            _message_cache.pop(message_id)
 
                     self._dispatch.dispatch(f"on_{name}", old_obj or obj)
 
@@ -590,20 +592,6 @@ class WebSocketClient:
                 ]
 
         return ids
-
-    def __delete_message_cache(self, ids: Union[Snowflake, List[Snowflake]]):
-        """
-        Deletes messages from cache.
-
-        :param ids: The ID or IDs of message(s).
-        :type ids: Union[Snowflake, List[Snowflake]]
-        """
-        if isinstance(ids, Snowflake):
-            ids = [ids]
-
-        _message_cache: "Storage" = self._http.cache[Message]
-        for message_id in ids:
-            _message_cache.pop(message_id)
 
     def __modify_guild_cache(
         self,

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -560,7 +560,7 @@ class WebSocketClient:
             return id
 
         if model.__name__ == "GuildScheduledEventUser":
-            id = model.guild_scheduled_event_id
+            id = obj.guild_scheduled_event_id
         elif model.__name__ == "Presence":
             id = obj.user.id
         elif model.__name__ in [

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -461,7 +461,7 @@ class WebSocketClient:
                     self._dispatch.dispatch(f"on_{name}", obj)
 
                     if id:
-                        _cache.add(obj, id)
+                        _cache.merge(obj, id)
                         if guild_obj:
                             _guild_cache.add(guild_obj, id)
 

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -614,7 +614,6 @@ class WebSocketClient:
         for message_id in ids:
             _message_cache.pop(message_id)
 
-
     def __contextualize(self, data: dict) -> "_Context":
         """
         Takes raw data given back from the Gateway

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -527,7 +527,7 @@ class WebSocketClient:
 
                         if "message" in name:
                             self.__delete_message_cache(id)
-                    elif ids and "message_delete_bulk" in name:
+                    elif ids and "message" in name:
                         # currently only message has '_delete_bulk' event but ig better keep this condition for future.
                         self.__delete_message_cache(ids)
 

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -480,12 +480,11 @@ class WebSocketClient:
                                     elif "_update" in name and hasattr(obj, "id"):
                                         _obj[index] = obj
                                     break
-                        elif ids:
-                            if "_update" in name:
-                                objs = getattr(obj, model_name, None)
-                                if objs is not None:
-                                    _obj.clear()
-                                    _obj.extend(objs)
+                        elif ids and "_update" in name:
+                            objs = getattr(obj, model_name, None)
+                            if objs is not None:
+                                _obj.clear()
+                                _obj.extend(objs)
 
                         setattr(guild, model_name, _obj)
                     self._http.cache[Guild].add(guild)

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -617,7 +617,7 @@ class WebSocketClient:
             return getattr(__import__(path), model.__name__[5:])
 
         return model
-    
+
     def __modify_guild_cache(
         self,
         name: str,

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -522,7 +522,7 @@ class WebSocketClient:
                         self.__delete_message_cache(ids)
                         self._dispatch.dispatch(f"on_{name}", obj)
 
-                    self._dispatch.dispatch(f"on_{name}", old_obj)
+                    self._dispatch.dispatch(f"on_{name}", old_obj or obj)
 
                 else:
                     self._dispatch.dispatch(f"on_{name}", obj)

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -549,7 +549,7 @@ class WebSocketClient:
         :type data: dict
         :param obj: The object of the event.
         :param model: The model of the event.
-        :return: object ID
+        :return: Object ID
         :rtype: Optional[Union[Snowflake, Tuple[Snowflake, Snowflake]]]
         """
         if isinstance(obj, (Member, GuildMember)):
@@ -565,7 +565,7 @@ class WebSocketClient:
             id = obj.user.id
         elif model.__name__ in [
             "GuildBan",
-            # Extend this for everything that starts with `Guild` and should not be cached
+            # Extend this for everything that starts with 'Guild' and should not be cached
         ]:
             id = None
         elif model.__name__.startswith("Guild"):
@@ -583,7 +583,7 @@ class WebSocketClient:
 
         :param obj: The object of the event.
         :param model: The model of the event.
-        :return: object IDs
+        :return: Object IDs
         :rtype: Optional[Union[Snowflake, Tuple[Snowflake, Snowflake]]]
         """
         ids = getattr(obj, "ids", None)

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -520,7 +520,6 @@ class WebSocketClient:
                     elif ids and "message" in name:
                         # currently only message has '_delete_bulk' event but ig better keep this condition for future.
                         self.__delete_message_cache(ids)
-                        self._dispatch.dispatch(f"on_{name}", obj)
 
                     self._dispatch.dispatch(f"on_{name}", old_obj or obj)
 

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -444,7 +444,7 @@ class WebSocketClient:
                 # I don't like this but idk what i should do then
                 guild_obj = guild_model = None
                 if model is GuildRole:
-                    guild_obj = Role(**data["role"]) if "role" in data else None
+                    guild_obj = Role(**role_data) if (role_data := data.get("role")) else None
                     guild_model = Role
                 elif model is GuildMember:
                     guild_obj = Member(**data)

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -474,7 +474,7 @@ class WebSocketClient:
                 elif "_update" in name:
                     self._dispatch.dispatch(f"on_raw_{name}", obj)
                     if not id and ids is None:
-                        return
+                        return self._dispatch.dispatch(f"on_{name}", obj)
 
                     self.__modify_guild_cache(
                         name, data, guild_model or model, guild_obj or obj, id, ids

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -451,6 +451,7 @@ class WebSocketClient:
                     ids = self.__get_object_ids(obj, model)
 
                 # I don't like this but idk what i should do then
+                guild_obj = None
                 if guild_model is Role:
                     guild_obj = Role(**data["role"]) if "role" in data else None
                 elif guild_model is not None:

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -459,7 +459,7 @@ class WebSocketClient:
                 if id is None:
                     ids = self.__get_object_ids(obj, model)
 
-                if "_create" in name or "_add" in name:
+                if "_create" in name or "_add" in name or "_execution" in name:
                     self._dispatch.dispatch(f"on_{name}", obj)
 
                     if id:

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -573,7 +573,15 @@ class WebSocketClient:
         for message_id in ids:
             _message_cache.pop(message_id)
 
-    def __modify_guild_cache(self, name: str, data: dict, model: Any, obj: Any, id: Optional[Snowflake] = None, ids: Optional[List[Snowflake]] = None):
+    def __modify_guild_cache(
+        self,
+        name: str,
+        data: dict,
+        model: Any,
+        obj: Any,
+        id: Optional[Snowflake] = None,
+        ids: Optional[List[Snowflake]] = None,
+    ):
         if not (
             (guild_id := data.get("guild_id"))
             and not isinstance(obj, Guild)

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -481,9 +481,7 @@ class WebSocketClient:
                     )
                     if ids:
                         # Not cached but it needed for events guild_emojis_update and guild_stickers_update
-                        self._dispatch.dispatch(
-                            f"on_{name}", obj
-                        )
+                        self._dispatch.dispatch(f"on_{name}", obj)
                         return
                     if id is None:
                         return

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -507,7 +507,9 @@ class WebSocketClient:
         :param data: The data for the event.
         :type data: dict
         :param obj: The object of the event.
+        :type obj: Any
         :param model: The model of the event.
+        :type model: Any
         :return: Object ID
         :rtype: Optional[Union[Snowflake, Tuple[Snowflake, Snowflake]]]
         """
@@ -541,7 +543,9 @@ class WebSocketClient:
         Gets a list of ids of object.
 
         :param obj: The object of the event.
+        :type obj: Any
         :param model: The model of the event.
+        :type model: Any
         :return: Object IDs
         :rtype: Optional[Union[Snowflake, Tuple[Snowflake, Snowflake]]]
         """
@@ -582,6 +586,18 @@ class WebSocketClient:
         id: Optional[Snowflake] = None,
         ids: Optional[List[Snowflake]] = None,
     ):
+        """
+        Modifies guild cache.
+
+        :param event: The name of the event.
+        :type event: str
+        :param data: The data for the event.
+        :type data: dict
+        :param obj: The object of the event.
+        :type obj: Any
+        :param model: The model of the event.
+        :type model: Any
+        """
         if not (
             (guild_id := data.get("guild_id"))
             and not isinstance(obj, Guild)

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -473,13 +473,13 @@ class WebSocketClient:
 
                 elif "_update" in name:
                     self._dispatch.dispatch(f"on_raw_{name}", obj)
-                    if not id and not ids:
+                    if not id and ids is None:
                         return
 
                     self.__modify_guild_cache(
                         name, data, guild_model or model, guild_obj or obj, id, ids
                     )
-                    if ids:
+                    if ids is not None:
                         # Not cached but it needed for events guild_emojis_update and guild_stickers_update
                         self._dispatch.dispatch(
                             f"on_{name}", obj
@@ -520,7 +520,7 @@ class WebSocketClient:
                         )
                         old_obj = _cache.pop(id)
 
-                    elif ids and "message" in name:
+                    elif ids is not None and "message" in name:
                         # currently only message has '_delete_bulk' event but ig better keep this condition for future.
                         _message_cache: "Storage" = self._http.cache[Message]
                         for message_id in ids:
@@ -651,7 +651,7 @@ class WebSocketClient:
                         elif "_update" in name and hasattr(obj, "id"):
                             iterable[index] = obj
                         break
-            elif ids and "_update" in name:
+            elif ids is not None and "_update" in name:
                 objs = getattr(obj, attr, None)
                 if objs is not None:
                     iterable.clear()

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -459,7 +459,7 @@ class WebSocketClient:
                 if id is None:
                     ids = self.__get_object_ids(obj, model)
 
-                if "_create" in name or "_add" in name or "_execution" in name:
+                if "_create" in name or "_add" in name:
                     self._dispatch.dispatch(f"on_{name}", obj)
 
                     if id:

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -479,6 +479,12 @@ class WebSocketClient:
                     self.__modify_guild_cache(
                         name, data, guild_model or model, guild_obj or obj, id, ids
                     )
+                    if ids:
+                        # Not cached but it needed for events guild_emojis_update and guild_stickers_update
+                        self._dispatch.dispatch(
+                            f"on_{name}", obj
+                        )
+                        return
                     if id is None:
                         return
                     if guild_obj:

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -514,9 +514,6 @@ class WebSocketClient:
                         )
                         old_obj = _cache.pop(id)
 
-                        if "message" in name:
-                            self.__delete_message_cache(id)
-
                     elif ids and "message" in name:
                         # currently only message has '_delete_bulk' event but ig better keep this condition for future.
                         self.__delete_message_cache(ids)

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -589,7 +589,7 @@ class WebSocketClient:
 
         if model.__name__.startswith("Guild"):
             model_name = model.__name__[5:].lower()
-            if _data := getattr(obj, model_name, None):
+            if (_data := getattr(obj, model_name, None)) is not None:
                 ids = [
                     getattr(_obj, "id") if not isinstance(_obj, dict) else Snowflake(_obj["id"])
                     for _obj in _data

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -443,7 +443,9 @@ class WebSocketClient:
                 obj = model(**data)
 
                 _cache: "Storage" = self._http.cache[model]
-                _guild_cache: "Storage" = self._http.cache[guild_model]  # There are stores 'Role' and 'Member' objects
+                _guild_cache: "Storage" = self._http.cache[
+                    guild_model
+                ]  # There are stores 'Role' and 'Member' objects
 
                 ids = None
                 id = self.__get_object_id(data, obj, model)
@@ -464,14 +466,18 @@ class WebSocketClient:
                         if guild_obj:
                             _guild_cache.add(guild_obj, id)
 
-                    self.__modify_guild_cache(name, data, guild_model or model, guild_obj or obj, id, ids)
+                    self.__modify_guild_cache(
+                        name, data, guild_model or model, guild_obj or obj, id, ids
+                    )
 
                 elif "_update" in name:
                     self._dispatch.dispatch(f"on_raw_{name}", obj)
                     if not id and not ids:
                         return
 
-                    self.__modify_guild_cache(name, data, guild_model or model, guild_obj or obj, id, ids)
+                    self.__modify_guild_cache(
+                        name, data, guild_model or model, guild_obj or obj, id, ids
+                    )
                     if id is None:
                         return
                     if guild_obj:
@@ -495,12 +501,16 @@ class WebSocketClient:
                     )  # give previously stored and new one
 
                 elif "_remove" in name or "_delete" in name:
-                    self._dispatch.dispatch(f"on_raw_{name}", obj)  # Deprecated. Remove this in the future.
+                    self._dispatch.dispatch(
+                        f"on_raw_{name}", obj
+                    )  # Deprecated. Remove this in the future.
 
                     old_obj = None
                     if id:
                         _guild_cache.pop(id)
-                        self.__modify_guild_cache(name, data, guild_model or model, guild_obj or obj, id, ids)
+                        self.__modify_guild_cache(
+                            name, data, guild_model or model, guild_obj or obj, id, ids
+                        )
                         old_obj = _cache.pop(id)
 
                         if "message" in name:
@@ -614,7 +624,6 @@ class WebSocketClient:
         path = "interactions.api.models"
         if model.__name__.startswith("Guild"):
             return getattr(__import__(path), model.__name__[5:])
-
 
     def __modify_guild_cache(
         self,

--- a/interactions/api/models/guild.py
+++ b/interactions/api/models/guild.py
@@ -360,6 +360,8 @@ class Guild(ClientSerializerMixin, IDMixin):
                     self.member_count = guild.member_count
                 if not self.presences:
                     self.presences = guild.presences
+                if not self.emojis:
+                    self.emojis = guiild.emojis
 
         if self.members:
             for member in self.members:

--- a/interactions/api/models/guild.py
+++ b/interactions/api/models/guild.py
@@ -361,7 +361,7 @@ class Guild(ClientSerializerMixin, IDMixin):
                 if not self.presences:
                     self.presences = guild.presences
                 if not self.emojis:
-                    self.emojis = guiild.emojis
+                    self.emojis = guild.emojis
 
         if self.members:
             for member in self.members:


### PR DESCRIPTION
## About

This pull request:
1. Moves getting object ID into separated method.
2. Adds method to get object IDs. It needs for `message_delete_bulk`, `emojis_update` and `stickers_update` events. It allows properly cache emojis and stickers.
3. Caches `GuildMember` like `Member`
4. Deletes messages from cache on `message_delete_bulk` event.
5. Moves `__modify_guild_cache` to own method.
6. Makes properly cache `Guild.members` and `Guild.roles`.
7. Properly dispatches remove/delete event so we no need to use raw remove/delete event.
8. Dispatches `_update` event if there are no id and ids. It allows use `on_channel_pins_update`, `on_webhooks_update` events without `raw` prefix.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues) (If existent):.
  - resolves #
- I've made this pull request for/as: (check all that apply)
  - [x] Documentation
  - [ ] Breaking change
  - [x] New feature/enhancement
  - [ ] Bugfix
