### PR TITLE
refactor: Change type of parameters in scheduled event requests from Snowflake to int

### DIFF
--- a/interactions/api/http/scheduledEvent.py
+++ b/interactions/api/http/scheduledEvent.py
@@ -47,7 +47,7 @@ class ScheduledEventRequest:
 
         :param guild_id: Guild ID snowflake.
         :param guild_scheduled_event_id: Guild Scheduled Event ID snowflake.
-        :param with_user_count: A boolean to include number of users subscribed to the associated event, if given.
+        :param with_user_count: Whether the number of users subscribed to the events is returned.
         :return: A dictionary containing the guild scheduled event object on success.
         """
 
@@ -66,7 +66,7 @@ class ScheduledEventRequest:
         Gets all guild scheduled events in a guild.
 
         :param guild_id: Guild ID snowflake.
-        :param with_user_count: A boolean to include number of users subscribed to the associated event, if given.
+        :param with_user_count: Whether the number of users subscribed to the associated event is returned.
         :return: A List of a dictionary containing the guild scheduled event objects on success.
         """
         return await self._req.request(

--- a/interactions/api/http/scheduledEvent.py
+++ b/interactions/api/http/scheduledEvent.py
@@ -1,7 +1,6 @@
 from typing import List
 
 from ...api.cache import Cache
-from ..models import Snowflake
 from .request import _Request
 from .route import Route
 
@@ -16,7 +15,7 @@ class ScheduledEventRequest:
     def __init__(self) -> None:
         pass
 
-    async def create_scheduled_event(self, guild_id: Snowflake, payload: dict) -> dict:
+    async def create_scheduled_event(self, guild_id: int, payload: dict) -> dict:
         """
         Creates a scheduled event.
 
@@ -24,7 +23,6 @@ class ScheduledEventRequest:
         :param payload: The dictionary containing the parameters and values to edit the associated event.
         :return: A dictionary containing the new guild scheduled event object on success.
         """
-        guild_id = int(guild_id)
         valid_keys = (
             "channel_id",
             "name",
@@ -42,7 +40,7 @@ class ScheduledEventRequest:
         )
 
     async def get_scheduled_event(
-        self, guild_id: Snowflake, guild_scheduled_event_id: Snowflake, with_user_count: bool
+        self, guild_id: int, guild_scheduled_event_id: int, with_user_count: bool
     ) -> dict:
         """
         Gets a guild scheduled event.
@@ -52,22 +50,18 @@ class ScheduledEventRequest:
         :param with_user_count: A boolean to include number of users subscribed to the associated event, if given.
         :return: A dictionary containing the guild scheduled event object on success.
         """
-        guild_id, event_id = int(guild_id), int(guild_scheduled_event_id)
-        params = {}
-        if with_user_count:
-            params["with_user_count"] = str(with_user_count)
 
         return await self._req.request(
             Route(
                 "GET",
                 "/guilds/{guild_id}/scheduled-events/{event_id}",
                 guild_id=guild_id,
-                event_id=event_id,
+                event_id=guild_scheduled_event_id,
             ),
-            params=params,
+            params={"with_user_count": str(with_user_count).lower()},
         )
 
-    async def get_scheduled_events(self, guild_id: Snowflake, with_user_count: bool) -> List[dict]:
+    async def get_scheduled_events(self, guild_id: int, with_user_count: bool) -> List[dict]:
         """
         Gets all guild scheduled events in a guild.
 
@@ -75,17 +69,13 @@ class ScheduledEventRequest:
         :param with_user_count: A boolean to include number of users subscribed to the associated event, if given.
         :return: A List of a dictionary containing the guild scheduled event objects on success.
         """
-        guild_id = int(guild_id)
-        params = {}
-        if with_user_count:
-            params["with_user_count"] = with_user_count
-
         return await self._req.request(
-            Route("GET", "/guilds/{guild_id}/scheduled-events", guild_id=guild_id), params=params
+            Route("GET", "/guilds/{guild_id}/scheduled-events", guild_id=guild_id),
+            params={"with_user_count": str(with_user_count).lower()}
         )
 
     async def modify_scheduled_event(
-        self, guild_id: Snowflake, guild_scheduled_event_id: Snowflake, payload: dict
+        self, guild_id: int, guild_scheduled_event_id: int, payload: dict
     ) -> dict:
         """
         Modifies a scheduled event.
@@ -95,7 +85,6 @@ class ScheduledEventRequest:
         :param payload: The dictionary containing the parameters and values to edit the associated event.
         :return: A dictionary containing the updated guild scheduled event object on success.
         """
-        guild_id, event_id = int(guild_id), int(guild_scheduled_event_id)
         valid_keys = (
             "channel_id",
             "name",
@@ -112,13 +101,13 @@ class ScheduledEventRequest:
                 "PATCH",
                 "/guilds/{guild_id}/scheduled-events/{event_id}",
                 guild_id=guild_id,
-                event_id=event_id,
+                event_id=guild_scheduled_event_id,
             ),
             json=data,
         )
 
     async def delete_scheduled_event(
-        self, guild_id: Snowflake, guild_scheduled_event_id: Snowflake
+        self, guild_id: int, guild_scheduled_event_id: int
     ) -> None:
         """
         Deletes a guild scheduled event.
@@ -127,25 +116,24 @@ class ScheduledEventRequest:
         :param guild_scheduled_event_id: Guild Scheduled Event ID snowflake.
         :return: Nothing on success.
         """
-        guild_id, event_id = int(guild_id), int(guild_scheduled_event_id)
 
         return await self._req.request(
             Route(
                 "DELETE",
                 "/guilds/{guild_id}/scheduled-events/{event_id}",
                 guild_id=guild_id,
-                event_id=event_id,
+                event_id=guild_scheduled_event_id,
             )
         )
 
     async def get_scheduled_event_users(
         self,
-        guild_id: Snowflake,
-        guild_scheduled_event_id: Snowflake,
+        guild_id: int,
+        guild_scheduled_event_id: int,
         limit: int = 100,
         with_member: bool = False,
-        before: Snowflake = None,
-        after: Snowflake = None,
+        before: int = None,
+        after: int = None,
     ) -> dict:
         """
         Get the registered users of a scheduled event.
@@ -158,22 +146,21 @@ class ScheduledEventRequest:
         :param after: Considers only users after given user ID snowflake. Defaults to None.
         :return: Returns a list of guild scheduled event user objects on success.
         """
-        guild_id, event_id = int(guild_id), int(guild_scheduled_event_id)
         params = {
             "limit": limit,
             "with_member": with_member,
         }
         if before:
-            params["before"] = int(before)
+            params["before"] = before
         if after:
-            params["after"] = int(after)
+            params["after"] = after
 
         return await self._req.request(
             Route(
                 "GET",
                 "/guilds/{guild_id}/scheduled-events/{event_id}/users",
                 guild_id=guild_id,
-                event_id=event_id,
+                event_id=guild_scheduled_event_id,
             ),
             params=params,
         )

--- a/interactions/api/http/scheduledEvent.py
+++ b/interactions/api/http/scheduledEvent.py
@@ -71,7 +71,7 @@ class ScheduledEventRequest:
         """
         return await self._req.request(
             Route("GET", "/guilds/{guild_id}/scheduled-events", guild_id=guild_id),
-            params={"with_user_count": str(with_user_count).lower()}
+            params={"with_user_count": str(with_user_count).lower()},
         )
 
     async def modify_scheduled_event(
@@ -106,9 +106,7 @@ class ScheduledEventRequest:
             json=data,
         )
 
-    async def delete_scheduled_event(
-        self, guild_id: int, guild_scheduled_event_id: int
-    ) -> None:
+    async def delete_scheduled_event(self, guild_id: int, guild_scheduled_event_id: int) -> None:
         """
         Deletes a guild scheduled event.
 


### PR DESCRIPTION
## About

This pull request refactors the scheduledEvent http methods to take in `int` objects instead of `Snowflake`.
There's also a fix for `get_scheduled_events`, so the method now works properly when the parameter `with_counts` is set to True.

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues) (If existent):.
  - resolves #
- I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [x] New feature/enhancement
  - [x] Bugfix
