### PR TITLE
fix: catch all index errors in the history iterator

### DIFF
--- a/interactions/api/models/channel.py
+++ b/interactions/api/models/channel.py
@@ -210,10 +210,10 @@ class AsyncHistoryIterator(DiscordPaginationIterator):
         self.objects.extend([Message(**msg, _client=self._client) for msg in msgs])
 
     async def __anext__(self) -> "Message":
-        if self.objects is None:
-            await self.get_first_objects()
-
         try:
+            if self.objects is None:
+                await self.get_first_objects()
+
             obj = self.objects.pop(0)
 
             if self.check:


### PR DESCRIPTION
## About

This pull request fixes an edge case where Discord doesn't return an error when getting messages from channels with no history, for example Categories

## Checklist

- [x] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.


I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [ ] To add a new feature
  - [ ] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [x] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

  <!--- Expand this when more comes up--->
