### PR TITLE
refactor: move getting http and bot info into `_ready`

### DIFF
--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -125,12 +125,6 @@ class Client:
     def start(self) -> None:
         """Starts the client session."""
 
-        if isinstance(self._http, str):
-            self._http = HTTPClient(self._http)
-
-        data = self._loop.run_until_complete(self._http.get_current_bot_information())
-        self.me = Application(**data, _client=self._http)
-
         try:
             self._loop.run_until_complete(self._ready())
         except (CancelledError, Exception) as e:
@@ -357,6 +351,12 @@ class Client:
             LOOP
         """
         ready: bool = False
+
+        if isinstance(self._http, str):
+            self._http = HTTPClient(self._http)
+
+        data = await self._http.get_current_bot_information()
+        self.me = Application(**data, _client=self._http)
 
         try:
             if self.me.flags is not None:


### PR DESCRIPTION
## About

This pull request moves http definition and getting bot information into `Client._ready`

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues) (If existent):.
  - resolves #
- I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [ ] Bugfix
