### PR TITLE
feat: Add support for age-restricted commands

### DIFF
--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -1050,6 +1050,7 @@ class Client:
         description_localizations: Optional[Dict[Union[str, Locale], str]] = MISSING,
         default_member_permissions: Optional[Union[int, Permissions]] = MISSING,
         dm_permission: Optional[bool] = MISSING,
+        nsfw: Optional[bool] = MISSING,
         default_scope: bool = True,
     ) -> Callable[[Callable[..., Coroutine]], Command]:
         """
@@ -1103,6 +1104,10 @@ class Client:
             The dictionary of localization for the ``description`` field. This enforces the same restrictions as the ``description`` field.
         :param Optional[Union[int, Permissions]] default_member_permissions: The permissions bit value of :class:`.Permissions`. If not given, defaults to :attr:`.Permissions.USE_APPLICATION_COMMANDS`
         :param Optional[bool] dm_permission: The application permissions if executed in a Direct Message. Defaults to ``True``.
+        :param Optional[bool] nsfw:
+            .. versionadded:: 4.4.0
+
+            Indicates whether the command is age-restricted. Defaults to ``False``
         :param Optional[bool] default_scope:
             .. versionadded:: 4.3.0
 
@@ -1121,6 +1126,7 @@ class Client:
                 scope=scope,
                 default_member_permissions=default_member_permissions,
                 dm_permission=dm_permission,
+                nsfw=nsfw,
                 name_localizations=name_localizations,
                 description_localizations=description_localizations,
                 default_scope=default_scope,
@@ -1139,6 +1145,7 @@ class Client:
         name_localizations: Optional[Dict[Union[str, Locale], Any]] = MISSING,
         default_member_permissions: Optional[Union[int, Permissions]] = MISSING,
         dm_permission: Optional[bool] = MISSING,
+        nsfw: Optional[bool] = MISSING,
         default_scope: bool = True,
     ) -> Callable[[Callable[..., Coroutine]], Command]:
         """
@@ -1165,6 +1172,10 @@ class Client:
             The dictionary of localization for the ``name`` field. This enforces the same restrictions as the ``name`` field.
         :param Optional[Union[int, Permissions]] default_member_permissions: The permissions bit value of :class:`.Permissions`. If not given, defaults to :attr:`.Permissions.USE_APPLICATION_COMMANDS`
         :param Optional[bool] dm_permission: The application permissions if executed in a Direct Message. Defaults to ``True``.
+        :param Optional[bool] nsfw:
+            .. versionadded:: 4.4.0
+
+            Indicates whether the command is age-restricted. Defaults to ``False``
         :param Optional[bool] default_scope:
             .. versionadded:: 4.3.0
 
@@ -1180,6 +1191,7 @@ class Client:
                 scope=scope,
                 default_member_permissions=default_member_permissions,
                 dm_permission=dm_permission,
+                nsfw=nsfw,
                 name_localizations=name_localizations,
                 default_scope=default_scope,
             )(coro)
@@ -1194,6 +1206,7 @@ class Client:
         name_localizations: Optional[Dict[Union[str, Locale], Any]] = MISSING,
         default_member_permissions: Optional[Union[int, Permissions]] = MISSING,
         dm_permission: Optional[bool] = MISSING,
+        nsfw: Optional[bool] = MISSING,
         default_scope: bool = True,
     ) -> Callable[[Callable[..., Coroutine]], Command]:
         """
@@ -1221,6 +1234,10 @@ class Client:
         :param Optional[Union[int, Permissions]] default_member_permissions:
         The permissions bit value of :class:`.Permissions`. If not given, defaults to :attr:`.Permissions.USE_APPLICATION_COMMANDS`
         :param Optional[bool] dm_permission: The application permissions if executed in a Direct Message. Defaults to ``True``.
+        :param Optional[bool] nsfw:
+            .. versionadded:: 4.4.0
+
+            Indicates whether the command is age-restricted. Defaults to ``False``
         :param Optional[bool] default_scope:
             .. versionadded:: 4.3.0
 
@@ -1236,6 +1253,7 @@ class Client:
                 scope=scope,
                 default_member_permissions=default_member_permissions,
                 dm_permission=dm_permission,
+                nsfw=nsfw,
                 name_localizations=name_localizations,
                 default_scope=default_scope,
             )(coro)

--- a/interactions/client/decor.py
+++ b/interactions/client/decor.py
@@ -104,7 +104,7 @@ def command(
                 description_localizations=_description_localizations,
                 default_member_permissions=_default_member_permissions,
                 dm_permission=_dm_permission,
-                nsfw=_nsfw
+                nsfw=_nsfw,
             )
             payloads.append(payload._json)
     else:
@@ -117,7 +117,7 @@ def command(
             description_localizations=_description_localizations,
             default_member_permissions=_default_member_permissions,
             dm_permission=_dm_permission,
-            nsfw=_nsfw
+            nsfw=_nsfw,
         )
         return payload._json
 

--- a/interactions/client/decor.py
+++ b/interactions/client/decor.py
@@ -20,7 +20,8 @@ def command(
     name_localizations: Optional[Dict[Union[str, Locale], str]] = MISSING,
     description_localizations: Optional[Dict[Union[str, Locale], str]] = MISSING,
     default_member_permissions: Optional[Union[int, Permissions]] = MISSING,
-    dm_permission: Optional[bool] = MISSING
+    dm_permission: Optional[bool] = MISSING,
+    nsfw: Optional[bool] = MISSING,
 ) -> Union[List[dict], dict]:  # sourcery skip: low-code-quality
     """
     A wrapper designed to interpret the client-facing API for
@@ -78,6 +79,7 @@ def command(
         )
     )
     _dm_permission: bool = True if dm_permission is MISSING else dm_permission
+    _nsfw: bool = False if nsfw is MISSING else nsfw
 
     payloads: list = []
 
@@ -102,6 +104,7 @@ def command(
                 description_localizations=_description_localizations,
                 default_member_permissions=_default_member_permissions,
                 dm_permission=_dm_permission,
+                nsfw=_nsfw
             )
             payloads.append(payload._json)
     else:
@@ -114,6 +117,7 @@ def command(
             description_localizations=_description_localizations,
             default_member_permissions=_default_member_permissions,
             dm_permission=_dm_permission,
+            nsfw=_nsfw
         )
         return payload._json
 

--- a/interactions/client/models/command.py
+++ b/interactions/client/models/command.py
@@ -175,7 +175,8 @@ class ApplicationCommand(DictSerializerMixin):
     :ivar Optional[bool] default_permission: The default permission accessibility state of the application command.
     :ivar int version: The Application Command version autoincrement identifier.
     :ivar str default_member_permissions: The default member permission state of the application command.
-    :ivar boolean dm_permission: The application permissions if executed in a Direct Message.
+    :ivar bool dm_permission: The application permissions if executed in a Direct Message.
+    :ivar bool nsfw: Indicates whether the command is age-restricted.
     :ivar Optional[Dict[Union[str, Locale], str]] name_localizations: The localisation dictionary for the application command name, if any.
     :ivar Optional[Dict[Union[str, Locale], str]] description_localizations: The localisation dictionary for the application command description, if any.
     """
@@ -191,6 +192,7 @@ class ApplicationCommand(DictSerializerMixin):
     version: int = field(default=None)
     default_member_permissions: str = field()
     dm_permission: bool = field(default=None)
+    nsfw: bool = field(default=None)
     name_localizations: Optional[Dict[Union[str, Locale], str]] = field(default=None)
     description_localizations: Optional[Dict[Union[str, Locale], str]] = field(default=None)
 
@@ -389,6 +391,7 @@ class Command(DictSerializerMixin):
     :ivar Optional[Dict[Union[str, Locale], str]] name_localizations: The dictionary of localization for the ``name`` field. This enforces the same restrictions as the ``name`` field.
     :ivar Optional[Dict[Union[str, Locale], str]] description_localizations: The dictionary of localization for the ``description`` field. This enforces the same restrictions as the ``description`` field.
     :ivar bool default_scope: Whether the command should use the default scope. Defaults to ``True``.
+    :ivar bool nsfw: Indicates whether the command is age-restricted. Defaults to ``False``.
 
     :ivar Dict[str, Callable[..., Awaitable]] coroutines: The dictionary of coroutines for the command.
     :ivar Dict[str, int] num_options: The dictionary of the number of options per subcommand.
@@ -410,6 +413,7 @@ class Command(DictSerializerMixin):
     name_localizations: Optional[Dict[Union[str, Locale], str]] = field(default=MISSING)
     description_localizations: Optional[Dict[Union[str, Locale], str]] = field(default=MISSING)
     default_scope: bool = field(default=True)
+    nsfw: bool = field(default=None)
 
     coroutines: Dict[str, Callable[..., Awaitable]] = field(init=False, factory=dict)
     num_options: Dict[str, int] = field(init=False, factory=dict)
@@ -479,6 +483,7 @@ class Command(DictSerializerMixin):
             description_localizations=self.description_localizations,
             default_member_permissions=self.default_member_permissions,
             dm_permission=self.dm_permission,
+            nsfw=self.nsfw,
         )
 
     @property

--- a/interactions/client/models/command.py
+++ b/interactions/client/models/command.py
@@ -173,10 +173,10 @@ class ApplicationCommand(DictSerializerMixin):
     :ivar str description: The description of the application command.
     :ivar Optional[List[Option]] options: The "options"/arguments of the application command.
     :ivar Optional[bool] default_permission: The default permission accessibility state of the application command.
+    :ivar Optional[bool] nsfw: Indicates whether the command is age-restricted.
     :ivar int version: The Application Command version autoincrement identifier.
     :ivar str default_member_permissions: The default member permission state of the application command.
     :ivar bool dm_permission: The application permissions if executed in a Direct Message.
-    :ivar bool nsfw: Indicates whether the command is age-restricted.
     :ivar Optional[Dict[Union[str, Locale], str]] name_localizations: The localisation dictionary for the application command name, if any.
     :ivar Optional[Dict[Union[str, Locale], str]] description_localizations: The localisation dictionary for the application command description, if any.
     """
@@ -189,10 +189,10 @@ class ApplicationCommand(DictSerializerMixin):
     description: str = field()
     options: Optional[List[Option]] = field(converter=convert_list(Option), default=None)
     default_permission: Optional[bool] = field(default=None)
+    nsfw: Optional[bool] = field(default=None)
     version: int = field(default=None)
     default_member_permissions: str = field()
     dm_permission: bool = field(default=None)
-    nsfw: bool = field(default=None)
     name_localizations: Optional[Dict[Union[str, Locale], str]] = field(default=None)
     description_localizations: Optional[Dict[Union[str, Locale], str]] = field(default=None)
 

--- a/interactions/client/models/command.py
+++ b/interactions/client/models/command.py
@@ -388,10 +388,10 @@ class Command(DictSerializerMixin):
     :ivar Optional[Union[int, Guild, List[int], List[Guild]]] scope: The scope of the command.
     :ivar Optional[str] default_member_permissions: The default member permissions of the command.
     :ivar Optional[bool] dm_permission: The DM permission of the command.
+    :ivar Optional[bool] nsfw: Indicates whether the command is age-restricted. Defaults to ``False``.
     :ivar Optional[Dict[Union[str, Locale], str]] name_localizations: The dictionary of localization for the ``name`` field. This enforces the same restrictions as the ``name`` field.
     :ivar Optional[Dict[Union[str, Locale], str]] description_localizations: The dictionary of localization for the ``description`` field. This enforces the same restrictions as the ``description`` field.
     :ivar bool default_scope: Whether the command should use the default scope. Defaults to ``True``.
-    :ivar bool nsfw: Indicates whether the command is age-restricted. Defaults to ``False``.
 
     :ivar Dict[str, Callable[..., Awaitable]] coroutines: The dictionary of coroutines for the command.
     :ivar Dict[str, int] num_options: The dictionary of the number of options per subcommand.
@@ -410,10 +410,10 @@ class Command(DictSerializerMixin):
     scope: Optional[Union[int, Guild, List[int], List[Guild]]] = field(default=MISSING)
     default_member_permissions: Optional[str] = field(default=MISSING)
     dm_permission: Optional[bool] = field(default=MISSING)
+    nsfw: Optional[bool] = field(default=None)
     name_localizations: Optional[Dict[Union[str, Locale], str]] = field(default=MISSING)
     description_localizations: Optional[Dict[Union[str, Locale], str]] = field(default=MISSING)
     default_scope: bool = field(default=True)
-    nsfw: bool = field(default=None)
 
     coroutines: Dict[str, Callable[..., Awaitable]] = field(init=False, factory=dict)
     num_options: Dict[str, int] = field(init=False, factory=dict)


### PR DESCRIPTION
## About

Title.

## Checklist

- [x] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.


I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [x] To add a new feature
  - [x] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [ ] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

  <!--- Expand this when more comes up--->
