### PR TITLE
refactor!: Change type of permissions attrs to `Permissions`

### DIFF
--- a/interactions/api/models/channel.py
+++ b/interactions/api/models/channel.py
@@ -22,6 +22,7 @@ from ...utils.abc.base_iterators import DiscordPaginationIterator
 from ...utils.attrs_utils import (
     ClientSerializerMixin,
     DictSerializerMixin,
+    convert_int,
     convert_list,
     define,
     field,
@@ -433,7 +434,7 @@ class Channel(ClientSerializerMixin, IDMixin):
     :ivar Optional[ThreadMetadata] thread_metadata: The thread metadata of the channel.
     :ivar Optional[ThreadMember] member: The member of the thread in the channel.
     :ivar Optional[int] default_auto_archive_duration: The set auto-archive time for all threads to naturally follow in the channel.
-    :ivar Optional[str] permissions: The permissions of the channel.
+    :ivar Optional[Permissions] permissions: The permissions of the channel.
     :ivar Optional[int] flags: The flags of the channel.
     :ivar Optional[int] total_message_sent: Number of messages ever sent in a thread.
     :ivar Optional[int] default_thread_slowmode_delay: The default slowmode delay in seconds for threads, if this channel is a forum.
@@ -484,7 +485,9 @@ class Channel(ClientSerializerMixin, IDMixin):
         converter=ThreadMember, default=None, add_client=True, repr=False
     )
     default_auto_archive_duration: Optional[int] = field(default=None)
-    permissions: Optional[str] = field(default=None, repr=False)
+    permissions: Optional[Permissions] = field(
+        converter=convert_int(Permissions), default=None, repr=False
+    )
     flags: Optional[int] = field(default=None, repr=False)
     total_message_sent: Optional[int] = field(default=None, repr=False)
     default_thread_slowmode_delay: Optional[int] = field(default=None, repr=False)
@@ -2070,7 +2073,7 @@ class Channel(ClientSerializerMixin, IDMixin):
             _id = int(id)
             _type = type
 
-        if not _type:
+        if _type is MISSING:
             raise LibraryException(12, "Please set the type of the overwrite!")
 
         overwrites.append(Overwrite(id=_id, type=_type, allow=allow, deny=deny))

--- a/interactions/api/models/guild.py
+++ b/interactions/api/models/guild.py
@@ -20,6 +20,7 @@ from ...utils.abc.base_iterators import DiscordPaginationIterator
 from ...utils.attrs_utils import (
     ClientSerializerMixin,
     DictSerializerMixin,
+    convert_int,
     convert_list,
     define,
     field,
@@ -29,6 +30,7 @@ from ..error import LibraryException
 from .audit_log import AuditLogEvents, AuditLogs
 from .channel import Channel, ChannelType, Thread, ThreadMember
 from .emoji import Emoji
+from .flags import Permissions
 from .member import Member
 from .message import Sticker, StickerPack
 from .misc import (
@@ -349,7 +351,7 @@ class Guild(ClientSerializerMixin, IDMixin):
     :ivar Optional[str] discovery_splash: The discovery splash banner of the guild.
     :ivar Optional[bool] owner: Whether the guild is owned.
     :ivar Snowflake owner_id: The ID of the owner of the guild.
-    :ivar Optional[str] permissions: The permissions of the guild.
+    :ivar Optional[Permissions] permissions: The permissions of the guild.
     :ivar Optional[str] region: The geographical region of the guild.
     :ivar Optional[Snowflake] afk_channel_id: The AFK voice channel of the guild.
     :ivar int afk_timeout: The timeout of the AFK voice channel of the guild.
@@ -400,7 +402,9 @@ class Guild(ClientSerializerMixin, IDMixin):
     discovery_splash: Optional[str] = field(default=None, repr=False)
     owner: Optional[bool] = field(default=None)
     owner_id: Snowflake = field(converter=Snowflake, default=None)
-    permissions: Optional[str] = field(default=None, repr=False)
+    permissions: Optional[Permissions] = field(
+        converter=convert_int(Permissions), default=None, repr=False
+    )
     region: Optional[str] = field(default=None, repr=False)  # None, we don't do Voices.
     afk_channel_id: Optional[Snowflake] = field(converter=Snowflake, default=None)
     afk_timeout: Optional[int] = field(default=None)
@@ -703,7 +707,7 @@ class Guild(ClientSerializerMixin, IDMixin):
     async def create_role(
         self,
         name: str,
-        permissions: Optional[int] = MISSING,
+        permissions: Optional[Union[Permissions, int]] = MISSING,
         color: Optional[int] = 0,
         hoist: Optional[bool] = False,
         icon: Optional[Image] = MISSING,
@@ -718,7 +722,7 @@ class Guild(ClientSerializerMixin, IDMixin):
 
         :param str name: The name of the role
         :param Optional[int] color: RGB color value as integer, default ``0``
-        :param Optional[int] permissions: Bitwise value of the enabled/disabled permissions
+        :param Optional[Union[Permissions, int]] permissions: Bitwise value of the enabled/disabled permissions
         :param Optional[bool] hoist: Whether the role should be displayed separately in the sidebar, default ``False``
         :param Optional[Image] icon: The role's icon image (if the guild has the ROLE_ICONS feature)
         :param Optional[str] unicode_emoji: The role's unicode emoji as a standard emoji (if the guild has the ROLE_ICONS feature)
@@ -729,7 +733,8 @@ class Guild(ClientSerializerMixin, IDMixin):
         """
         if not self._client:
             raise LibraryException(code=13)
-        _permissions = permissions if permissions is not MISSING else None
+
+        _permissions = int(permissions) if permissions is not MISSING else None
         _icon = icon if icon is not MISSING else None
         _unicode_emoji = unicode_emoji if unicode_emoji is not MISSING else None
         payload = dict(
@@ -839,7 +844,7 @@ class Guild(ClientSerializerMixin, IDMixin):
         self,
         role_id: Union[int, Snowflake, Role],
         name: Optional[str] = MISSING,
-        permissions: Optional[int] = MISSING,
+        permissions: Optional[Union[Permissions, int]] = MISSING,
         color: Optional[int] = MISSING,
         hoist: Optional[bool] = MISSING,
         icon: Optional[Image] = MISSING,
@@ -855,7 +860,7 @@ class Guild(ClientSerializerMixin, IDMixin):
         :param Union[int, Snowflake, Role] role_id: The id of the role to edit
         :param Optional[str] name: The name of the role, defaults to the current value of the role
         :param Optional[int] color: RGB color value as integer, defaults to the current value of the role
-        :param Optional[int] permissions: Bitwise value of the enabled/disabled permissions, defaults to the current value of the role
+        :param Optional[Union[Permissions, int]] permissions: Bitwise value of the enabled/disabled permissions, defaults to the current value of the role
         :param Optional[bool] hoist: Whether the role should be displayed separately in the sidebar, defaults to the current value of the role
         :param Optional[Image] icon: The role's icon image (if the guild has the ROLE_ICONS feature), defaults to the current value of the role
         :param Optional[str] unicode_emoji: The role's unicode emoji as a standard emoji (if the guild has the ROLE_ICONS feature), defaults to the current value of the role
@@ -876,7 +881,7 @@ class Guild(ClientSerializerMixin, IDMixin):
         _color = role.color if color is MISSING else color
         _hoist = role.hoist if hoist is MISSING else hoist
         _mentionable = role.mentionable if mentionable is MISSING else mentionable
-        _permissions = role.permissions if permissions is MISSING else permissions
+        _permissions = int(role.permissions if permissions is MISSING else permissions)
         _icon = role.icon if icon is MISSING else icon
         _unicode_emoji = role.unicode_emoji if unicode_emoji is MISSING else unicode_emoji
 

--- a/interactions/api/models/message.py
+++ b/interactions/api/models/message.py
@@ -766,6 +766,9 @@ class Message(ClientSerializerMixin, IDMixin):
     position: Optional[int] = field(default=None, repr=False)
 
     def __attrs_post_init__(self):
+        if self.referenced_message is not None:
+            self.referenced_message = Message(**self.referenced_message, _client=self._client)
+
         if self.member and self.guild_id:
             self.member._extras["guild_id"] = self.guild_id
 
@@ -789,9 +792,6 @@ class Message(ClientSerializerMixin, IDMixin):
         Returns when the message was created.
         """
         return self.id.timestamp
-
-        if self.referenced_message is not None:
-            self.referenced_message = Message(**self.referenced_message, _client=self._client)
 
     async def get_channel(self) -> Channel:
         """

--- a/interactions/api/models/misc.py
+++ b/interactions/api/models/misc.py
@@ -15,7 +15,7 @@ from os.path import basename
 from typing import List, Optional, Union
 
 from ...base import get_logger
-from ...utils.attrs_utils import DictSerializerMixin, convert_list, define, field
+from ...utils.attrs_utils import DictSerializerMixin, convert_int, convert_list, define, field
 from ...utils.missing import MISSING
 from ..error import LibraryException
 from .flags import Permissions
@@ -48,14 +48,14 @@ class Overwrite(DictSerializerMixin):
 
     :ivar str id: Role or User ID
     :ivar int type: Type that corresponds ot the ID; 0 for role and 1 for member.
-    :ivar Union[Permissions, int, str] allow: Permission bit set.
-    :ivar Union[Permissions, int, str] deny: Permission bit set.
+    :ivar Permissions allow: Permission bit set.
+    :ivar Permissions deny: Permission bit set.
     """
 
     id: int = field()
     type: int = field()
-    allow: Union[Permissions, int, str] = field()
-    deny: Union[Permissions, int, str] = field()
+    allow: Permissions = field(converter=convert_int(Permissions))
+    deny: Permissions = field(converter=convert_int(Permissions))
 
 
 @define()

--- a/interactions/api/models/role.py
+++ b/interactions/api/models/role.py
@@ -1,9 +1,16 @@
 from datetime import datetime
 from typing import TYPE_CHECKING, List, Optional, Union
 
-from ...utils.attrs_utils import ClientSerializerMixin, DictSerializerMixin, define, field
+from ...utils.attrs_utils import (
+    ClientSerializerMixin,
+    DictSerializerMixin,
+    convert_int,
+    define,
+    field,
+)
 from ...utils.missing import MISSING
 from ..error import LibraryException
+from .flags import Permissions
 from .misc import IDMixin, Image, Snowflake
 
 if TYPE_CHECKING:
@@ -52,7 +59,7 @@ class Role(ClientSerializerMixin, IDMixin):
     :ivar Optional[str] icon: Role icon hash, if any.
     :ivar Optional[str] unicode_emoji: Role unicode emoji
     :ivar int position: Role position
-    :ivar str permissions: Role permissions as a bit set
+    :ivar Permissions permissions: Role permissions as a bit set
     :ivar bool managed: A status denoting if this role is managed by an integration
     :ivar bool mentionable: A status denoting if this role is mentionable
     :ivar Optional[RoleTags] tags: The tags this role has
@@ -65,7 +72,7 @@ class Role(ClientSerializerMixin, IDMixin):
     icon: Optional[str] = field(default=None, repr=False)
     unicode_emoji: Optional[str] = field(default=None)
     position: int = field()
-    permissions: str = field()
+    permissions: Permissions = field(converter=convert_int(Permissions))
     managed: bool = field()
     mentionable: bool = field()
     tags: Optional[RoleTags] = field(converter=RoleTags, default=None)
@@ -117,7 +124,7 @@ class Role(ClientSerializerMixin, IDMixin):
         self,
         guild_id: Union[int, Snowflake, "Guild"],
         name: Optional[str] = MISSING,
-        permissions: Optional[int] = MISSING,
+        permissions: Optional[Union[Permissions, int]] = MISSING,
         color: Optional[int] = MISSING,
         hoist: Optional[bool] = MISSING,
         icon: Optional[Image] = MISSING,
@@ -133,7 +140,7 @@ class Role(ClientSerializerMixin, IDMixin):
         :param int guild_id: The id of the guild to edit the role on
         :param Optional[str] name: The name of the role, defaults to the current value of the role
         :param Optional[int] color: RGB color value as integer, defaults to the current value of the role
-        :param Optional[int] permissions: Bitwise value of the enabled/disabled permissions, defaults to the current value of the role
+        :param Optional[Union[Permissions, int]] permissions: Bitwise value of the enabled/disabled permissions, defaults to the current value of the role
         :param Optional[bool] hoist: Whether the role should be displayed separately in the sidebar, defaults to the current value of the role
         :param Optional[Image] icon: The role's icon image (if the guild has the ROLE_ICONS feature), defaults to the current value of the role
         :param Optional[str] unicode_emoji: The role's unicode emoji as a standard emoji (if the guild has the ROLE_ICONS feature), defaults to the current value of the role
@@ -148,7 +155,7 @@ class Role(ClientSerializerMixin, IDMixin):
         _color = self.color if color is MISSING else color
         _hoist = self.hoist if hoist is MISSING else hoist
         _mentionable = self.mentionable if mentionable is MISSING else mentionable
-        _permissions = self.permissions if permissions is MISSING else permissions
+        _permissions = int(self.permissions if permissions is MISSING else permissions)
         _icon = self.icon if icon is MISSING else icon
         _unicode_emoji = self.unicode_emoji if unicode_emoji is MISSING else unicode_emoji
         _guild_id = int(guild_id) if isinstance(guild_id, (int, Snowflake)) else int(guild_id.id)

--- a/interactions/client/context.py
+++ b/interactions/client/context.py
@@ -434,7 +434,7 @@ class CommandContext(_Context):
     :ivar bool deferred: Whether the response was deferred or not.
     :ivar Optional[Locale] locale: The selected language of the user invoking the interaction.
     :ivar Optional[Locale] guild_locale: The guild's preferred language, if invoked in a guild.
-    :ivar str app_permissions: Bitwise set of permissions the bot has within the channel the interaction was sent from.
+    :ivar Permissions app_permissions: Bitwise set of permissions the bot has within the channel the interaction was sent from.
     :ivar Client client:
         .. versionadded:: 4.3.0
 
@@ -696,7 +696,7 @@ class ComponentContext(_Context):
     :ivar bool deferred: Whether the response was deferred or not.
     :ivar Optional[Locale] locale: The selected language of the user invoking the interaction.
     :ivar Optional[Locale] guild_locale: The guild's preferred language, if invoked in a guild.
-    :ivar str app_permissions: Bitwise set of permissions the bot has within the channel the interaction was sent from.
+    :ivar Permissions app_permissions: Bitwise set of permissions the bot has within the channel the interaction was sent from.
     """
 
     async def edit(self, content: Optional[str] = MISSING, **kwargs) -> Message:


### PR DESCRIPTION
## About

This pull request changes the type of `permissions` attribute of the most dataclasses to `Permissions` type. [Case when you can't change perms for `Overwrite`](https://discord.com/channels/789032594456576001/1043376697145315359)
Additionally fixes wrong check for `type` parameter in `Channel.add_permission_overwrite`.

## Checklist

- [x] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.


I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [ ] To add a new feature
  - [x] As a general enhancement
  - [x] As a refactor of the library/the library's code
  - [x] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [x] A breaking change

  <!--- Expand this when more comes up--->
