### PR TITLE
fix: Change event sets, fix proper close() WS handling

### DIFF
--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -701,7 +701,7 @@ class WebSocketClient:
         Restarts the client's connection and heartbeat with the Gateway.
         """
 
-        self._ready.clear()
+        self.ready.clear()
 
         async with self.reconnect_lock:
             self.__closed.clear()
@@ -831,9 +831,11 @@ class WebSocketClient:
             # This is because the ratelimiter limits already accounts for this.
             await self._ratelimiter.block()
 
-        self._last_send = perf_counter()
-        log.debug(packet)
-        await self._client.send_str(packet)
+        if self._client is not None:  # this mitigates against another edge case.
+            self._last_send = perf_counter()
+            log.debug(packet)
+
+            await self._client.send_str(packet)
 
     async def __identify(
         self, shard: Optional[List[Tuple[int]]] = None, presence: Optional[ClientPresence] = None
@@ -919,4 +921,4 @@ class WebSocketClient:
         """
         if self._client:
             await self._client.close()
-        self._closed = True
+        self.__closed.set()


### PR DESCRIPTION
## About

This pull request fixes minor bugs relating to setting event locks and prevents another edge case of setting heartbeats when client isn't defined.

## Checklist

- [X] I've ran `pre-commit` to format and lint the change(s) made.
- [X] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues) (If existent):.
  - resolves #
- I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [X] Bugfix
