### PR TITLE
fix: Mitigate gateway null responses.

### DIFF
--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -807,8 +807,10 @@ class WebSocketClient:
                 msg = loads(packet.data)
             except Exception as e:
                 import traceback
+
                 log.debug(
-                    f'Error serialising message: {"".join(traceback.format_exception(type(e), e, e.__traceback__))}.')
+                    f'Error serialising message: {"".join(traceback.format_exception(type(e), e, e.__traceback__))}.'
+                )
                 # There's an edge case when the packet's None... or some other deserialisation error.
                 # Instead of raising an exception, we just log it to debug, so it doesn't annoy end user's console logs.
                 msg = None


### PR DESCRIPTION
## About

This pull request properly checks whether the websocket stream exists such that dispatching a None object wouldn't happen and reorders the sequence when the heartbeat manager resets so that no heartbeats are sent when the WS client is None.

More testers are welcome :)

## Checklist

- [X] I've ran `pre-commit` to format and lint the change(s) made.
- [X] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues) (If existent):.
  - resolves #
- I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [X] New feature/enhancement
  - [X] Bugfix
