### PR TITLE
fix: Reimplement manual sharding/presence, fix forum tag implementation

### DIFF
--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -122,6 +122,8 @@ class WebSocketClient:
         intents: Intents,
         session_id: Optional[str] = MISSING,
         sequence: Optional[int] = MISSING,
+        shards: Optional[List[Tuple[int]]] = MISSING,
+        presence: Optional[ClientPresence] = MISSING,
     ) -> None:
         """
         :param token: The token of the application for connecting to the Gateway.
@@ -132,6 +134,10 @@ class WebSocketClient:
         :type session_id?: Optional[str]
         :param sequence?: The identifier sequence if trying to reconnect. Defaults to ``None``.
         :type sequence?: Optional[int]
+        :param shards?: The list of shards for the application's initial connection, if provided. Defaults to ``None``.
+        :type shards?: Optional[List[Tuple[int]]]
+        :param presence?: The presence shown on an application once first connected. Defaults to ``None``.
+        :type presence?: Optional[ClientPresence]
         """
         try:
             self._loop = get_event_loop() if version_info < (3, 10) else get_running_loop()
@@ -161,8 +167,8 @@ class WebSocketClient:
         }
 
         self._intents: Intents = intents
-        self.__shard: Optional[List[Tuple[int]]] = None
-        self.__presence: Optional[ClientPresence] = None
+        self.__shard: Optional[List[Tuple[int]]] = None if shards is MISSING else shards
+        self.__presence: Optional[ClientPresence] = None if presence is MISSING else presence
 
         self._task: Optional[Task] = None
         self.__heartbeat_event = Event(loop=self._loop) if version_info < (3, 10) else Event()

--- a/interactions/api/http/channel.py
+++ b/interactions/api/http/channel.py
@@ -4,6 +4,7 @@ from ...api.cache import Cache
 from ..error import LibraryException
 from ..models.channel import Channel
 from ..models.message import Message
+from ..models.misc import Snowflake
 from .request import _Request
 from .route import Route
 
@@ -312,8 +313,10 @@ class ChannelRequest:
         self,
         channel_id: int,
         name: str,
+        moderated: bool = False,
         emoji_id: Optional[int] = None,
         emoji_name: Optional[str] = None,
+        reason: Optional[str] = None,
     ) -> dict:
         """
         Create a new tag.
@@ -324,25 +327,41 @@ class ChannelRequest:
 
         :param channel_id: Channel ID snowflake.
         :param name: The name of the tag
+        :param moderated: Whether the tag can only be assigned to moderators or not. Defaults to ``False``
         :param emoji_id: The ID of the emoji to use for the tag
         :param emoji_name: The name of the emoji to use for the tag
+        :param reason: The reason for the creating the tag, if any.
+        :return: A Forum tag.
         """
 
-        _dct = {"name": name}
+        # This *assumes* cache is up-to-date.
+
+        _channel = self.cache[Channel].get(Snowflake(channel_id))
+        _tags = [_._json for _ in _channel.available_tags]  # list of tags in dict form
+
+        _dct = {"name": name, "moderated": moderated}
         if emoji_id:
             _dct["emoji_id"] = emoji_id
         if emoji_name:
             _dct["emoji_name"] = emoji_name
 
-        return await self._req.request(Route("POST", f"/channels/{channel_id}/tags"), json=_dct)
+        _tags.append(_dct)
+
+        updated_channel = await self.modify_channel(
+            channel_id, {"available_tags": _tags}, reason=reason
+        )
+        _channel_obj = Channel(**updated_channel, _client=self)
+        return _channel_obj.available_tags[-1]._json
 
     async def edit_tag(
         self,
         channel_id: int,
         tag_id: int,
         name: str,
+        moderated: Optional[bool] = None,
         emoji_id: Optional[int] = None,
         emoji_name: Optional[str] = None,
+        reason: Optional[str] = None,
     ) -> dict:
         """
         Update a tag.
@@ -351,28 +370,62 @@ class ChannelRequest:
             Can either have an emoji_id or an emoji_name, but not both.
             emoji_id is meant for custom emojis, emoji_name is meant for unicode emojis.
 
+            The object returns *will* have a different tag ID.
+
         :param channel_id: Channel ID snowflake.
         :param tag_id: The ID of the tag to update.
+        :param moderated: Whether the tag can only be assigned to moderators or not. Defaults to ``False``
         :param name: The new name of the tag
         :param emoji_id: The ID of the emoji to use for the tag
         :param emoji_name: The name of the emoji to use for the tag
+        :param reason: The reason for deleting the tag, if any.
+
+        :return The updated tag object.
         """
 
-        _dct = {"name": name}
+        # This *assumes* cache is up-to-date.
+
+        _channel = self.cache[Channel].get(Snowflake(channel_id))
+        _tags = [_._json for _ in _channel.available_tags]  # list of tags in dict form
+
+        _old_tag = [tag for tag in _tags if tag["id"] == tag_id][0]
+
+        _tags.remove(_old_tag)
+
+        _dct = {"name": name, "tag_id": tag_id}
+        if moderated:
+            _dct["moderated"] = moderated
         if emoji_id:
             _dct["emoji_id"] = emoji_id
         if emoji_name:
             _dct["emoji_name"] = emoji_name
 
-        return await self._req.request(
-            Route("PUT", f"/channels/{channel_id}/tags/{tag_id}"), json=_dct
-        )
+        _tags.append(_dct)
 
-    async def delete_tag(self, channel_id: int, tag_id: int) -> None:  # wha?
+        updated_channel = await self.modify_channel(
+            channel_id, {"available_tags": _tags}, reason=reason
+        )
+        _channel_obj = Channel(**updated_channel, _client=self)
+
+        self.cache[Channel].merge(_channel_obj)
+
+        return [tag for tag in _channel_obj.available_tags if tag.name == name][0]
+
+    async def delete_tag(self, channel_id: int, tag_id: int, reason: Optional[str] = None) -> None:
         """
         Delete a forum tag.
 
         :param channel_id: Channel ID snowflake.
         :param tag_id: The ID of the tag to delete
+        :param reason: The reason for deleting the tag, if any.
         """
-        return await self._req.request(Route("DELETE", f"/channels/{channel_id}/tags/{tag_id}"))
+        _channel = self.cache[Channel].get(Snowflake(channel_id))
+        _tags = [_._json for _ in _channel.available_tags]
+
+        _old_tag = [tag for tag in _tags if tag["id"] == Snowflake(tag_id)][0]
+
+        _tags.remove(_old_tag)
+
+        request = await self.modify_channel(channel_id, {"available_tags": _tags}, reason=reason)
+
+        self.cache[Channel].merge(Channel(**request, _client=self))

--- a/interactions/api/http/thread.py
+++ b/interactions/api/http/thread.py
@@ -159,7 +159,7 @@ class ThreadRequest:
         reason: Optional[str] = None,
     ) -> dict:
         """
-        From a given channel, create a Thread with an optional message to start with..
+        From a given channel, create a Thread with an optional message to start with.
 
         :param channel_id: The ID of the channel to create this thread in
         :param name: The name of the thread
@@ -212,7 +212,7 @@ class ThreadRequest:
         :param name: The name of the thread
         :param auto_archive_duration: duration in minutes to automatically archive the thread after recent activity,
             can be set to: 60, 1440, 4320, 10080
-        :param message_payload: The payload/dictionary contents of the first message in the forum thread.
+        :param message: The payload/dictionary contents of the first message in the forum thread.
         :param applied_tags: List of tag ids that can be applied to the forum, if any.
         :param files: An optional list of files to send attached to the message.
         :param rate_limit_per_user: Seconds a user has to wait before sending another message (0 to 21600), if given.

--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -80,11 +80,13 @@ class Client:
         self._loop: AbstractEventLoop = get_event_loop()
         self._http: HTTPClient = token
         self._intents: Intents = kwargs.get("intents", Intents.DEFAULT)
-        self._websocket: WSClient = WSClient(token=token, intents=self._intents)
         self._shards: List[Tuple[int]] = kwargs.get("shards", [])
         self._commands: List[Command] = []
         self._default_scope = kwargs.get("default_scope")
         self._presence = kwargs.get("presence")
+        self._websocket: WSClient = WSClient(
+            token=token, intents=self._intents, shards=self._shards, presence=self._presence
+        )
         self._token = token
         self._extensions = {}
         self._scopes = set([])


### PR DESCRIPTION
## About

This pull request reimplements manual sharding/presence from Client args, which may have been accidentally removed in ~#1022.
This PR also refactors forum tag http implementation to account for cache, a new tag attribute + non-deprecated endpoint.
(This was broken prior because of cache and how the API handles tag editing, primarily)

(minor out of scope related PR but /shrug)

## Checklist

- [X] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [X] I've ensured the change(s) work on `3.8.6` and higher.


I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [ ] To add a new feature
  - [ ] As a general enhancement
  - [X] As a refactor of the library/the library's code
  - [x] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

  <!--- Expand this when more comes up--->
