### PR TITLE
feat&fix: Implement `Guild.get_scheduled_events` & fix iso

### DIFF
--- a/interactions/api/models/guild.py
+++ b/interactions/api/models/guild.py
@@ -1632,8 +1632,7 @@ class Guild(ClientSerializerMixin, IDMixin):
         if not self._client:
             raise LibraryException(code=13)
         res = await self._client.get_scheduled_events(
-            guild_id=self.id,
-            with_user_count=with_user_count
+            guild_id=self.id, with_user_count=with_user_count
         )
         return [ScheduledEvents(**scheduled_event) for scheduled_event in res]
 

--- a/interactions/api/models/guild.py
+++ b/interactions/api/models/guild.py
@@ -1620,6 +1620,23 @@ class Guild(ClientSerializerMixin, IDMixin):
         )
         return ScheduledEvents(**res)
 
+    async def get_scheduled_events(self, with_user_count: bool) -> List["ScheduledEvents"]:
+        """
+        Gets all scheduled events of the guild.
+
+        :param with_user_count: A boolean to include number of users subscribed to the associated event, if given.
+        :type with_user_count: bool
+        :return: The sheduled events of the guild.
+        :rtype: List[ScheduledEvents]
+        """
+        if not self._client:
+            raise LibraryException(code=13)
+        res = await self._client.get_scheduled_events(
+            guild_id=self.id,
+            with_user_count=with_user_count
+        )
+        return [ScheduledEvents(**scheduled_event) for scheduled_event in res]
+
     async def modify_scheduled_event(
         self,
         event_id: Union[int, "ScheduledEvents", Snowflake],
@@ -2631,7 +2648,7 @@ class ScheduledEvents(DictSerializerMixin, IDMixin):
     creator_id: Optional[Snowflake] = field(converter=Snowflake, default=None)
     name: str = field()
     description: str = field()
-    scheduled_start_time: Optional[datetime] = field(converter=datetime.isoformat, default=None)
+    scheduled_start_time: Optional[datetime] = field(converter=datetime.fromisoformat, default=None)
     scheduled_end_time: Optional[datetime] = field(converter=datetime.fromisoformat, default=None)
     privacy_level: int = field()
     entity_type: int = field()

--- a/interactions/api/models/guild.py
+++ b/interactions/api/models/guild.py
@@ -1634,7 +1634,7 @@ class Guild(ClientSerializerMixin, IDMixin):
         res = await self._client.get_scheduled_events(
             guild_id=self.id, with_user_count=with_user_count
         )
-        return [ScheduledEvents(**scheduled_event) for scheduled_event in res]
+        return [ScheduledEvents(**scheduled_event) for scheduled_event in res] if res else []
 
     async def modify_scheduled_event(
         self,


### PR DESCRIPTION
## About

This pull request adds `get_scheduled_events` method to get all scheduled events of the guild and fixes bug with wrong datetime converting

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues) (If existent):.
  - resolves #
- I've made this pull request for/as: (check all that apply)
  - [x] Documentation
  - [ ] Breaking change
  - [x] New feature/enhancement
  - [x] Bugfix
