### PR TITLE
refactor: allow stacking extension decorators

### DIFF
--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -1817,22 +1817,21 @@ class Extension:
                     self._listeners[listener_name] = listeners
 
             if hasattr(func, "__component_data__"):
-                if hasattr(func, "__component_data__"):
-                    all_component_data: List[Tuple[tuple, dict]] = func.__component_data__
-                    for args, kwargs in all_component_data:
-                        func = client.component(*args, **kwargs)(func)
+                all_component_data: List[Tuple[tuple, dict]] = func.__component_data__
+                for args, kwargs in all_component_data:
+                    func = client.component(*args, **kwargs)(func)
 
-                        component = kwargs.get("component") or args[0]
-                        comp_name = (
-                            _component(component).custom_id
-                            if isinstance(component, (Button, SelectMenu))
-                            else component
-                        )
-                        comp_name = f"component_{comp_name}"
+                    component = kwargs.get("component") or args[0]
+                    comp_name = (
+                        _component(component).custom_id
+                        if isinstance(component, (Button, SelectMenu))
+                        else component
+                    )
+                    comp_name = f"component_{comp_name}"
 
-                        listeners = self._listeners.get(comp_name, [])
-                        listeners.append(func)
-                        self._listeners[comp_name] = listeners
+                    listeners = self._listeners.get(comp_name, [])
+                    listeners.append(func)
+                    self._listeners[comp_name] = listeners
 
             if hasattr(func, "__autocomplete_data__"):
                 all_args_kwargs = func.__autocomplete_data__

--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -1839,8 +1839,8 @@ class Extension:
                 for args, kwargs in all_args_kwargs:
                     func = client.autocomplete(*args, **kwargs)(func)
 
-                    name = kwargs.get("name") or args[0]
-                    _command = kwargs.get("command") or args[1]
+                    _command = kwargs.get("command") or args[0]
+                    name = kwargs.get("name") or args[1]
 
                     _command: Union[Snowflake, int] = (
                         _command.id if isinstance(_command, ApplicationCommand) else _command

--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -1934,8 +1934,7 @@ def extension_listener(func: Optional[Coroutine] = None, name: Optional[str] = N
 
     if func:
         # allows omitting `()` on `@listener`
-        func.__listener_name__ = name or func.__name__
-        return func
+        return decorator(func)
 
     return decorator
 

--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -1935,7 +1935,8 @@ def extension_listener(func: Optional[Coroutine] = None, name: Optional[str] = N
 
     if func:
         # allows omitting `()` on `@listener`
-        return decorator(func)
+        func.__listener_name__ = name or func.__name__
+        return func
 
     return decorator
 


### PR DESCRIPTION
## About

This pull request adds ability to stack extension decorators

## Checklist

- [x] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.


I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [ ] To add a new feature
  - [x] As a general enhancement
  - [x] As a refactor of the library/the library's code
  - [x] To fix an existing bug
  - [x] resolves #1107 


This is:
  - [ ] A breaking change

  <!--- Expand this when more comes up--->
