### PR TITLE
fix: The issue of multiple client unable to load the commands from the same extension

### DIFF
--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -509,7 +509,7 @@ class Client:
             This is an internal method. Do not call it unless you know what you are doing!
         """
         for cmd in self._commands:
-            if cmd.resolved:
+            if cmd.coro.__qualname__ in [Cmd.__qualname__ for Cmd in self.__command_coroutines]:
                 continue
 
             cmd.listener = self._websocket._dispatch
@@ -555,7 +555,6 @@ class Client:
                     self._scopes.add(cmd.scope if isinstance(cmd.scope, int) else cmd.scope.id)
 
             self.event(coro, name=f"command_{cmd.name}")
-            cmd.resolved = True
 
     async def __sync(self) -> None:  # sourcery no-metrics
         """

--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -1386,6 +1386,7 @@ class Client:
         else:
             log.debug(f"Loaded extension {name}.")
             self._extensions[_name] = module
+            del sys.modules[name]
             return extension
 
     def remove(

--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -1424,7 +1424,6 @@ class Client:
                         self._loop.create_task(
                             _extension.teardown(remove_commands=remove_commands)
                         )  # made for Extension, usable by others
-            del sys.modules[_name]
 
         else:
             with contextlib.suppress(AttributeError):

--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -509,7 +509,7 @@ class Client:
             This is an internal method. Do not call it unless you know what you are doing!
         """
         for cmd in self._commands:
-            if cmd.coro.__qualname__ in [Cmd.__qualname__ for Cmd in self.__command_coroutines]:
+            if cmd.coro.__qualname__ in [_cmd.__qualname__ for _cmd in self.__command_coroutines]:
                 continue
 
             cmd.listener = self._websocket._dispatch

--- a/interactions/client/models/command.py
+++ b/interactions/client/models/command.py
@@ -860,8 +860,7 @@ class Command(DictSerializerMixin):
             if has_args:  # foo(ctx, ..., *args, ..., **kwargs) OR foo(ctx, *args, ...)
                 return await _coro(
                     ctx,
-                    # pos before *args
-                    *(kwargs[opt] for opt in par_opts if opt in kwargs),
+                    *(kwargs[opt] for opt in par_opts if opt in kwargs),  # pos before *args
                     *args,
                     *(
                         kwargs[opt]

--- a/interactions/client/models/command.py
+++ b/interactions/client/models/command.py
@@ -411,7 +411,6 @@ class Command(DictSerializerMixin):
     :ivar Dict[str, int] num_options: The dictionary of the number of options per subcommand.
     :ivar Dict[str, Union[Callable[..., Awaitable], str]] autocompletions: The dictionary of autocompletions for the command.
     :ivar Optional[str] recent_group: The name of the group most recently utilized.
-    :ivar bool resolved: Whether the command is synced. Defaults to ``False``.
     :ivar Optional[Extension] extension: The extension that the command belongs to, if any.
     :ivar Client client: The client that the command belongs to.
     :ivar Optional[Listener] listener: The listener, used for dispatching command errors.
@@ -436,7 +435,6 @@ class Command(DictSerializerMixin):
     )
     recent_group: Optional[str] = field(default=None, init=False)
     error_callback: Optional[Callable[..., Awaitable]] = field(default=None, init=False)
-    resolved: bool = field(default=False, init=False)
     extension: Optional["Extension"] = field(default=None, init=False)
     client: "Client" = field(default=None, init=False)
     listener: Optional["Listener"] = field(default=None, init=False)
@@ -862,7 +860,8 @@ class Command(DictSerializerMixin):
             if has_args:  # foo(ctx, ..., *args, ..., **kwargs) OR foo(ctx, *args, ...)
                 return await _coro(
                     ctx,
-                    *(kwargs[opt] for opt in par_opts if opt in kwargs),  # pos before *args
+                    # pos before *args
+                    *(kwargs[opt] for opt in par_opts if opt in kwargs),
                     *args,
                     *(
                         kwargs[opt]


### PR DESCRIPTION
## About

This pull request is about fixing the issue of multiple client unable to load the commands from the same extension
```py
bot1 = Client(
    token=login["token1"],
)
bot2 = Client(
    token=login["token2"],
)
for filename in os.listdir("./cogs"):
    if filename.endswith(".py"):
        bot1.load(f"cogs.{filename[:-3]}")
        bot2.load(f"cogs.{filename[:-3]}")
```
Will load the cogs into both Clients However due to some unidentified reasons the commands `self.client` will always be bot2
## Checklist

- [x] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.


I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [ ] To add a new feature
  - [ ] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [x] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

  <!--- Expand this when more comes up--->
