### PR TITLE
Raise all exceptions from request

### DIFF
--- a/interactions/api/http/request.py
+++ b/interactions/api/http/request.py
@@ -223,10 +223,7 @@ class _Request:
             except Exception as e:
                 with suppress(RuntimeError):
                     _limiter.lock.release()
-                if isinstance(e, LibraryException):
-                    raise
-                log.error("".join(traceback.format_exception(type(e), e, e.__traceback__)))
-                break
+                raise
 
     async def close(self) -> None:
         """Closes the current session."""


### PR DESCRIPTION
## About

When hitting the rate limit using `ctx.message.edit(files=[...])` the following trace is logged:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/interactions/api/http/request.py", line 146, in request
    async with self._session.request(
  File "/usr/local/lib/python3.8/dist-packages/aiohttp/client.py", line 1141, in __aenter__
    self._resp = await self._coro
  File "/usr/local/lib/python3.8/dist-packages/aiohttp/client.py", line 508, in _request
    req = self._request_class(
  File "/usr/local/lib/python3.8/dist-packages/aiohttp/client_reqrep.py", line 313, in __init__
    self.update_body_from_data(data)
  File "/usr/local/lib/python3.8/dist-packages/aiohttp/client_reqrep.py", line 517, in update_body_from_data
    size = body.size
  File "/usr/local/lib/python3.8/dist-packages/aiohttp/multipart.py", line 871, in size
    if encoding or te_encoding or part.size is None:
  File "/usr/local/lib/python3.8/dist-packages/aiohttp/payload.py", line 379, in size
    return os.fstat(self._value.fileno()).st_size - self._value.tell()
ValueError: I/O operation on closed file
```

It appears the files are closed before the request is sent (or retried). This only happens in a rate-limit scenario. I dug into the code and I can't see a reason hide all errors that aren't `LibraryException`.

Sorry, I haven't tested this code (I'm doing this just before heading out). Just raising here for discussion, will send test results soon.

## Checklist

- [ ] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [ ] I've ensured the change(s) work on `3.8.6` and higher.


I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [ ] To add a new feature
  - [ ] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [x] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

  <!--- Expand this when more comes up--->
