### PR TITLE
fix: autodefer erroring when `*args` is empty

### DIFF
--- a/interactions/utils/utils.py
+++ b/interactions/utils/utils.py
@@ -78,13 +78,12 @@ def autodefer(
             except RuntimeError as e:
                 raise RuntimeError("No running event loop detected!") from e
 
-            if isinstance(args[0], (ComponentContext, CommandContext)):
+            if args and isinstance(args[0], (ComponentContext, CommandContext)):
                 self = ctx
                 args = list(args)
                 ctx = args.pop(0)
 
                 task: Task = loop.create_task(coro(self, ctx, *args, **kwargs))
-
             else:
                 task: Task = loop.create_task(coro(ctx, *args, **kwargs))
 


### PR DESCRIPTION
## About

This pull request fixes autodefer erroring when `*args` is empty.

## Checklist

- [x] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.


I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [ ] To add a new feature
  - [ ] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [x] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

  <!--- Expand this when more comes up--->
