### PR TITLE
refactor(context): move `delete` to base context

### DIFF
--- a/interactions/client/context.py
+++ b/interactions/client/context.py
@@ -414,6 +414,28 @@ class _Context(ClientSerializerMixin):
         else:
             return any(perm in self.author.permissions for perm in permissions)
 
+    async def delete(self) -> None:
+        """
+        This deletes the interaction response of a message sent by
+        the contextually derived information from this class.
+
+        .. note::
+            Doing this will proceed in the context message no longer
+            being present.
+        """
+        if self.responded and self.message is not None:
+            await self._client.delete_interaction_response(
+                application_id=str(self.application_id),
+                token=self.token,
+                message_id=int(self.message.id),
+            )
+        else:
+            await self._client.delete_interaction_response(
+                application_id=str(self.application_id), token=self.token
+            )
+
+        self.message = None
+
 
 @define()
 class CommandContext(_Context):
@@ -612,28 +634,6 @@ class CommandContext(_Context):
             _client=self._client,
             author={"_client": self._client, "id": None, "username": None, "discriminator": None},
         )
-
-    async def delete(self) -> None:
-        """
-        This deletes the interaction response of a message sent by
-        the contextually derived information from this class.
-
-        .. note::
-            Doing this will proceed in the context message no longer
-            being present.
-        """
-        if self.responded and self.message is not None:
-            await self._client.delete_interaction_response(
-                application_id=str(self.application_id),
-                token=self.token,
-                message_id=int(self.message.id),
-            )
-        else:
-            await self._client.delete_interaction_response(
-                application_id=str(self.application_id), token=self.token
-            )
-
-        self.message = None
 
     async def populate(self, choices: Union[Choice, List[Choice]]) -> List[Choice]:
         """


### PR DESCRIPTION
## About

This pull request moves `delete` method from `CommandContext` to `_Context` to make it available for the `ComponentContext`.

Tip how to delete message from component interaction:
```py
await ctx.defer(edit_origin=True)
await ctx.delete()
```

## Checklist

- [ ] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.
- [ ] I have added the `versionadded`, `versionchanged` and `deprecated` to any new or changed user-facing function I committed.
<!-- If you are unsure what the next version is, feel free to ask in #unstable at https://discord.gg/interactions -->

### Pull-Request specification

I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [ ] To add a new feature
  - [x] As a general enhancement
  - [x] As a refactor of the library/the library's code
  - [ ] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

<!--- Expand this when more comes up--->
