### PR TITLE
fix: Fix race condition when reconnecting

### DIFF
--- a/interactions/base.py
+++ b/interactions/base.py
@@ -6,7 +6,7 @@ __all__ = (
     "__authors__",
 )
 
-__version__ = "4.3.2-beta.1"
+__version__ = "4.3.2-rc.1"
 
 __authors__ = {
     "current": [


### PR DESCRIPTION
## About

This pull request fixes race conditions that, on rc1 release, makes it impossible to reconnect because of lock referencing (a function that uses a lock internally cause another function that needs that lock). Can be reproduced if forcing it to reconnect manually or automatically

(ignore the first commit, this is an old branch and i cba)

## Checklist

- [X] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [X] I've ensured the change(s) work on `3.8.6` and higher.


I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [ ] To add a new feature
  - [ ] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [X] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

  <!--- Expand this when more comes up--->
