### PR TITLE
fix: bug can't use list with components in `disable_components`

### DIFF
--- a/interactions/utils/utils.py
+++ b/interactions/utils/utils.py
@@ -232,7 +232,7 @@ def disable_components(
     elif isinstance(components, list):
         if not all(
             isinstance(component, (Button, SelectMenu)) for component in components
-        ) or not all(isinstance(component, (ActionRow, Component)) for component in components):
+        ) and not all(isinstance(component, (ActionRow, Component)) for component in components):
             raise LibraryException(
                 12,
                 "You must only specify lists of 'Buttons' and 'SelectMenus' or 'ActionRow' and 'Component'",


### PR DESCRIPTION
## About

Read title.

## Checklist

- [ ] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.
- [ ] I have added the `versionadded`, `versionchanged` and `deprecated` to any new or changed user-facing function I committed.
<!-- If you are unsure what the next version is, feel free to ask in #unstable at https://discord.gg/interactions -->

### Pull-Request specification

I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [ ] To add a new feature
  - [ ] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [x] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

<!--- Expand this when more comes up--->
