### PR TITLE
fix: Always convert annotation to a type

### DIFF
--- a/interactions/client/models/command.py
+++ b/interactions/client/models/command.py
@@ -2,7 +2,18 @@ import contextlib
 from asyncio import CancelledError
 from functools import wraps
 from inspect import getdoc, signature
-from typing import TYPE_CHECKING, Any, Awaitable, Callable, Coroutine, Dict, List, Optional, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Awaitable,
+    Callable,
+    Coroutine,
+    Dict,
+    List,
+    Optional,
+    Union,
+    get_type_hints,
+)
 
 from ...api.error import LibraryException
 from ...api.models.channel import Channel, ChannelType
@@ -228,8 +239,10 @@ def option(
             coro._options = []
 
         param = parameters[-1 - len(coro._options)]
-
         option_type = kwargs.pop("type", param.annotation)
+        if isinstance(option_type, str):
+            option_type = get_type_hints(coro).get(param.name)
+
         name = kwargs.pop("name", param.name)
         if name != param.name:
             kwargs["converter"] = param.name


### PR DESCRIPTION
## About

If `__future__.annotations` is imported, function annotations are converted from type to str. This PR converts it back to its equivalent type.

## Checklist

- [x] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.


I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [ ] To add a new feature
  - [ ] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [x] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

  <!--- Expand this when more comes up--->
