### PR TITLE
feat!: rework how i.py handles the event loop

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -50,11 +50,13 @@ What does that mean? Well, we'll show you:
 
 .. code-block:: python
 
+    import asyncio
     import interactions
+    import discord
     from discord.ext import commands
 
     client = interactions.Client(token="...")
-    dpy = commands.Bot(prefix="/")
+    dpy = commands.Bot(command_prefix="/", intents=...)
 
     @dpy.command()
     async def hello(ctx):
@@ -67,13 +69,10 @@ What does that mean? Well, we'll show you:
     async def test(ctx):
         await ctx.send("Hello from discord-interactions!")
 
-    loop = asyncio.get_event_loop()
+    async def main():
+        await asyncio.gather(client.astart(), dpy.start(token=token))
 
-    task2 = loop.create_task(dpy.start(token="...", bot=True))
-    task1 = loop.create_task(client.ready())
-
-    gathered = asyncio.gather(task1, task2, loop=loop)
-    loop.run_until_complete(gathered)
+    asyncio.run(main())
 
 Both of these variables ``interactions`` and ``dpy`` will be able to run in the same established environment, and additionally
 will both function properly as their respective libraries intend them to. This implementation uses asyncio.gather to execute

--- a/interactions/api/dispatch.py
+++ b/interactions/api/dispatch.py
@@ -1,4 +1,4 @@
-from asyncio import AbstractEventLoop, Future, get_event_loop
+from asyncio import AbstractEventLoop, Future, get_running_loop
 from logging import Logger
 from typing import Callable, Coroutine, Dict, List, Optional
 
@@ -20,7 +20,7 @@ class Listener:
     __slots__ = ("loop", "events", "extra_events")
 
     def __init__(self) -> None:
-        self.loop: AbstractEventLoop = get_event_loop()
+        self.loop: AbstractEventLoop = get_running_loop()
         self.events: Dict[str, List[Callable[..., Coroutine]]] = {}
         self.extra_events: Dict[str, List[Future]] = {}  # used in `Client.wait_for`
 

--- a/interactions/api/gateway/heartbeat.py
+++ b/interactions/api/gateway/heartbeat.py
@@ -1,6 +1,4 @@
-import contextlib
-from asyncio import AbstractEventLoop, Event
-from sys import version_info
+from asyncio import Event
 
 __all__ = ("_Heartbeat",)
 
@@ -11,11 +9,6 @@ class _Heartbeat:
     event: Event
     delay: float
 
-    def __init__(self, loop: AbstractEventLoop) -> None:
-        """
-        :param loop: The event loop to base the asynchronous manager.
-        :type loop: AbstractEventLoop
-        """
-        with contextlib.suppress(TypeError):
-            self.event = Event(loop=loop) if version_info < (3, 10) else Event()
+    def __init__(self) -> None:
+        self.event = Event()
         self.delay = 0.0

--- a/interactions/api/gateway/ratelimit.py
+++ b/interactions/api/gateway/ratelimit.py
@@ -1,8 +1,6 @@
 import asyncio
 import logging
-from sys import version_info
 from time import time
-from typing import Optional
 
 log = logging.getLogger("gateway.ratelimit")
 
@@ -22,8 +20,8 @@ class WSRateLimit:
     :ivar float per_second: A constant denoting how many requests can be done per unit of seconds. (i.e., per 60 seconds, per 45, etc.)
     """
 
-    def __init__(self, loop: Optional[asyncio.AbstractEventLoop] = None):
-        self.lock = asyncio.Lock(loop=loop) if version_info < (3, 10) else asyncio.Lock()
+    def __init__(self):
+        self.lock = asyncio.Lock()
         # To conserve timings, we need to do 115/60
         # Also, credit to d.py for their ratelimiter inspiration
 


### PR DESCRIPTION
## About

This pull request reworks how `interactions.py` handles the event loop to follow by the standards set by `asyncio.run()` - basically, instead of making and holding the event loop, it should instead let `asyncio.run()` make it, and get it with `asyncio.get_running_loop()`.

An attempt has been made to keep breaking changes minimal, but there are two exceptions:
- Running any method in `Client` before running `await client.astart()` or `client.start()` that relies on `_websocket` *will not work*, erroring out instead. That shouldn't be a huge problem, as `await client.wait_until_ready()` will work regardless.
- If an extension is loaded before the bot is started *and* relies on the event loop (IE creating a task to run an asynchronous function), it will most likely error out (unless `bot.load` is run in an asynchronous function). To avoid this, users are suggested to do the following:

```python
async def main():
    bot.load("ext_that_uses_loop")
    await bot.astart()

asyncio.run(main())
```

## Draft Notice

Nothing about this is final, and feedback is important. I've only done basic testing, so more needs to be done to find any bugs, and the solution to `client.wait_until_ready()` needs to be looked at too. Really, this PR was just to get the ball rolling.

## Checklist

- [x] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.


I've made this pull request: (check all that apply)
  - [x] For the documentation
  - [x] To add a new feature
  - [x] As a general enhancement
  - [x] As a refactor of the library/the library's code
  - [ ] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [x] A breaking change

  <!--- Expand this when more comes up--->
