### PR TITLE
feat: Add full support for prune endpoints

### DIFF
--- a/interactions/api/http/guild.py
+++ b/interactions/api/http/guild.py
@@ -601,6 +601,32 @@ class GuildRequest:
             Route("DELETE", f"/guilds/{guild_id}/members/{user_id}"), reason=reason
         )
 
+    async def begin_guild_prune(
+            self,
+            guild_id: int,
+            days: int = 7,
+            compute_prune_count: bool = True,
+            include_roles: Optional[List[Role]] = None,
+    ) -> dict:
+        """
+        Begins a prune operation.
+
+        :param guild_id: Guild ID snowflake
+        :param days: Number of days to count. Defaults to ``7``.
+        :param compute_prune_count: Whether the returned "pruned" dict contains the computed prune count or None.
+        :param include_roles: Role IDs to include, if given.
+        :return: A dict containing `{"pruned": int}` or `{"pruned": None}`
+        """
+
+        payload = {
+            "days": days,
+            "compute_prune_count": compute_prune_count,
+        }
+        if include_roles:
+            payload["include_roles"] = include_roles
+
+        return await self._req.request(Route("POST", f"/guilds/{guild_id}/prune"), json=payload)
+
     async def get_guild_prune_count(
         self, guild_id: int, days: int = 7, include_roles: Optional[List[int]] = None
     ) -> dict:
@@ -608,7 +634,7 @@ class GuildRequest:
         Retrieves a dict from an API that results in how many members would be pruned given the amount of days.
 
         :param guild_id: Guild ID snowflake.
-        :param days:  Number of days to count. Defaults to ``7``.
+        :param days: Number of days to count. Defaults to ``7``.
         :param include_roles: Role IDs to include, if given.
         :return: A dict denoting `{"pruned": int}`
         """

--- a/interactions/api/http/guild.py
+++ b/interactions/api/http/guild.py
@@ -602,11 +602,11 @@ class GuildRequest:
         )
 
     async def begin_guild_prune(
-            self,
-            guild_id: int,
-            days: int = 7,
-            compute_prune_count: bool = True,
-            include_roles: Optional[List[int]] = None,
+        self,
+        guild_id: int,
+        days: int = 7,
+        compute_prune_count: bool = True,
+        include_roles: Optional[List[int]] = None,
     ) -> dict:
         """
         Begins a prune operation.
@@ -623,9 +623,7 @@ class GuildRequest:
             "compute_prune_count": compute_prune_count,
         }
         if include_roles:
-            payload["include_roles"] = ", ".join(
-                str(x) for x in include_roles
-            )
+            payload["include_roles"] = ", ".join(str(x) for x in include_roles)
 
         return await self._req.request(Route("POST", f"/guilds/{guild_id}/prune"), json=payload)
 

--- a/interactions/api/http/guild.py
+++ b/interactions/api/http/guild.py
@@ -606,7 +606,7 @@ class GuildRequest:
             guild_id: int,
             days: int = 7,
             compute_prune_count: bool = True,
-            include_roles: Optional[List[Role]] = None,
+            include_roles: Optional[List[int]] = None,
     ) -> dict:
         """
         Begins a prune operation.
@@ -623,7 +623,9 @@ class GuildRequest:
             "compute_prune_count": compute_prune_count,
         }
         if include_roles:
-            payload["include_roles"] = include_roles
+            payload["include_roles"] = ", ".join(
+                str(x) for x in include_roles
+            )
 
         return await self._req.request(Route("POST", f"/guilds/{guild_id}/prune"), json=payload)
 

--- a/interactions/api/http/guild.py
+++ b/interactions/api/http/guild.py
@@ -612,7 +612,7 @@ class GuildRequest:
         Begins a prune operation.
 
         :param guild_id: Guild ID snowflake
-        :param days: Number of days to count. Defaults to ``7``.
+        :param days: Number of days to count, minimum 1, maximum 30. Defaults to 7.
         :param compute_prune_count: Whether the returned "pruned" dict contains the computed prune count or None.
         :param include_roles: Role IDs to include, if given.
         :return: A dict containing `{"pruned": int}` or `{"pruned": None}`
@@ -636,7 +636,7 @@ class GuildRequest:
         Retrieves a dict from an API that results in how many members would be pruned given the amount of days.
 
         :param guild_id: Guild ID snowflake.
-        :param days: Number of days to count. Defaults to 7.
+        :param days: Number of days to count, minimum 1, maximum 30. Defaults to 7.
         :param include_roles: Role IDs to include, if given.
         :return: A dict denoting `{"pruned": int}`
         """

--- a/interactions/api/http/guild.py
+++ b/interactions/api/http/guild.py
@@ -636,7 +636,7 @@ class GuildRequest:
         Retrieves a dict from an API that results in how many members would be pruned given the amount of days.
 
         :param guild_id: Guild ID snowflake.
-        :param days: Number of days to count. Defaults to ``7``.
+        :param days: Number of days to count. Defaults to 7.
         :param include_roles: Role IDs to include, if given.
         :return: A dict denoting `{"pruned": int}`
         """

--- a/interactions/api/models/guild.py
+++ b/interactions/api/models/guild.py
@@ -1909,7 +1909,7 @@ class Guild(ClientSerializerMixin, IDMixin):
         self,
         days: int = 7,
         compute_prune_count: bool = True,
-        include_roles: Optional[Union[List[Role], List[int]]] = MISSING,
+        include_roles: Optional[Union[List[Role], List[int], List[Snowflake], List[str]]] = MISSING,
     ) -> Optional[int]:
         """
         Begins a prune operation.
@@ -1924,7 +1924,7 @@ class Guild(ClientSerializerMixin, IDMixin):
             raise LibraryException(code=13)
 
         if include_roles is not MISSING:
-            _roles = [role.id if isinstance(role, Role) else role for role in include_roles]
+            _roles = [int(role.id) if isinstance(role, Role) else int(role) for role in include_roles]
         else:
             _roles = None
 
@@ -1938,7 +1938,9 @@ class Guild(ClientSerializerMixin, IDMixin):
         return res.get("pruned")
 
     async def get_prune_count(
-        self, days: int = 7, include_roles: Optional[Union[List[Role], List[int]]] = MISSING
+            self,
+            days: int = 7,
+            include_roles: Optional[Union[List[Role], List[int], List[Snowflake], List[str]]] = MISSING
     ) -> int:
         """
         Returns the number of members that would be removed in a prune operation.
@@ -1952,7 +1954,7 @@ class Guild(ClientSerializerMixin, IDMixin):
             raise LibraryException(code=13)
 
         if include_roles is not MISSING:
-            _roles = [role.id if isinstance(role, Role) else role for role in include_roles]
+            _roles = [int(role.id) if isinstance(role, Role) else int(role) for role in include_roles]
         else:
             _roles = None
 

--- a/interactions/api/models/guild.py
+++ b/interactions/api/models/guild.py
@@ -1932,7 +1932,36 @@ class Guild(ClientSerializerMixin, IDMixin):
             guild_id=int(self.id),
             days=days,
             compute_prune_count=compute_prune_count,
-            include_roles=_roles
+            include_roles=_roles,
+        )
+
+        return res.get("pruned")
+
+    async def get_prune_count(
+            self,
+            days: int = 7,
+            include_roles: Optional[Union[List[Role], List[int]]] = MISSING
+    ) -> int:
+        """
+        Returns the number of members that would be removed in a prune operation.
+
+        :param days: Number of days to count. Defaults to 7.
+        :param include_roles: Role IDs to include, if given.
+        :return: The number of members that would be pruned.
+        :rtype: int
+        """
+        if not self._client:
+            raise LibraryException(code=13)
+
+        if include_roles is not MISSING:
+            _roles = [role.id if isinstance(role, Role) else role for role in include_roles]
+        else:
+            _roles = None
+
+        res: dict = await self._client.get_guild_prune_count(
+            guild_id=int(self.id),
+            days=days,
+            include_roles=_roles,
         )
 
         return res.get("pruned")

--- a/interactions/api/models/guild.py
+++ b/interactions/api/models/guild.py
@@ -1914,7 +1914,7 @@ class Guild(ClientSerializerMixin, IDMixin):
         """
         Begins a prune operation.
 
-        :param days: Number of days to count. Defaults to 7.
+        :param days: Number of days to count, minimum 1, maximum 3. Defaults to 7.
         :param compute_prune_count: Whether the returned "pruned" dict contains the computed prune count or None.
         :param include_roles: Role IDs to include, if given.
         :return: The number of pruned members, if compute_prune_count is not false. Otherwise returns None.
@@ -1945,7 +1945,7 @@ class Guild(ClientSerializerMixin, IDMixin):
         """
         Returns the number of members that would be removed in a prune operation.
 
-        :param days: Number of days to count. Defaults to 7.
+        :param days: Number of days to count, minimum 1, maximum 3. Defaults to 7.
         :param include_roles: Role IDs to include, if given.
         :return: The number of members that would be pruned.
         :rtype: int

--- a/interactions/api/models/guild.py
+++ b/interactions/api/models/guild.py
@@ -1905,6 +1905,38 @@ class Guild(ClientSerializerMixin, IDMixin):
 
         return res
 
+    async def prune(
+            self,
+            days: int = 7,
+            compute_prune_count: bool = True,
+            include_roles: Optional[Union[List[Role], List[int]]] = MISSING,
+    ) -> Optional[int]:
+        """
+        Begins a prune operation.
+
+        :param days: Number of days to count. Defaults to 7.
+        :param compute_prune_count: Whether the returned "pruned" dict contains the computed prune count or None.
+        :param include_roles: Role IDs to include, if given.
+        :return: The number of pruned members, if compute_prune_count is not false. Otherwise returns None.
+        :rtype: Optional[int]
+        """
+        if not self._client:
+            raise LibraryException(code=13)
+
+        if include_roles is not MISSING:
+            _roles = [role.id if isinstance(role, Role) else role for role in include_roles]
+        else:
+            _roles = None
+
+        res: dict = await self._client.begin_guild_prune(
+            guild_id=int(self.id),
+            days=days,
+            compute_prune_count=compute_prune_count,
+            include_roles=_roles
+        )
+
+        return res.get("pruned")
+
     async def get_emoji(
         self,
         emoji_id: int,

--- a/interactions/api/models/guild.py
+++ b/interactions/api/models/guild.py
@@ -1914,7 +1914,7 @@ class Guild(ClientSerializerMixin, IDMixin):
         """
         Begins a prune operation.
 
-        :param days: Number of days to count, minimum 1, maximum 3. Defaults to 7.
+        :param days: Number of days to count, minimum 1, maximum 30. Defaults to 7.
         :param compute_prune_count: Whether the returned "pruned" dict contains the computed prune count or None.
         :param include_roles: Role IDs to include, if given.
         :return: The number of pruned members, if compute_prune_count is not false. Otherwise returns None.
@@ -1947,7 +1947,7 @@ class Guild(ClientSerializerMixin, IDMixin):
         """
         Returns the number of members that would be removed in a prune operation.
 
-        :param days: Number of days to count, minimum 1, maximum 3. Defaults to 7.
+        :param days: Number of days to count, minimum 1, maximum 30. Defaults to 7.
         :param include_roles: Role IDs to include, if given.
         :return: The number of members that would be pruned.
         :rtype: int

--- a/interactions/api/models/guild.py
+++ b/interactions/api/models/guild.py
@@ -1906,10 +1906,10 @@ class Guild(ClientSerializerMixin, IDMixin):
         return res
 
     async def prune(
-            self,
-            days: int = 7,
-            compute_prune_count: bool = True,
-            include_roles: Optional[Union[List[Role], List[int]]] = MISSING,
+        self,
+        days: int = 7,
+        compute_prune_count: bool = True,
+        include_roles: Optional[Union[List[Role], List[int]]] = MISSING,
     ) -> Optional[int]:
         """
         Begins a prune operation.
@@ -1938,9 +1938,7 @@ class Guild(ClientSerializerMixin, IDMixin):
         return res.get("pruned")
 
     async def get_prune_count(
-            self,
-            days: int = 7,
-            include_roles: Optional[Union[List[Role], List[int]]] = MISSING
+        self, days: int = 7, include_roles: Optional[Union[List[Role], List[int]]] = MISSING
     ) -> int:
         """
         Returns the number of members that would be removed in a prune operation.

--- a/interactions/api/models/guild.py
+++ b/interactions/api/models/guild.py
@@ -1924,7 +1924,9 @@ class Guild(ClientSerializerMixin, IDMixin):
             raise LibraryException(code=13)
 
         if include_roles is not MISSING:
-            _roles = [int(role.id) if isinstance(role, Role) else int(role) for role in include_roles]
+            _roles = [
+                int(role.id) if isinstance(role, Role) else int(role) for role in include_roles
+            ]
         else:
             _roles = None
 
@@ -1938,9 +1940,9 @@ class Guild(ClientSerializerMixin, IDMixin):
         return res.get("pruned")
 
     async def get_prune_count(
-            self,
-            days: int = 7,
-            include_roles: Optional[Union[List[Role], List[int], List[Snowflake], List[str]]] = MISSING
+        self,
+        days: int = 7,
+        include_roles: Optional[Union[List[Role], List[int], List[Snowflake], List[str]]] = MISSING,
     ) -> int:
         """
         Returns the number of members that would be removed in a prune operation.
@@ -1954,7 +1956,9 @@ class Guild(ClientSerializerMixin, IDMixin):
             raise LibraryException(code=13)
 
         if include_roles is not MISSING:
-            _roles = [int(role.id) if isinstance(role, Role) else int(role) for role in include_roles]
+            _roles = [
+                int(role.id) if isinstance(role, Role) else int(role) for role in include_roles
+            ]
         else:
             _roles = None
 


### PR DESCRIPTION
## About

This pull request adds support for both `prune` endpoints, as well as their respective helper methods: `Guild.prune()` & `Guild.get_prune_count`.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues) (If existent):.
  - resolves #
- I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [x] New feature/enhancement
  - [ ] Bugfix
