### PR TITLE
fix: warn for no app cmd scope for disable_sync

### DIFF
--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -460,13 +460,13 @@ class Client:
         # responsible for checking if a command is in the cache but not a coro -> allowing removal
 
         for _id in _guild_ids:
-            _cmds = await self._http.get_application_commands(
-                application_id=self.me.id, guild_id=_id, with_localizations=True
-            )
-
-            if isinstance(_cmds, dict) and _cmds.get("code"):
-                if int(_cmds.get("code")) != 50001:
-                    raise LibraryException(_cmds["code"], message=f'{_cmds["message"]} |')
+            try:
+                _cmds = await self._http.get_application_commands(
+                    application_id=self.me.id, guild_id=_id, with_localizations=True
+                )
+            except LibraryException as e:
+                if int(e.code) != 50001:
+                    raise LibraryException(code=e.code, message=e.message)
 
                 log.warning(
                     f"Your bot is missing access to guild with corresponding id {_id}! "


### PR DESCRIPTION
## About

This pull request fixes #1075 by implementing the same fix as #868 to the code that runs during `disable_sync`. See #1075 for more information.

But basically, if `disable_sync` is on, guilds without the `application.commands` scope will no longer make the bot error out, making it warn as intended instead.

## Checklist

- [x] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [ ] I've ensured the change(s) work on `3.8.6` and higher. (I actually can't test this, as Discord has made invite links with the `bot` scope also have the `application.commands` scope too. I don't have a server that invited the bot during the weird era where it was possible to just have the `bot` scope. It's really an edge case for when this happens, but it still can. Regardless, this fix should still work.)


I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [ ] To add a new feature
  - [ ] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [x] To fix an existing bug
  - [x] To resolve #1075 


This is:
  - [ ] A breaking change (technically yes, but this is more restoring the intended behavior than anything.)

  <!--- Expand this when more comes up--->
