### PR TITLE
docs: remove return type from send&edit methods

### DIFF
--- a/interactions/client/context.py
+++ b/interactions/client/context.py
@@ -110,9 +110,10 @@ class _Context(ClientSerializerMixin):
 
         Returns the current channel, if cached.
         """
-        return self._client.cache[Channel].get(self.channel_id, None) or self._client.cache[
-            Thread
-        ].get(self.channel_id, None)
+        return (
+            self._client.cache[Channel].get(self.channel_id, None) 
+            or self._client.cache[Thread].get(self.channel_id, None)
+        )
 
     @property
     def guild(self) -> Optional[Guild]:
@@ -191,8 +192,7 @@ class _Context(ClientSerializerMixin):
         :param Optional[Union[ActionRow, Button, SelectMenu, List[Union[ActionRow, Button, SelectMenu]]]] components: A component, or list of components for the message.
         :param Optional[bool] ephemeral: Whether the response is hidden or not.
         :param Optional[bool] suppress_embeds: Whether embeds are not shown in the message.
-        :return: The sent message as a dict.
-        :rtype: Tuple[dict, Union[File, List[File]]]
+        :return: The sent message.
         """
         if (
             content is MISSING
@@ -299,8 +299,7 @@ class _Context(ClientSerializerMixin):
         :param Optional[Union[AllowedMentions, dict]] allowed_mentions: The allowed mentions for the message.
         :param Optional[MessageReference] message_reference: Include to make your message a reply.
         :param Optional[Union[ActionRow, Button, SelectMenu, List[Union[ActionRow, Button, SelectMenu]]]] components: A component, or list of components for the message.
-        :return: The edited message as a dict.
-        :rtype: dict
+        :return: The edited message.
         """
 
         payload = {}
@@ -703,8 +702,8 @@ class ComponentContext(_Context):
     :ivar User user: The user data model.
     :ivar bool responded: Whether an original response was made or not.
     :ivar bool deferred: Whether the response was deferred or not.
-    :ivar str locale: The selected language of the user invoking the interaction.
-    :ivar str guild_locale: The guild's preferred language, if invoked in a guild.
+    :ivar Optional[Locale] locale: The selected language of the user invoking the interaction.
+    :ivar Optional[Locale] guild_locale: The guild's preferred language, if invoked in a guild.
     :ivar str app_permissions: Bitwise set of permissions the bot has within the channel the interaction was sent from.
     """
 

--- a/interactions/client/context.py
+++ b/interactions/client/context.py
@@ -110,10 +110,9 @@ class _Context(ClientSerializerMixin):
 
         Returns the current channel, if cached.
         """
-        return (
-            self._client.cache[Channel].get(self.channel_id, None) 
-            or self._client.cache[Thread].get(self.channel_id, None)
-        )
+        return self._client.cache[Channel].get(self.channel_id, None) or self._client.cache[
+            Thread
+        ].get(self.channel_id, None)
 
     @property
     def guild(self) -> Optional[Guild]:


### PR DESCRIPTION
## About
also add missed locale type in ComponentContext
This is bit confusing when you see in the docs `send` and `edit` returns dict

## Checklist

- [ ] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [ ] I've ensured the change(s) work on `3.8.6` and higher.


I've made this pull request: (check all that apply)
  - [x] For the documentation
  - [ ] To add a new feature
  - [ ] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [ ] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

  <!--- Expand this when more comes up--->
