### PR TITLE
feat: add the client, command, and extension to CommandContext instances

### DIFF
--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -1038,6 +1038,7 @@ class Client:
                 description_localizations=description_localizations,
                 default_scope=default_scope,
             )
+            cmd.client = self
             self._commands.append(cmd)
             return cmd
 
@@ -1590,6 +1591,7 @@ class Extension:
                 continue
 
             cmd.extension = self
+            cmd.client = self.client
             self.client._commands.append(cmd)
 
             commands = self._commands.get(cmd.name, [])

--- a/interactions/client/context.py
+++ b/interactions/client/context.py
@@ -1,8 +1,7 @@
 from logging import Logger
-from typing import List, Optional, Union
+from typing import TYPE_CHECKING, List, Optional, Union
 
 from ..api.error import LibraryException
-from ..api.http.client import HTTPClient
 from ..api.models.channel import Channel
 from ..api.models.flags import Permissions
 from ..api.models.guild import Guild
@@ -17,6 +16,10 @@ from .enums import InteractionCallbackType, InteractionType
 from .models.command import Choice
 from .models.component import ActionRow, Button, Modal, SelectMenu, _build_components
 from .models.misc import InteractionData
+
+if TYPE_CHECKING:
+    from .bot import Client, Extension
+    from .models.command import Command
 
 log: Logger = get_logger("context")
 
@@ -43,7 +46,6 @@ class _Context(ClientSerializerMixin):
     :ivar Optional[Guild] guild: The guild data model.
     """
 
-    client: HTTPClient = field(default=None)
     message: Optional[Message] = field(converter=Message, default=None, add_client=True)
     author: Member = field(converter=Member, default=None, add_client=True)
     member: Member = field(converter=Member, add_client=True)
@@ -66,9 +68,6 @@ class _Context(ClientSerializerMixin):
     app_permissions: Permissions = field(converter=convert_int(Permissions), default=None)
 
     def __attrs_post_init__(self) -> None:
-        # backwards compatibility
-        self.client = self._client
-
         if self.member:
             if self.guild_id:
                 self.member._extras["guild_id"] = self.guild_id
@@ -370,6 +369,10 @@ class CommandContext(_Context):
     """
 
     target: Optional[Union[Message, Member, User]] = field(default=None)
+
+    client: "Client" = field(default=None, init=False)
+    command: "Command" = field(default=None, init=False)
+    extension: "Extension" = field(default=None, init=False)
 
     def __attrs_post_init__(self) -> None:
         super().__attrs_post_init__()

--- a/interactions/client/context.py
+++ b/interactions/client/context.py
@@ -366,6 +366,9 @@ class CommandContext(_Context):
     :ivar str locale?: The selected language of the user invoking the interaction.
     :ivar str guild_locale?: The guild's preferred language, if invoked in a guild.
     :ivar str app_permissions?: Bitwise set of permissions the bot has within the channel the interaction was sent from.
+    :ivar Client client: The client instance that the command belongs to.
+    :ivar Command command: The command object that is being invoked.
+    :ivar Extension extension: The extension the command belongs to.
     """
 
     target: Optional[Union[Message, Member, User]] = field(default=None)

--- a/interactions/client/models/command.py
+++ b/interactions/client/models/command.py
@@ -17,7 +17,7 @@ from ..enums import ApplicationCommandType, Locale, OptionType, PermissionType
 
 if TYPE_CHECKING:
     from ...api.dispatch import Listener
-    from ..bot import Extension
+    from ..bot import Client, Extension
     from ..context import CommandContext
 
 __all__ = (
@@ -437,6 +437,7 @@ class Command(DictSerializerMixin):
     error_callback: Optional[Callable[..., Awaitable]] = field(default=None, init=False)
     resolved: bool = field(default=False, init=False)
     extension: Optional["Extension"] = field(default=None, init=False)
+    client: "Client" = field(default=None, init=False)
     listener: Optional["Listener"] = field(default=None, init=False)
 
     def __attrs_post_init__(self) -> None:
@@ -927,6 +928,10 @@ class Command(DictSerializerMixin):
 
         @wraps(coro)
         async def wrapper(ctx: "CommandContext", *args, **kwargs):
+            ctx.client = self.client
+            ctx.command = self
+            ctx.extension = self.extension
+
             try:
                 if self.extension:
                     return await coro(self.extension, ctx, *args, **kwargs)

--- a/interactions/client/models/command.py
+++ b/interactions/client/models/command.py
@@ -413,6 +413,7 @@ class Command(DictSerializerMixin):
     :ivar Optional[str] recent_group: The name of the group most recently utilized.
     :ivar bool resolved: Whether the command is synced. Defaults to ``False``.
     :ivar Optional[Extension] extension: The extension that the command belongs to, if any.
+    :ivar Client client: The client that the command belongs to.
     :ivar Optional[Listener] listener: The listener, used for dispatching command errors.
     """
 


### PR DESCRIPTION
## About

This pull request adds the client, command, and extension to CommandContext instances

## Checklist

- [x] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.


I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [x] To add a new feature
  - [x] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [ ] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

  <!--- Expand this when more comes up--->
