### PR TITLE
fix: Pass HTTPClient to all objects when using get() with cache.

### DIFF
--- a/interactions/api/models/message.py
+++ b/interactions/api/models/message.py
@@ -350,7 +350,7 @@ class Embed(DictSerializerMixin):
 
         interactions.Embed(
             title="Embed title",
-            fields=[interaction.EmbedField(...)],
+            fields=[interactions.EmbedField(...)],
         )
 
     :ivar Optional[str] title: Title of embed

--- a/interactions/utils/get.py
+++ b/interactions/utils/get.py
@@ -192,7 +192,7 @@ def get(client: "Client", obj: Type[_T], **kwargs) -> Optional[_T]:
         http_name = f"get_{_obj.__name__.lower()}"
         kwarg_name = f"{_obj.__name__.lower()}_ids"
         _objects: List[Union[_obj, Coroutine]] = (
-            [] if force_http else _get_cache(_obj, client, kwarg_name, _list=True, **kwargs)
+            _get_cache(_obj, client, kwarg_name, _list=True, **kwargs) if not force_http else []
         )  # some sourcery stuff i dunno
 
         if force_cache:
@@ -227,7 +227,7 @@ def get(client: "Client", obj: Type[_T], **kwargs) -> Optional[_T]:
     kwarg_name = f"{obj.__name__.lower()}_id"
 
     _obj: Optional[_T] = (
-        None if force_http else _get_cache(obj, client, kwarg_name, **kwargs)
+        _get_cache(obj, client, kwarg_name, **kwargs) if not force_http else None
     )  # more sourcery stuff
 
     if force_cache:
@@ -289,14 +289,14 @@ def _get_cache(
             ]
             for item in _values:
                 _obj = client._http.cache[_object].get(item, None)
-                if isinstance(_obj, _object):
+                if _obj:
                     _obj._client = client._http
                 _objs.append(_obj)
 
         else:
             for _id in kwargs.get(kwarg_name):
                 _obj = client._http.cache[_object].get(Snowflake(_id), None)
-                if isinstance(_obj, _object):
+                if _obj:
                     _obj._client = client._http
                 _objs.append(_obj)
         return _objs
@@ -310,7 +310,7 @@ def _get_cache(
             _values = Snowflake(kwargs.get(kwarg_name))
 
         _obj = client._http.cache[_object].get(_values)
-        if isinstance(_obj, _object):
+        if _obj:
             _obj._client = client._http
         return _obj
 


### PR DESCRIPTION
## About

This bug was found on [the support server](https://discord.com/channels/789032594456576001/1051526179846373457).
Basically, some objects do not have the HTTPClient passed through when getting the objects from the cache. This PR makes sure that, if the object is found in cache, it has the HTTPClient added to it.

PS: The `get()` function is a pain to debug, I would like to suggest to rewrite it in a way that it will be less hard for the next contributor to fix it.

## Checklist

- [x] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.


I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [ ] To add a new feature
  - [ ] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [x] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

  <!--- Expand this when more comes up--->
