### PR TITLE
feat: create `Context.has_permissions()` & `Member.has_permissions()`

### DIFF
--- a/interactions/api/models/channel.py
+++ b/interactions/api/models/channel.py
@@ -1231,13 +1231,9 @@ class Channel(ClientSerializerMixin, IDMixin):
         if not self.guild_id:
             return Permissions.DEFAULT
 
-        from .guild import Guild
+        permissions = await member.get_guild_permissions(self.guild_id)
 
-        guild = Guild(**await self._client.get_guild(int(self.guild_id)), _client=self._client)
-
-        permissions = await member.get_guild_permissions(guild)
-
-        if permissions & Permissions.ADMINISTRATOR == Permissions.ADMINISTRATOR:
+        if Permissions.ADMINISTRATOR in permissions:
             return Permissions.ALL
 
         # @everyone role overwrites

--- a/interactions/api/models/member.py
+++ b/interactions/api/models/member.py
@@ -507,7 +507,9 @@ class Member(ClientSerializerMixin, IDMixin):
         url += ".gif" if self.avatar.startswith("a_") else ".png"
         return url
 
-    async def get_guild_permissions(self, guild_id: Optional[Union[int, Snowflake, "Guild"]] = MISSING) -> Permissions:
+    async def get_guild_permissions(
+        self, guild_id: Optional[Union[int, Snowflake, "Guild"]] = MISSING
+    ) -> Permissions:
         """
         Returns the permissions of the member for the specified guild.
 
@@ -557,7 +559,7 @@ class Member(ClientSerializerMixin, IDMixin):
         *permissions: Union[int, Permissions],
         channel: Optional[Channel] = MISSING,
         guild_id: Optional[Union[int, Snowflake, "Guild"]] = MISSING,
-        operator: str = "and"
+        operator: str = "and",
     ) -> bool:
         """
         Returns whether the member has the permissions passed.
@@ -577,7 +579,11 @@ class Member(ClientSerializerMixin, IDMixin):
         :return: Whether the member has the permissions
         :rtype: bool
         """
-        perms = await self.get_guild_permissions(guild_id) if channel is MISSING else await channel.get_permissions_for(self)
+        perms = (
+            await self.get_guild_permissions(guild_id)
+            if channel is MISSING
+            else await channel.get_permissions_for(self)
+        )
 
         if operator == "and":
             for perm in permissions:

--- a/interactions/api/models/member.py
+++ b/interactions/api/models/member.py
@@ -525,17 +525,13 @@ class Member(ClientSerializerMixin, IDMixin):
         """
         from .guild import Guild
 
-        if isinstance(guild_id, Guild):
-            guild = guild_id
+        if guild_id is MISSING:
+            _guild_id = self.guild_id
+            if isinstance(_guild_id, LibraryException):
+                raise _guild_id
 
         else:
-            if guild_id is MISSING:
-                _guild_id = self.guild_id
-                if isinstance(_guild_id, LibraryException):
-                    raise _guild_id
-
-            else:
-                _guild_id = int(guild_id)
+            _guild_id = int(guild_id) if not isinstance(guild_id, Guild) else int(guild_id.id)
 
             guild = Guild(**await self._client.get_guild(int(_guild_id)), _client=self._client)
 

--- a/interactions/api/models/member.py
+++ b/interactions/api/models/member.py
@@ -507,7 +507,7 @@ class Member(ClientSerializerMixin, IDMixin):
         url += ".gif" if self.avatar.startswith("a_") else ".png"
         return url
 
-    async def get_guild_permissions(self, guild: "Guild") -> Permissions:
+    async def get_guild_permissions(self, guild_id: Optional[Union[int, Snowflake, "Guild"]] = MISSING) -> Permissions:
         """
         Returns the permissions of the member for the specified guild.
 
@@ -521,6 +521,22 @@ class Member(ClientSerializerMixin, IDMixin):
         :return: Base permissions of the member in the specified guild
         :rtype: Permissions
         """
+        from .guild import Guild
+
+        if isinstance(guild_id, Guild):
+            guild = guild_id
+
+        else:
+            if guild_id is MISSING:
+                _guild_id = self.guild_id
+                if isinstance(_guild_id, LibraryException):
+                    raise _guild_id
+
+            else:
+                _guild_id = int(guild_id)
+
+            guild = Guild(**await self._client.get_guild(int(_guild_id)), _client=self._client)
+
         if int(guild.owner_id) == int(self.id):
             return Permissions.ALL
 
@@ -531,7 +547,45 @@ class Member(ClientSerializerMixin, IDMixin):
             role = await guild.get_role(role_id)
             permissions |= int(role.permissions)
 
-        if permissions & Permissions.ADMINISTRATOR == Permissions.ADMINISTRATOR:
+        if Permissions.ADMINISTRATOR in Permissions(permissions):
             return Permissions.ALL
 
         return Permissions(permissions)
+
+    async def has_permissions(
+        self,
+        *permissions: Union[int, Permissions],
+        channel: Optional[Channel] = MISSING,
+        guild_id: Optional[Union[int, Snowflake, "Guild"]] = MISSING,
+        operator: str = "and"
+    ) -> bool:
+        """
+        Returns whether the member has the permissions passed.
+
+        .. note::
+            If the channel argument is present, the function will look if the member has the permissions in the specified channel.
+            If the argument is missing, then it will only consider the member's guild permissions.
+
+        :param *permissions: The list of permissions
+        :type *permissions: Union[int, Permissions]
+        :param channel: The channel where to check for permissions
+        :type channel: Channel
+        :param guild_id: The id of the guild
+        :type guild_id: Optional[Union[int, Snowflake, Guild]]
+        :param operator: The operator to use to calculate permissions. Possible values: `and`, `or`. Defaults to `and`.
+        :type operator: str
+        :return: Whether the member has the permissions
+        :rtype: bool
+        """
+        perms = await self.get_guild_permissions(guild_id) if channel is MISSING else await channel.get_permissions_for(self)
+
+        if operator == "and":
+            for perm in permissions:
+                if perm not in perms:
+                    return False
+            return True
+        else:
+            for perm in permissions:
+                if perm in perms:
+                    return True
+            return False

--- a/interactions/api/models/member.py
+++ b/interactions/api/models/member.py
@@ -533,7 +533,7 @@ class Member(ClientSerializerMixin, IDMixin):
         else:
             _guild_id = int(guild_id) if not isinstance(guild_id, Guild) else int(guild_id.id)
 
-            guild = Guild(**await self._client.get_guild(int(_guild_id)), _client=self._client)
+        guild = Guild(**await self._client.get_guild(int(_guild_id)), _client=self._client)
 
         if int(guild.owner_id) == int(self.id):
             return Permissions.ALL

--- a/interactions/client/context.py
+++ b/interactions/client/context.py
@@ -310,6 +310,32 @@ class _Context(ClientSerializerMixin):
 
         return payload
 
+    async def has_permissions(
+        self,
+        *permissions: Union[int, Permissions],
+        operator: str = "and"
+    ) -> bool:
+        """
+        Returns whether the author of the interaction has the permissions in the given context.
+
+        :param *permissions: The list of permissions
+        :type *permissions: Union[int, Permissions]
+        :param operator: The operator to use to calculate permissions. Possible values: `and`, `or`. Defaults to `and`.
+        :type operator: str
+        :return: Whether the author has the permissions
+        :rtype: bool
+        """
+        if operator == "and":
+            for perm in permissions:
+                if perm not in self.author.permissions:
+                    return False
+            return True
+        else:
+            for perm in permissions:
+                if perm in self.author.permissions:
+                    return True
+            return False
+
 
 @define()
 class CommandContext(_Context):

--- a/interactions/client/context.py
+++ b/interactions/client/context.py
@@ -311,9 +311,7 @@ class _Context(ClientSerializerMixin):
         return payload
 
     async def has_permissions(
-        self,
-        *permissions: Union[int, Permissions],
-        operator: str = "and"
+        self, *permissions: Union[int, Permissions], operator: str = "and"
     ) -> bool:
         """
         Returns whether the author of the interaction has the permissions in the given context.


### PR DESCRIPTION
## About

Creation of `Context.has_permissions()` & `Member.has_permissions()`.
Also, allowed `Member.get_guild_permissions()` to not pass in the guild_id thanks to #1025 .

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues) (If existent):.
  - resolves #
- I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [x] New feature/enhancement
  - [ ] Bugfix
