### PR TITLE
feat: Add a ``wait_for_select`` method

### DIFF
--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -386,10 +386,10 @@ class WebSocketClient:
                             __args.append(_context.data.values)
                         else:
                             _list = []  # temp storage for items
+                            _data = self.__select_option_type_context(
+                                _context, _context.data.component_type.value
+                            )  # resolved.
                             for value in _context.data._json.get("values"):
-                                _data = self.__select_option_type_context(
-                                    _context, _context.data.component_type.value
-                                )  # resolved.
                                 _list.append(_data[value])
                             __args.append(_list)
 

--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -1599,9 +1599,17 @@ class Client:
         Waits for a component to be interacted with, and returns the resulting context.
 
         .. note::
-            If you are waiting for a select menu, you can find the selected values in ``ctx.data.values``
+            If you are waiting for a select menu, you can find the selected values in ``ctx.data.values``.
+            Another possibility is using the meth:`self.wait_for_select` method like this:
 
-        :param Union[str, interactions.Button, interactions.SelectMenu, List[Union[str, interactions.Button, interactions.SelectMenu]]] components: The component(s) to wait for
+            .. code-block:: python
+                ctx, values = await bot.wait_for_select(custom_id)
+
+            In this case ``ctx`` will be your normal context and ``values`` will be a list of :class:`str`, :class:`Member`, :class:`User`, :class:`Channel` or :class:`Role`
+            depending on which select type you reveived.
+
+
+        :param Union[str, Button, SelectMenu, List[Union[str, Button, SelectMenu]]] components: The component(s) to wait for
         :param Union[interactions.Message, int, List[Union[interactions.Message, int]]] messages: The message(s) to check for
         :param Callable check: A function or coroutine to call, which should return a truthy value if the data should be returned
         :param float timeout: How long to wait for the event before raising an error
@@ -1659,8 +1667,8 @@ class Client:
     async def wait_for_select(
         self,
         components: Union[
-            Union[str, Button],
-            List[Union[str, Button]],
+            Union[str, SelectMenu],
+            List[Union[str, SelectMenu]],
         ] = None,
         messages: Union[Message, int, List[Union[Message, int]]] = None,
         check: Optional[Callable[..., Union[bool, Awaitable[bool]]]] = None,
@@ -1670,7 +1678,7 @@ class Client:
         Waits for a select menu to be interacted with, and returns the resulting context and a list of the selected values.
 
 
-        :param Union[str, interactions.SelectMenu, List[Union[str, interactions.SelectMenu]]] components: The component(s) to wait for
+        :param Union[str, SelectMenu, List[Union[str, SelectMenu]]] components: The component(s) to wait for
         :param Union[interactions.Message, int, List[Union[interactions.Message, int]]] messages: The message(s) to check for
         :param Callable check: A function or coroutine to call, which should return a truthy value if the data should be returned
         :param float timeout: How long to wait for the event before raising an error

--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -13,11 +13,14 @@ from typing import Any, Awaitable, Callable, Coroutine, Dict, List, Optional, Tu
 from ..api import WebSocketClient as WSClient
 from ..api.error import LibraryException
 from ..api.http.client import HTTPClient
+from ..api.models.channel import Channel
 from ..api.models.flags import Intents, Permissions
 from ..api.models.guild import Guild
+from ..api.models.member import Member
 from ..api.models.message import Message
 from ..api.models.misc import Image, Snowflake
 from ..api.models.presence import ClientPresence
+from ..api.models.role import Role
 from ..api.models.team import Application
 from ..api.models.user import User
 from ..base import get_logger
@@ -1652,6 +1655,88 @@ class Client:
             return check(ctx) if check else True
 
         return await self.wait_for("on_component", check=_check, timeout=timeout)
+
+    async def wait_for_select(
+        self,
+        components: Union[
+            Union[str, Button],
+            List[Union[str, Button]],
+        ] = None,
+        messages: Union[Message, int, List[Union[Message, int]]] = None,
+        check: Optional[Callable[..., Union[bool, Awaitable[bool]]]] = None,
+        timeout: Optional[float] = None,
+    ) -> Tuple[ComponentContext, List[Union[str, Member, User, Role, Channel]]]:
+        """
+        Waits for a select menu to be interacted with, and returns the resulting context and a list of the selected values.
+
+
+        :param Union[str, interactions.SelectMenu, List[Union[str, interactions.SelectMenu]]] components: The component(s) to wait for
+        :param Union[interactions.Message, int, List[Union[interactions.Message, int]]] messages: The message(s) to check for
+        :param Callable check: A function or coroutine to call, which should return a truthy value if the data should be returned
+        :param float timeout: How long to wait for the event before raising an error
+        :return: The ComponentContext and list of selections of the dispatched event
+        :rtype: Tuple[ComponentContext, Union[List[str], List[Member], List[User], List[Channel], List[Role]]]
+        """
+        custom_ids: List[str] = []
+        messages_ids: List[int] = []
+
+        if components:
+            if isinstance(components, list):
+                for component in components:
+                    if isinstance(component, SelectMenu):
+                        custom_ids.append(component.custom_id)
+                    elif isinstance(component, ActionRow):
+                        custom_ids.extend([c.custom_id for c in component.components])
+                    elif isinstance(component, list):
+                        for c in component:
+                            if isinstance(c, SelectMenu):
+                                custom_ids.append(c.custom_id)
+                            elif isinstance(c, ActionRow):
+                                custom_ids.extend([s.custom_id for s in c.components])
+                            elif isinstance(c, str):
+                                custom_ids.append(c)
+                    elif isinstance(component, str):
+                        custom_ids.append(component)
+            elif isinstance(components, SelectMenu):
+                custom_ids.append(components.custom_id)
+            elif isinstance(components, ActionRow):
+                custom_ids.extend([c.custom_id for c in components.components])  # noqa
+            elif isinstance(components, str):
+                custom_ids.append(components)
+
+        if messages:
+            if isinstance(messages, Message):
+                messages_ids.append(int(messages.id))
+            elif isinstance(messages, list):
+                for message in messages:
+                    if isinstance(message, Message):
+                        messages_ids.append(int(message.id))
+                    else:
+                        messages_ids.append(int(message))
+            else:  # account for plain ints, string, or Snowflakes
+                messages_ids.append(int(messages))
+
+        def _check(_ctx: ComponentContext) -> bool:
+            if custom_ids and _ctx.data.custom_id not in custom_ids:
+                return False
+            if messages_ids and int(_ctx.message.id) not in messages_ids:
+                return False
+            if _ctx.data.component_type.value not in {4, 5, 6, 7, 8}:
+                return False
+            return check(_ctx) if check else True
+
+        ctx: ComponentContext = await self.wait_for("on_component", check=_check, timeout=timeout)
+
+        if ctx.data.component_type == 4:
+            return ctx, ctx.data.values
+        else:
+            _list = []  # temp storage for items
+            _data = self._websocket._WebSocketClient__select_option_type_context(
+                ctx, ctx.data.component_type.value
+            )  # resolved.
+            for value in ctx.data.values:
+                _list.append(_data[value])
+            return ctx, _list
 
     async def wait_for_modal(
         self,

--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -1600,7 +1600,7 @@ class Client:
 
         .. note::
             If you are waiting for a select menu, you can find the selected values in ``ctx.data.values``.
-            Another possibility is using the meth:`self.wait_for_select` method like this:
+            Another possibility is using the :meth:`self.wait_for_select` method like this:
 
             .. code-block:: python
                 ctx, values = await bot.wait_for_select(custom_id)

--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -1600,16 +1600,7 @@ class Client:
 
         .. note::
             If you are waiting for a select menu, you can find the selected values in ``ctx.data.values``.
-            Another possibility is using the :meth:`self.wait_for_select` method like this:
-
-            .. code-block:: python
-
-                ctx, values = await bot.wait_for_select(custom_id)
-
-
-            In this case ``ctx`` will be your normal context and ``values`` will be a list of :class:`str`, :class:`Member`, :class:`User`, :class:`Channel` or :class:`Role` objects,
-            depending on which select type you received.
-
+            Another possibility is using the :meth:`.Client.wait_for_select` method.
 
         :param Union[str, Button, SelectMenu, List[Union[str, Button, SelectMenu]]] components: The component(s) to wait for
         :param Union[interactions.Message, int, List[Union[interactions.Message, int]]] messages: The message(s) to check for
@@ -1678,6 +1669,15 @@ class Client:
     ) -> Tuple[ComponentContext, List[Union[str, Member, User, Role, Channel]]]:
         """
         Waits for a select menu to be interacted with, and returns the resulting context and a list of the selected values.
+
+        The method can be used like this:
+
+        .. code-block:: python
+
+            ctx, values = await bot.wait_for_select(custom_id)
+
+        In this case ``ctx`` will be your normal context and ``values`` will be a list of :class:`str`, :class:`.Member`, :class:`.User`, :class:`.Channel` or :class:`.Role` objects,
+        depending on which select type you received.
 
 
         :param Union[str, SelectMenu, List[Union[str, SelectMenu]]] components: The component(s) to wait for

--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -1608,7 +1608,7 @@ class Client:
 
 
             In this case ``ctx`` will be your normal context and ``values`` will be a list of :class:`str`, :class:`Member`, :class:`User`, :class:`Channel` or :class:`Role` objects,
-            depending on which select type you reveived.
+            depending on which select type you received.
 
 
         :param Union[str, Button, SelectMenu, List[Union[str, Button, SelectMenu]]] components: The component(s) to wait for

--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -1603,7 +1603,9 @@ class Client:
             Another possibility is using the :meth:`self.wait_for_select` method like this:
 
             .. code-block:: python
+
                 ctx, values = await bot.wait_for_select(custom_id)
+
 
             In this case ``ctx`` will be your normal context and ``values`` will be a list of :class:`str`, :class:`Member`, :class:`User`, :class:`Channel` or :class:`Role` objects,
             depending on which select type you reveived.

--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -1605,7 +1605,7 @@ class Client:
             .. code-block:: python
                 ctx, values = await bot.wait_for_select(custom_id)
 
-            In this case ``ctx`` will be your normal context and ``values`` will be a list of :class:`str`, :class:`Member`, :class:`User`, :class:`Channel` or :class:`Role`
+            In this case ``ctx`` will be your normal context and ``values`` will be a list of :class:`str`, :class:`Member`, :class:`User`, :class:`Channel` or :class:`Role` objects,
             depending on which select type you reveived.
 
 


### PR DESCRIPTION
## About

This pull request adds ``wait_for_select`` to the client, allowing an easier receving of the selected values.

## Checklist

- [x] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.


I've made this pull request: (check all that apply)
  - [x] For the documentation
  - [x] To add a new feature
  - [x] As a general enhancement
  - [x] As a refactor of the library/the library's code
  - [ ] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

  <!--- Expand this when more comes up--->
