### PR TITLE
fix: 429 error not shown

### DIFF
--- a/interactions/api/http/request.py
+++ b/interactions/api/http/request.py
@@ -148,9 +148,8 @@ class _Request:
                 ) as response:
                     if response.content_type == "application/json":
                         data = await response.json()
-                        __import__("pprint").pprint(data)
                         if isinstance(data, dict):
-                            message: str = data.get("message")
+                            message: Optional[str] = data.get("message")
                             code: int = data.get("code", response.status)
                         else:
                             message, code = None, response.status

--- a/interactions/api/http/request.py
+++ b/interactions/api/http/request.py
@@ -149,8 +149,9 @@ class _Request:
                     if response.content_type == "application/json":
                         data = await response.json()
                         __import__("pprint").pprint(data)
-                        message: str = data.get("message")
-                        code: int = data.get("code")
+                        if isinstance(data, dict):
+                            message: str = data.get("message")
+                            code: int = data.get("code")
                     else:
                         data, message, code = None, None, response.status
 

--- a/interactions/api/http/request.py
+++ b/interactions/api/http/request.py
@@ -2,7 +2,6 @@ import asyncio
 import traceback
 from asyncio import AbstractEventLoop, Lock, get_event_loop, get_running_loop, new_event_loop
 from contextlib import suppress
-from datetime import timedelta
 from json import dumps
 from logging import Logger
 from sys import version_info

--- a/interactions/api/http/request.py
+++ b/interactions/api/http/request.py
@@ -189,9 +189,9 @@ class _Request:
                         )
                     if code == 429:
                         amount = dict(
-                            hours=reset_after // 3600,
-                            minutes=(reset_after % 3600) // 60,
-                            seconds=reset_after % 60,
+                            hours=int(reset_after // 3600),
+                            minutes=int((reset_after % 3600) // 60),
+                            seconds=int(reset_after % 60),
                         )
                         log.warning(
                             f"(429) {LibraryException.lookup(429)} Locking down future requests for "

--- a/interactions/api/http/request.py
+++ b/interactions/api/http/request.py
@@ -148,8 +148,9 @@ class _Request:
                 ) as response:
                     if response.content_type == "application/json":
                         data = await response.json()
+                        message: str = data.get("message")
                     else:
-                        data = None
+                        data, message = None, None
 
                     reset_after: float = float(
                         response.headers.get(
@@ -160,7 +161,6 @@ class _Request:
                     _bucket: str = response.headers.get("X-RateLimit-Bucket")
                     is_global: bool = response.headers.get("X-RateLimit-Global", False)
                     code: int = response.status
-                    message: str = data.get("message")
 
                     log.debug(f"{route.method}: {route.__api__ + route.path}: {kwargs}")
 

--- a/interactions/api/http/request.py
+++ b/interactions/api/http/request.py
@@ -2,6 +2,7 @@ import asyncio
 import traceback
 from asyncio import AbstractEventLoop, Lock, get_event_loop, get_running_loop, new_event_loop
 from contextlib import suppress
+from datetime import timedelta
 from json import dumps
 from logging import Logger
 from sys import version_info
@@ -187,12 +188,14 @@ class _Request:
                             severity=50,
                         )
                     if code == 429:
+                        amount = dict(
+                            hours=reset_after // 3600,
+                            minutes=(reset_after % 3600) // 60,
+                            seconds=reset_after % 60,
+                        )
                         log.warning(
                             f"(429) {LibraryException.lookup(429)} Locking down future requests for "
-                            + f"{reset_after if reset_after < 60 else reset_after // 60} "
-                            + f"{'seconds' if reset_after < 60 else 'minutes'}"
-                            + f" {reset_after % 60 if reset_after > 60 else ''}"
-                            + f"{' seconds' if reset_after > 60 else ''}."
+                            + f"{amount['hours']} hours {amount['minutes']} minutes {amount['seconds']} seconds."
                         )
                         if is_global:
                             self._global_lock.reset_after = reset_after

--- a/interactions/api/http/request.py
+++ b/interactions/api/http/request.py
@@ -151,7 +151,9 @@ class _Request:
                         __import__("pprint").pprint(data)
                         if isinstance(data, dict):
                             message: str = data.get("message")
-                            code: int = data.get("code")
+                            code: int = data.get("code", response.status)
+                        else:
+                            message, code = None, response.status
                     else:
                         data, message, code = None, None, response.status
 

--- a/interactions/api/http/request.py
+++ b/interactions/api/http/request.py
@@ -179,7 +179,7 @@ class _Request:
                         # This "redundant" debug line is for debug use and tracing back the error codes.
 
                         raise LibraryException(message=message, code=code, severity=40, data=data)
-                    elif isinstance(data, dict) and code in (0, 403) and message:
+                    elif isinstance(data, dict) and code == 0 and message:
                         log.debug(
                             f"RETURN {response.status}: {dumps(data, indent=4, sort_keys=True)}"
                         )

--- a/interactions/api/http/request.py
+++ b/interactions/api/http/request.py
@@ -188,7 +188,11 @@ class _Request:
                         )
                     if code == 429:
                         log.warning(
-                            f"{LibraryException.lookup(429)} Locking down future requests for {reset_after} seconds."
+                            f"(429) {LibraryException.lookup(429)} Locking down future requests for "
+                            + f"{reset_after if reset_after < 60 else reset_after // 60} "
+                            + f"{'seconds' if reset_after < 60 else 'minutes'}"
+                            + f" {reset_after % 60 if reset_after > 60 else ''}"
+                            + f"{' seconds' if reset_after > 60 else ''}."
                         )
                         if is_global:
                             self._global_lock.reset_after = reset_after

--- a/interactions/api/http/request.py
+++ b/interactions/api/http/request.py
@@ -187,14 +187,14 @@ class _Request:
                             severity=50,
                         )
                     if code == 429:
-                        amount = dict(
-                            hours=int(reset_after // 3600),
-                            minutes=int((reset_after % 3600) // 60),
-                            seconds=int(reset_after % 60),
-                        )
+                        hours = int(reset_after // 3600)
+                        minutes = int((reset_after % 3600) // 60)
+                        seconds = int(reset_after % 60)
                         log.warning(
                             f"(429) {LibraryException.lookup(429)} Locking down future requests for "
-                            + f"{amount['hours']} hours {amount['minutes']} minutes {amount['seconds']} seconds."
+                            + f"{f'{hours} hours ' if hours else ''}"
+                            + f"{f'{minutes} minutes ' if minutes else ''}"
+                            + f"{f'{seconds} seconds ' if seconds else ''}"
                         )
                         if is_global:
                             self._global_lock.reset_after = reset_after

--- a/interactions/api/http/request.py
+++ b/interactions/api/http/request.py
@@ -146,7 +146,6 @@ class _Request:
                 async with self._session.request(
                     route.method, route.__api__ + route.path, **kwargs
                 ) as response:
-                    breakpoint()
                     if response.content_type == "application/json":
                         data = await response.json()
                         message: str = data.get("message")
@@ -188,6 +187,9 @@ class _Request:
                             severity=50,
                         )
                     if code == 429:
+                        log.warning(
+                            f"{LibraryException.lookup(429)} Locking down future requests for {reset_after} seconds."
+                        )
                         if is_global:
                             self._global_lock.reset_after = reset_after
                             self._loop.call_later(
@@ -197,9 +199,6 @@ class _Request:
                             _limiter.reset_after = reset_after
                             await asyncio.sleep(_limiter.reset_after)
                             continue
-                        log.warning(
-                            f"{LibraryException.lookup(429)} Locking down future requests for {reset_after} seconds."
-                        )
                     if remaining is not None and int(remaining) == 0:
                         log.warning(
                             f"The HTTP client has exhausted a per-route ratelimit. Locking route for {reset_after} seconds."

--- a/interactions/api/http/request.py
+++ b/interactions/api/http/request.py
@@ -149,8 +149,9 @@ class _Request:
                     if response.content_type == "application/json":
                         data = await response.json()
                         message: str = data.get("message")
+                        code: int = data.get("code")
                     else:
-                        data, message = None, None
+                        data, message, code = None, None, response.status
 
                     reset_after: float = float(
                         response.headers.get(
@@ -160,7 +161,6 @@ class _Request:
                     remaining: str = response.headers.get("X-RateLimit-Remaining")
                     _bucket: str = response.headers.get("X-RateLimit-Bucket")
                     is_global: bool = response.headers.get("X-RateLimit-Global", False)
-                    code: int = response.status
 
                     log.debug(f"{route.method}: {route.__api__ + route.path}: {kwargs}")
 
@@ -170,12 +170,16 @@ class _Request:
                     if isinstance(data, dict) and (
                         data.get("errors") or (code and code != 429 and message)
                     ):
-                        log.debug(f"RETURN {code}: {dumps(data, indent=4, sort_keys=True)}")
+                        log.debug(
+                            f"RETURN {response.status}: {dumps(data, indent=4, sort_keys=True)}"
+                        )
                         # This "redundant" debug line is for debug use and tracing back the error codes.
 
                         raise LibraryException(message=message, code=code, severity=40, data=data)
                     elif isinstance(data, dict) and code in (0, 403) and message:
-                        log.debug(f"RETURN {code}: {dumps(data, indent=4, sort_keys=True)}")
+                        log.debug(
+                            f"RETURN {response.status}: {dumps(data, indent=4, sort_keys=True)}"
+                        )
                         # This "redundant" debug line is for debug use and tracing back the error codes.
 
                         raise LibraryException(

--- a/interactions/api/http/request.py
+++ b/interactions/api/http/request.py
@@ -148,6 +148,7 @@ class _Request:
                 ) as response:
                     if response.content_type == "application/json":
                         data = await response.json()
+                        __import__("pprint").pprint(data)
                         message: str = data.get("message")
                         code: int = data.get("code")
                     else:

--- a/interactions/api/http/request.py
+++ b/interactions/api/http/request.py
@@ -146,6 +146,7 @@ class _Request:
                 async with self._session.request(
                     route.method, route.__api__ + route.path, **kwargs
                 ) as response:
+                    breakpoint()
                     if response.content_type == "application/json":
                         data = await response.json()
                         message: str = data.get("message")


### PR DESCRIPTION
## About

This pull request shows the 429 error properly.

I've been seeing lots of `JSONDecodeError`s from mostly Replit users (there is a documented case of it happening with Heroku as well), which leads to a `TypeError`. The common "fix" given to them was just to do `kill 1` in the shell with no additional information as to what happened and why.

When I looked further into the code, I saw that when Cloudflare ratelimits you, it returns an HTML page instead of JSON, causing the `JSONDecodeError` (because the library tries to JSONify the response immediately without any checks), which is typical for Replit users. The suggestion of `kill 1` basically runs the code on a new server in Replit, sometimes with a new IP, so it temporarily works again.

Ideally, this error shouldn't occur at all because the library handles ratelimits awesomely, but when it *does* occur, it isn't handled properly.

This PR highlights that it is a 429 error instead of not handling the exception.

## Checklist

- [x] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.


I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [ ] To add a new feature
  - [x] As a general enhancement
  - [x] As a refactor of the library/the library's code
  - [x] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

  <!--- Expand this when more comes up--->
