### PR TITLE
feat: Paginate guilds when syncing

### DIFF
--- a/interactions/api/http/guild.py
+++ b/interactions/api/http/guild.py
@@ -20,13 +20,30 @@ class GuildRequest:
     def __init__(self) -> None:
         pass
 
-    async def get_self_guilds(self) -> List[dict]:
+    async def get_self_guilds(
+        self,
+        limit: Optional[int] = 200,
+        before: Optional[int] = None,
+        after: Optional[int] = None
+    ) -> List[dict]:
         """
         Gets all guild objects associated with the current bot user.
 
-        :return a list of partial guild objects the current bot user is a part of.
+        :param limit: Number of guilds to return. Defaults to 200.
+        :param before: Consider only users before the given Guild ID snowflake.
+        :param after: Consider only users after the given Guild ID snowflake.
+        :return: A list of partial guild objects the current bot user is a part of.
         """
-        request = await self._req.request(Route("GET", "/users/@me/guilds"))
+
+        params = {}
+        if limit is not None:
+            params["limit"] = limit
+        if before:
+            params["before"] = before
+        if after:
+            params["after"] = after
+
+        request = await self._req.request(Route("GET", "/users/@me/guilds"), params=params)
 
         for guild in request:
             if guild.get("id"):

--- a/interactions/api/http/guild.py
+++ b/interactions/api/http/guild.py
@@ -21,10 +21,7 @@ class GuildRequest:
         pass
 
     async def get_self_guilds(
-        self,
-        limit: Optional[int] = 200,
-        before: Optional[int] = None,
-        after: Optional[int] = None
+        self, limit: Optional[int] = 200, before: Optional[int] = None, after: Optional[int] = None
     ) -> List[dict]:
         """
         Gets all guild objects associated with the current bot user.

--- a/interactions/api/models/guild.py
+++ b/interactions/api/models/guild.py
@@ -49,6 +49,7 @@ from .webhook import Webhook
 
 if TYPE_CHECKING:
     from ..http.client import HTTPClient
+    from ...client.bot import Client
     from .gw import AutoModerationRule, VoiceState
     from .message import Message
 

--- a/interactions/api/models/guild.py
+++ b/interactions/api/models/guild.py
@@ -3036,6 +3036,37 @@ class Guild(ClientSerializerMixin, IDMixin):
             else None
         )
 
+    @classmethod
+    async def get_all_guilds(cls, http: "HTTPClient") -> List["Guild"]:
+        """
+        .. versionadded:: 4.4.0
+
+        Gets all guilds that the bot is present in.
+
+        :return: List of guilds
+        :rtype: List[Guild]
+        """
+
+        _after = None
+        _all: list = []
+
+        res: list = await http.get_self_guilds(limit=200)
+
+        while len(res) >= 1000:
+
+            for guild in res:
+                _all.append(Guild(**guild))
+            _after = int(res[-1]["id"])
+
+            res = await http.get_self_guilds(
+                after=_after,
+            )
+
+        for guild in res:
+            _all.append(Guild(**guild))
+
+        return _all
+
 
 @define()
 class GuildPreview(DictSerializerMixin, IDMixin):

--- a/interactions/api/models/guild.py
+++ b/interactions/api/models/guild.py
@@ -48,7 +48,6 @@ from .user import User
 from .webhook import Webhook
 
 if TYPE_CHECKING:
-    from ...client.bot import Client
     from ..http.client import HTTPClient
     from .gw import AutoModerationRule, VoiceState
     from .message import Message
@@ -3036,38 +3035,6 @@ class Guild(ClientSerializerMixin, IDMixin):
             if self.banner
             else None
         )
-
-    @classmethod
-    async def get_all_guilds(cls, client: "Client") -> List["Guild"]:
-        """
-        .. versionadded:: 4.4.0
-
-        Gets all guilds that the bot is present in.
-
-        :param Client client: The bot instance
-        :return: List of guilds
-        :rtype: List[Guild]
-        """
-
-        _after = None
-        _all: list = []
-
-        res: list = await client._http.get_self_guilds(limit=200)
-
-        while len(res) >= 200:
-
-            for guild in res:
-                _all.append(Guild(**guild))
-            _after = int(res[-1]["id"])
-
-            res = await client._http.get_self_guilds(
-                after=_after,
-            )
-
-        for guild in res:
-            _all.append(Guild(**guild))
-
-        return _all
 
 
 @define()

--- a/interactions/api/models/guild.py
+++ b/interactions/api/models/guild.py
@@ -48,8 +48,8 @@ from .user import User
 from .webhook import Webhook
 
 if TYPE_CHECKING:
-    from ..http.client import HTTPClient
     from ...client.bot import Client
+    from ..http.client import HTTPClient
     from .gw import AutoModerationRule, VoiceState
     from .message import Message
 

--- a/interactions/api/models/guild.py
+++ b/interactions/api/models/guild.py
@@ -3037,12 +3037,13 @@ class Guild(ClientSerializerMixin, IDMixin):
         )
 
     @classmethod
-    async def get_all_guilds(cls, http: "HTTPClient") -> List["Guild"]:
+    async def get_all_guilds(cls, client: "Client") -> List["Guild"]:
         """
         .. versionadded:: 4.4.0
 
         Gets all guilds that the bot is present in.
 
+        :param Client client: The bot instance
         :return: List of guilds
         :rtype: List[Guild]
         """
@@ -3050,7 +3051,7 @@ class Guild(ClientSerializerMixin, IDMixin):
         _after = None
         _all: list = []
 
-        res: list = await http.get_self_guilds(limit=200)
+        res: list = await client._http.get_self_guilds(limit=200)
 
         while len(res) >= 1000:
 
@@ -3058,7 +3059,7 @@ class Guild(ClientSerializerMixin, IDMixin):
                 _all.append(Guild(**guild))
             _after = int(res[-1]["id"])
 
-            res = await http.get_self_guilds(
+            res = await client._http.get_self_guilds(
                 after=_after,
             )
 

--- a/interactions/api/models/guild.py
+++ b/interactions/api/models/guild.py
@@ -3054,7 +3054,7 @@ class Guild(ClientSerializerMixin, IDMixin):
 
         res: list = await client._http.get_self_guilds(limit=200)
 
-        while len(res) >= 1000:
+        while len(res) >= 200:
 
             for guild in res:
                 _all.append(Guild(**guild))

--- a/interactions/api/models/guild.py
+++ b/interactions/api/models/guild.py
@@ -2067,9 +2067,9 @@ class Guild(ClientSerializerMixin, IDMixin):
 
         for ban in res:
             ban["user"] = User(**ban["user"])
-        _all.append(res)
+        _all.extend(res)
 
-        return res
+        return _all
 
     async def prune(
         self,

--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -507,7 +507,7 @@ class Client:
         """
         await self._websocket.wait_until_ready()
 
-    async def __get_all_guilds(self) -> List[dict]:
+    async def _get_all_guilds(self) -> List[dict]:
         """
         Gets all guilds that the bot is present in.
 
@@ -539,7 +539,7 @@ class Client:
         # until then this will deliver a cache if sync is off to make autocomplete work bug-free
         # but even with sync off, we should cache all commands here always
 
-        _guilds = await self.__get_all_guilds()
+        _guilds = await self._get_all_guilds()
         _guild_ids = [int(_["id"]) for _ in _guilds]
         self._scopes.update(_guild_ids)
         _cmds = await self._http.get_application_commands(
@@ -644,7 +644,7 @@ class Client:
         # sourcery skip: low-code-quality
 
         log.debug("starting command sync")
-        _guilds = await self.__get_all_guilds()
+        _guilds = await self._get_all_guilds()
         _guild_ids = [int(_["id"]) for _ in _guilds]
         self._scopes.update(_guild_ids)
         _cmds = await self._http.get_application_commands(

--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -513,8 +513,8 @@ class Client:
         # until then this will deliver a cache if sync is off to make autocomplete work bug-free
         # but even with sync off, we should cache all commands here always
 
-        _guilds = await self._http.get_self_guilds()
-        _guild_ids = [int(_["id"]) for _ in _guilds]
+        _guilds = await Guild.get_all_guilds(self._http)
+        _guild_ids = [int(_.id) for _ in _guilds]
         self._scopes.update(_guild_ids)
         _cmds = await self._http.get_application_commands(
             application_id=self.me.id, with_localizations=True
@@ -618,8 +618,8 @@ class Client:
         # sourcery skip: low-code-quality
 
         log.debug("starting command sync")
-        _guilds = await self._http.get_self_guilds()
-        _guild_ids = [int(_["id"]) for _ in _guilds]
+        _guilds = await Guild.get_all_guilds(self._http)
+        _guild_ids = [int(_.id) for _ in _guilds]
         self._scopes.update(_guild_ids)
         _cmds = await self._http.get_application_commands(
             application_id=self.me.id, with_localizations=True

--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -513,7 +513,7 @@ class Client:
         # until then this will deliver a cache if sync is off to make autocomplete work bug-free
         # but even with sync off, we should cache all commands here always
 
-        _guilds = await Guild.get_all_guilds(self._http)
+        _guilds = await Guild.get_all_guilds(self)
         _guild_ids = [int(_.id) for _ in _guilds]
         self._scopes.update(_guild_ids)
         _cmds = await self._http.get_application_commands(
@@ -618,7 +618,7 @@ class Client:
         # sourcery skip: low-code-quality
 
         log.debug("starting command sync")
-        _guilds = await Guild.get_all_guilds(self._http)
+        _guilds = await Guild.get_all_guilds(self)
         _guild_ids = [int(_.id) for _ in _guilds]
         self._scopes.update(_guild_ids)
         _cmds = await self._http.get_application_commands(

--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -507,14 +507,40 @@ class Client:
         """
         await self._websocket.wait_until_ready()
 
+    async def __get_all_guilds(self) -> List[dict]:
+        """
+        Gets all guilds that the bot is present in.
+
+        :return: List of guilds
+        :rtype: List[dict]
+        """
+
+        _after = None
+        _all: list = []
+
+        res = await self._http.get_self_guilds(limit=200)
+
+        while len(res) >= 200:
+
+            _all.extend(res)
+            _after = int(res[-1]["id"])
+
+            res = await self._http.get_self_guilds(
+                after=_after,
+            )
+
+        _all.extend(res)
+
+        return _all
+
     async def __get_all_commands(self) -> None:
         # this method is just copied from the sync method
         # I expect this to be changed in the sync rework
         # until then this will deliver a cache if sync is off to make autocomplete work bug-free
         # but even with sync off, we should cache all commands here always
 
-        _guilds = await Guild.get_all_guilds(self)
-        _guild_ids = [int(_.id) for _ in _guilds]
+        _guilds = await self.__get_all_guilds()
+        _guild_ids = [int(_["id"]) for _ in _guilds]
         self._scopes.update(_guild_ids)
         _cmds = await self._http.get_application_commands(
             application_id=self.me.id, with_localizations=True
@@ -618,8 +644,8 @@ class Client:
         # sourcery skip: low-code-quality
 
         log.debug("starting command sync")
-        _guilds = await Guild.get_all_guilds(self)
-        _guild_ids = [int(_.id) for _ in _guilds]
+        _guilds = await self.__get_all_guilds()
+        _guild_ids = [int(_["id"]) for _ in _guilds]
         self._scopes.update(_guild_ids)
         _cmds = await self._http.get_application_commands(
             application_id=self.me.id, with_localizations=True


### PR DESCRIPTION
## About

![image](https://user-images.githubusercontent.com/19358286/205181931-731dff99-f9fb-43f5-a230-e61f6da6f30c.png)
Previously, the library did not account for bots which were present in more than 200 guilds BUT used guild commands. Now, the function when syncing uses a paginator to make sure all guilds are acquired.

## Checklist

- [x] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.


I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [x] To add a new feature
  - [ ] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [x] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

  <!--- Expand this when more comes up--->
