### PR TITLE
fix: Set the websocket's token without referencing the httpclient

### DIFF
--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -149,7 +149,7 @@ class WebSocketClient:
             "timeout": 60,
             "autoclose": False,
             "compress": 0,
-            "headers": {"User-Agent": self._http._req._headers["User-Agent"]},
+            "headers": {"User-Agent": token},
         }
 
         self._intents: Intents = intents

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -149,7 +149,9 @@ class WebSocketClient:
             "timeout": 60,
             "autoclose": False,
             "compress": 0,
-            "headers": {"User-Agent": f"DiscordBot (https://github.com/interactions-py/library {__version__}) "},
+            "headers": {
+                "User-Agent": f"DiscordBot (https://github.com/interactions-py/library {__version__}) "
+            },
         }
 
         self._intents: Intents = intents

--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
 
 from aiohttp import ClientWebSocketResponse, WSMessage, WSMsgType
 
-from ...base import get_logger
+from ...base import __version__, get_logger
 from ...client.enums import InteractionType, OptionType
 from ...client.models import Option
 from ...utils.missing import MISSING
@@ -149,7 +149,7 @@ class WebSocketClient:
             "timeout": 60,
             "autoclose": False,
             "compress": 0,
-            "headers": {"User-Agent": token},
+            "headers": {"User-Agent": f"DiscordBot (https://github.com/interactions-py/library {__version__}) "},
         }
 
         self._intents: Intents = intents


### PR DESCRIPTION
## About

This pull request fixes `AttributeError: 'str' object has no attribute '_req'`

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [x] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues) (If existent):.
  - resolves: an issue [presented on Discord](https://canary.discord.com/channels/789032594456576001/876490879815254097/1013737202959794248)
- I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [x] Bugfix
