### PR TITLE
fix: `Message.referenced_message` returns wrong data

### DIFF
--- a/interactions/api/models/message.py
+++ b/interactions/api/models/message.py
@@ -683,7 +683,7 @@ class Message(ClientSerializerMixin, IDMixin):
     :ivar Optional[Application] application: Application object that's sent by Rich Presence
     :ivar Optional[MessageReference] message_reference: Data showing the source of a message (crosspost, channel follow, add, pin, or replied message)
     :ivar Optional[MessageFlags] flags: Message flags
-    :ivar Optional[referenced_message] referenced_message: The message associated with the message_reference.
+    :ivar Optional[Message] referenced_message: The message associated with the message_reference.
     :ivar Optional[MessageInteraction] interaction: Message interaction object, if the message is sent by an interaction.
     :ivar Optional[Channel] thread: The thread that started from this message, if any, with a thread member object embedded.
     :ivar Optional[List[ActionRow]] components: Array of Action Rows associated with this message, if any.

--- a/interactions/api/models/message.py
+++ b/interactions/api/models/message.py
@@ -682,7 +682,8 @@ class Message(ClientSerializerMixin, IDMixin):
     :ivar Optional[MessageActivity] activity: Message activity object that's sent by Rich Presence
     :ivar Optional[Application] application: Application object that's sent by Rich Presence
     :ivar Optional[MessageReference] message_reference: Data showing the source of a message (crosspost, channel follow, add, pin, or replied message)
-    :ivar int flags: Message flags
+    :ivar Optional[MessageFlags] flags: Message flags
+    :ivar Optional[referenced_message] referenced_message: The message associated with the message_reference.
     :ivar Optional[MessageInteraction] interaction: Message interaction object, if the message is sent by an interaction.
     :ivar Optional[Channel] thread: The thread that started from this message, if any, with a thread member object embedded.
     :ivar Optional[List[ActionRow]] components: Array of Action Rows associated with this message, if any.
@@ -724,8 +725,8 @@ class Message(ClientSerializerMixin, IDMixin):
     application: Optional[Application] = field(converter=Application, default=None)
     application_id: Optional[Snowflake] = field(converter=Snowflake, default=None)
     message_reference: Optional[MessageReference] = field(converter=MessageReference, default=None)
-    flags: Optional[Union[int, MessageFlags]] = field(converter=MessageFlags, default=None)
-    referenced_message: Optional[MessageReference] = field(converter=MessageReference, default=None)
+    flags: Optional[MessageFlags] = field(converter=MessageFlags, default=None)
+    referenced_message: Optional[Message] = field(converter=Message, add_client=True, default=None)
     interaction: Optional[MessageInteraction] = field(
         converter=MessageInteraction, default=None, add_client=True, repr=False
     )

--- a/interactions/api/models/message.py
+++ b/interactions/api/models/message.py
@@ -726,7 +726,7 @@ class Message(ClientSerializerMixin, IDMixin):
     application_id: Optional[Snowflake] = field(converter=Snowflake, default=None)
     message_reference: Optional[MessageReference] = field(converter=MessageReference, default=None)
     flags: Optional[MessageFlags] = field(converter=MessageFlags, default=None)
-    referenced_message: Optional[Message] = field(converter=Message, add_client=True, default=None)
+    referenced_message: Optional["Message"] = field(default=None)
     interaction: Optional[MessageInteraction] = field(
         converter=MessageInteraction, default=None, add_client=True, repr=False
     )
@@ -756,6 +756,9 @@ class Message(ClientSerializerMixin, IDMixin):
 
         if self.author and self.member:
             self.member.user = self.author
+
+        if self.referenced_message is not None:
+            self.referenced_message = Message(**self.referenced_message, _client=self._client)
 
     async def get_channel(self) -> Channel:
         """


### PR DESCRIPTION
## About

This pull request fixes wrong serialization for `Message.referenced_message` attr

## Checklist

- [ ] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [ ] I've ensured the change(s) work on `3.8.6` and higher.


I've made this pull request: (check all that apply)
  - [x] For the documentation
  - [ ] To add a new feature
  - [ ] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [x] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

  <!--- Expand this when more comes up--->
