### PR TITLE
fix: add missed client to `Message.attachments`

### DIFF
--- a/interactions/api/models/message.py
+++ b/interactions/api/models/message.py
@@ -797,7 +797,9 @@ class Message(ClientSerializerMixin, IDMixin):
     mention_channels: Optional[List[ChannelMention]] = field(
         converter=convert_list(ChannelMention), default=None
     )
-    attachments: List[Attachment] = field(converter=convert_list(Attachment), default=None, add_client=True)
+    attachments: List[Attachment] = field(
+        converter=convert_list(Attachment), default=None, add_client=True
+    )
     embeds: List[Embed] = field(converter=convert_list(Embed), default=None)
     reactions: Optional[List[ReactionObject]] = field(
         converter=convert_list(ReactionObject), default=None

--- a/interactions/api/models/message.py
+++ b/interactions/api/models/message.py
@@ -797,7 +797,7 @@ class Message(ClientSerializerMixin, IDMixin):
     mention_channels: Optional[List[ChannelMention]] = field(
         converter=convert_list(ChannelMention), default=None
     )
-    attachments: List[Attachment] = field(converter=convert_list(Attachment), default=None)
+    attachments: List[Attachment] = field(converter=convert_list(Attachment), default=None, add_client=True)
     embeds: List[Embed] = field(converter=convert_list(Embed), default=None)
     reactions: Optional[List[ReactionObject]] = field(
         converter=convert_list(ReactionObject), default=None


### PR DESCRIPTION
## About

This pull request adds missed client to `Message.attachments` field.

## Checklist

- [ ] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [ ] I've ensured the change(s) work on `3.8.6` and higher.


I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [ ] To add a new feature
  - [ ] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [x] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

  <!--- Expand this when more comes up--->
