### PR TITLE
fix: set `message.member.user` as `message.author` again

### DIFF
--- a/interactions/api/models/message.py
+++ b/interactions/api/models/message.py
@@ -831,6 +831,9 @@ class Message(ClientSerializerMixin, IDMixin):
             if self.guild_id:
                 self.member._extras["guild_id"] = self.guild_id
 
+        if self.author and self.member:
+            self.member.user = self.author
+
     async def get_channel(self) -> Channel:
         """
         Gets the channel where the message was sent.


### PR DESCRIPTION
## About

This pull request sets the `message.member.user` attributem which has been done in a previous version already but probably was removed in the attrs rewrite

## Checklist

- [x] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [ ] I've ensured the change(s) work on `3.8.6` and higher.


I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [ ] To add a new feature
  - [x] As a general enhancement
  - [x] As a refactor of the library/the library's code
  - [ ] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

  <!--- Expand this when more comes up--->
