### PR TITLE
fix: Fix constant gateway resume/invalid session loop.

### DIFF
--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -989,9 +989,9 @@ class WebSocketClient:
                 "token": self._http.token,
                 "intents": self._intents.value,
                 "properties": {
-                    "$os": platform,
-                    "$browser": "interactions.py",
-                    "$device": "interactions.py",
+                    "os": platform,
+                    "browser": "interactions.py",
+                    "device": "interactions.py",
                 },
                 "compress": True,
             },
@@ -1055,5 +1055,4 @@ class WebSocketClient:
         """
         if self._client:
             await self._client.close()
-
         self.__closed.set()


### PR DESCRIPTION
## About

This pull request fixes the gateway `RESUME`/`INVALID_SESSION` loop that exists near the start of turning on the bot (or maybe any other point, idk). This isn't breaking, as smaller bots aren't impacted but bots of higher userbases (tested ~35k+) may loop repeatedly before this fix (and consequently, a 1006 error code which is pretty much vague).

(Not sure how this works without crashing either my bot or terminal but.. it does xD)

## Checklist

- [X] I've ran `pre-commit` to format and lint the change(s) made.
- [X] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues) (If existent):.
  - resolves #
- I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [X] Bugfix
