### PR TITLE
refactor: make Command.dispatch a function

### DIFF
--- a/interactions/client/models/command.py
+++ b/interactions/client/models/command.py
@@ -711,13 +711,17 @@ class Command(DictSerializerMixin):
         **kwargs,
     ) -> Optional[BaseResult]:
         """
-        Returns a coroutine that calls the command along with the subcommands, if any.
+        Call the command along with any subcommands
 
-        .. note::
-            The coroutine returned is never the same object.
-
-        :return: A coroutine that calls the command along with the subcommands, if any.
-        :rtype: Callable[..., Awaitable]
+        :param ctx: The context for the interaction
+        :type ctx: CommandContext
+        :param args: The args to be passed to the command
+        :param sub_command_group: The subcommand group being invoked, if any
+        :type sub_command_group: Optional[str]
+        :param sub_command: The subcommand being invoked, if any
+        :type sub_command: Optional[str]
+        :param kwargs: The kwargs to pass to the command
+        :return:
         """
         base_coro = self.coro
         base_res = BaseResult(

--- a/interactions/client/models/command.py
+++ b/interactions/client/models/command.py
@@ -710,18 +710,21 @@ class Command(DictSerializerMixin):
         sub_command: Optional[str] = None,
         **kwargs,
     ) -> Optional[BaseResult]:
-        """
+        r"""
         Call the command along with any subcommands
 
         :param ctx: The context for the interaction
         :type ctx: CommandContext
         :param args: The args to be passed to the command
+        :type args: tuple
         :param sub_command_group: The subcommand group being invoked, if any
         :type sub_command_group: Optional[str]
         :param sub_command: The subcommand being invoked, if any
         :type sub_command: Optional[str]
         :param kwargs: The kwargs to pass to the command
-        :return:
+        :type kwargs: Dict
+        :return: The result of the base command if no StopCommand is returned anywhere, else None
+        :rtype: Optional[BaseResult]
         """
         base_coro = self.coro
         base_res = BaseResult(


### PR DESCRIPTION
## About

This pull request changes Command.dispatch from a property into a function
This is mostly just to make it easier to override in exts, though it does help to simplify the code

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues) (If existent):.
  - resolves #
- I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [ ] Bugfix
