### PR TITLE
fix: location of select values when dispatching for new select types

### DIFF
--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -382,11 +382,13 @@ class WebSocketClient:
                         if _context.data.component_type.value not in {5, 6, 7, 8}:
                             __args.append(_context.data.values)
                         else:
+                            _list = []  # temp storage for items
                             for value in _context.data._json.get("values"):
                                 _data = self.__select_option_type_context(
                                     _context, _context.data.component_type.value
                                 )  # resolved.
-                                __args.append(_data[value])
+                                _list.append(_data[value])
+                            __args.append(_list)
 
                     self._dispatch.dispatch("on_component", _context)
                 elif data["type"] == InteractionType.APPLICATION_COMMAND_AUTOCOMPLETE:


### PR DESCRIPTION
## About

This pull request fixes new select values being put directly into the coroutine arguments instead of into a list

## Checklist

- [x] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.


I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [ ] To add a new feature
  - [ ] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [x] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

  <!--- Expand this when more comes up--->
