### PR TITLE
fix: Remove unwanted arguments passed to HTTP methods

### DIFF
--- a/interactions/api/models/channel.py
+++ b/interactions/api/models/channel.py
@@ -846,10 +846,7 @@ class Channel(ClientSerializerMixin, IDMixin):
             payload["auto_archive_duration"] = auto_archive_duration
         if locked is not MISSING:
             payload["locked"] = locked
-        if position is MISSING:
-            if self.position is not None:
-                payload["position"] = self.position
-        else:
+        if position is not MISSING:
             payload["position"] = position
 
         res = await self._client.modify_channel(

--- a/interactions/api/models/channel.py
+++ b/interactions/api/models/channel.py
@@ -846,8 +846,9 @@ class Channel(ClientSerializerMixin, IDMixin):
             payload["auto_archive_duration"] = auto_archive_duration
         if locked is not MISSING:
             payload["locked"] = locked
-        if position is MISSING and self.position is not None:
-            payload["position"] = self.position
+        if position is MISSING:
+            if self.position is not None:
+                payload["position"] = self.position
         else:
             payload["position"] = position
 

--- a/interactions/api/models/channel.py
+++ b/interactions/api/models/channel.py
@@ -808,7 +808,6 @@ class Channel(ClientSerializerMixin, IDMixin):
         _rate_limit_per_user = (
             self.rate_limit_per_user if rate_limit_per_user is MISSING else rate_limit_per_user
         )
-        _position = self.position if position is MISSING else position
         _parent_id = (
             (int(self.parent_id) if self.parent_id else None)
             if parent_id is MISSING
@@ -831,7 +830,6 @@ class Channel(ClientSerializerMixin, IDMixin):
             bitrate=_bitrate,
             user_limit=_user_limit,
             rate_limit_per_user=_rate_limit_per_user,
-            position=_position,
             parent_id=_parent_id,
             nsfw=_nsfw,
             permission_overwrites=_permission_overwrites,
@@ -848,6 +846,10 @@ class Channel(ClientSerializerMixin, IDMixin):
             payload["auto_archive_duration"] = auto_archive_duration
         if locked is not MISSING:
             payload["locked"] = locked
+        if position is MISSING and self.position is not None:
+            payload["position"] = self.position
+        else:
+            payload["position"] = position
 
         res = await self._client.modify_channel(
             channel_id=int(self.id),


### PR DESCRIPTION
## About

EDIT: This PR's purpose is now refactoring all edit/modify helper methods so that only the provided arguments are sent in the http payload

## Checklist

- [x] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.


I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [ ] To add a new feature
  - [ ] As a general enhancement
  - [x] As a refactor of the library/the library's code
  - [x] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change
  ^ Not sure

  <!--- Expand this when more comes up--->