### PR TITLE
feat: Add `channel` & `guild` properties for `VoiceState`

### DIFF
--- a/interactions/api/models/gw.py
+++ b/interactions/api/models/gw.py
@@ -648,6 +648,21 @@ class VoiceState(ClientSerializerMixin):
         """
         return self.channel_id is not None
 
+    @property
+    def channel(self) -> Optional[Channel]:
+        """
+        Returns the current channel, if cached.
+        """
+        return self._client.cache[Channel].get(self.channel_id)
+
+    @property
+    def guild(self) -> Optional[Guild]:
+        """
+        Returns the current guild, if cached.
+        """
+
+        return self._client.cache[Guild].get(self.guild_id)
+
     async def mute_member(self, reason: Optional[str] = None) -> Member:
         """
         Mutes the current member.
@@ -689,15 +704,21 @@ class VoiceState(ClientSerializerMixin):
 
         :rtype: Channel
         """
-        return Channel(
-            **await self._client.get_channel(int(self.channel_id)),
-            _client=self._client,
-        )
+        if channel := self.channel:
+            return channel
 
-    async def get_guild(self) -> "Guild":
+        res = await self._client.get_channel(int(self.channel_id))
+        return Channel(**res, _client=self._client)
+
+    async def get_guild(self) -> Guild:
         """
         Gets the guild in what the update took place.
 
         :rtype: Guild
         """
-        return Guild(**await self._client.get_guild(int(self.guild_id)), _client=self._client)
+
+        if guild := self.guild:
+            return guild
+
+        res = await self._client.get_guild(int(self.guild_id))
+        return Guild(**res, _client=self._client)


### PR DESCRIPTION
## About

This pull request adds `channel` & `guild` properties for `VoiceState`. Uses cached guild & channel if exists for `get_channel` and `get_guild` methods

## Checklist

- [x] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [ ] I've ensured the change(s) work on `3.8.6` and higher.
- [ ] I have added the `versionadded`, `versionchanged` and `deprecated` to any new or changed user-facing function I committed.
<!-- If you are unsure what the next version is, feel free to ask in #unstable at https://discord.gg/interactions -->

### Pull-Request specification

I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [x] To add a new feature
  - [x] As a general enhancement
  - [x] As a refactor of the library/the library's code
  - [ ] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

<!--- Expand this when more comes up--->
