### PR TITLE
refactor!: remove all unwanted `__repr__` and `__str__`

### DIFF
--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -232,3 +232,7 @@ your option name! Example:
 ~~~~~~~~~~~~~~~
 
 The ``Color`` class was refactored into an enum. You may now access its contents via ``interactions.Color.COLOR``.
+Due to `complaints <https://www.github.com/interactions-py/library/issues/1040>`_ on str and repr magic methods, we have
+decided to `remove all implementations of them in the model classes <https://www.github.com/interactions.py/library/pulls/1050>`_.
+This affects the way you can send emojis. You can no longer use ``str(emoji)`` or ``f"{emoji}"``.
+Instead you will have to use ``emoji.format`` or ``f"{emoji.format}"`` to transform an emoji into a send-able form.

--- a/interactions/api/models/channel.py
+++ b/interactions/api/models/channel.py
@@ -478,9 +478,6 @@ class Channel(ClientSerializerMixin, IDMixin):
                 if not self.recipients:
                     self.recipients = channel.recipients
 
-    def __repr__(self) -> str:
-        return self.name
-
     @property
     def typing(self) -> Union[Awaitable, ContextManager]:
         """

--- a/interactions/api/models/emoji.py
+++ b/interactions/api/models/emoji.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 __all__ = ("Emoji",)
 
 
-@define(repr=False)
+@define()
 class Emoji(ClientSerializerMixin):
     """
     A class objecting representing an emoji.
@@ -36,7 +36,7 @@ class Emoji(ClientSerializerMixin):
     animated: Optional[bool] = field(default=None)
     available: Optional[bool] = field(default=None)
 
-    def __repr__(self):
+    def __str__(self):
         return (
             f"<{'a' if self.animated else ''}:{self.name}:{self.id}>"
             if self.id is not None

--- a/interactions/api/models/emoji.py
+++ b/interactions/api/models/emoji.py
@@ -40,6 +40,8 @@ class Emoji(ClientSerializerMixin):
         return (
             f"<{'a' if self.animated else ''}:{self.name}:{self.id}>"
             if self.id is not None
+            else f":{self.name}:"
+            if self.require_colons
             else self.name
         )
 

--- a/interactions/api/models/emoji.py
+++ b/interactions/api/models/emoji.py
@@ -36,7 +36,12 @@ class Emoji(ClientSerializerMixin):
     animated: Optional[bool] = field(default=None)
     available: Optional[bool] = field(default=None)
 
-    def __str__(self):
+    @property
+    def format(self) -> str:
+        """
+        Formats the emoji into a send-able form.
+        :rtype: str
+        """
         return (
             f"<{'a' if self.animated else ''}:{self.name}:{self.id}>"
             if self.id is not None

--- a/interactions/api/models/guild.py
+++ b/interactions/api/models/guild.py
@@ -482,9 +482,6 @@ class Guild(ClientSerializerMixin, IDMixin):
                 if not member._extras.get("guild_id"):
                     member._extras["guild_id"] = self.id
 
-    def __repr__(self) -> str:
-        return self.name
-
     async def ban(
         self,
         member_id: Union[int, Member, Snowflake],

--- a/interactions/api/models/member.py
+++ b/interactions/api/models/member.py
@@ -66,9 +66,6 @@ class Member(ClientSerializerMixin, IDMixin):
     )  # TODO: Investigate what this is for when documented by Discord.
     flags: int = field(repr=False)  # TODO: Investigate what this is for when documented by Discord.
 
-    def __str__(self) -> str:
-        return self.name or ""
-
     def __getattr__(self, name):
         # Forward any attributes the user has to make it easier for devs
         try:

--- a/interactions/api/models/user.py
+++ b/interactions/api/models/user.py
@@ -55,9 +55,6 @@ class User(ClientSerializerMixin, IDMixin):
     public_flags: Optional[UserFlags] = field(converter=UserFlags, default=None, repr=False)
     bio: Optional[str] = field(default=None)
 
-    def __str__(self) -> str:
-        return self.username
-
     def has_public_flag(self, flag: Union[UserFlags, int]) -> bool:
         if self.public_flags == 0 or self.public_flags is None:
             return False


### PR DESCRIPTION
## About

This pull request removes the `__repr__` and `__str__` so they do not override the attrs repr

## Checklist

- [x] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.


I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [ ] To add a new feature
  - [ ] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [x] To fix an existing bug
  - [x] To resolve #1140


This is:
  - [ ] A breaking change

  <!--- Expand this when more comes up--->
