### PR TITLE
fix!: remove restriction on positional arguments for the `search_iterable` function

### DIFF
--- a/interactions/utils/utils.py
+++ b/interactions/utils/utils.py
@@ -178,7 +178,7 @@ def spread_to_rows(
 
 
 def search_iterable(
-    iterable: Iterable[_T], check: Optional[Callable[[_T], bool]] = None, /, **kwargs
+    iterable: Iterable[_T], check: Optional[Callable[[_T], bool]] = None, **kwargs
 ) -> List[_T]:
     r"""
     .. versionadded:: 4.3.0


### PR DESCRIPTION
## About

This pull request removes the positional arguments only restriction for `search_iterable`, that made some functions error out, example:
```
Traceback (most recent call last):
  File "PATH\command_builder.py", line 144, in send_and_add_to_database
    got_permission = await member.has_permissions(
  File "PATH\Python\Python310\lib\site-packages\interactions\api\models\member.py", line 675, in has_permissions
    else await channel.get_permissions_for(self)
  File "PATH\Python\Python310\lib\site-packages\interactions\api\models\channel.py", line 1973, in get_permissions_for
    if not self.guild_id:
  File "PATH\Python\Python310\lib\site-packages\interactions\api\models\channel.py", line 512, in guild_id
    if len(search_iterable(guild.channels, check=check)) == 1:
  File "PATH\Python\Python310\lib\site-packages\interactions\utils\utils.py", line 205, in search_iterable
    return list(iterable)
  File "PATH\Python\Python310\lib\site-packages\interactions\utils\utils.py", line 201, in <lambda>       
    lambda item: all(getattr(item, attr) == value for attr, value in kwargs.items()),
  File "PATH\Python\Python310\lib\site-packages\interactions\utils\utils.py", line 201, in <genexpr>      
    lambda item: all(getattr(item, attr) == value for attr, value in kwargs.items()),
AttributeError: 'Channel' object has no attribute 'check'
```

## Checklist

- [x] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.


I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [ ] To add a new feature
  - [ ] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [x] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [x] A breaking change

  <!--- Expand this when more comes up--->
