### PR TITLE
docs: add missed fields for the `GuildAuditLogEntry`

### DIFF
--- a/interactions/api/models/audit_log.py
+++ b/interactions/api/models/audit_log.py
@@ -234,8 +234,8 @@ class AuditLogEntry(DictSerializerMixin):
     :ivar Optional[Snowflake] user_id: User or app that made the changes
     :ivar Snowflake id: ID of the entry
     :ivar AuditLogEvents action_type: Type of action that occurred
-    :ivar OptionalAuditEntryInfo options: Additional info for certain event types
-    :ivar str reason: Reason for the change (1-512 characters)
+    :ivar Optional[AuditEntryInfo] options: Additional info for certain event types
+    :ivar Optional[str] reason: Reason for the change (1-512 characters)
     """
 
     target_id: Optional[str] = field(default=None)

--- a/interactions/api/models/gw.py
+++ b/interactions/api/models/gw.py
@@ -214,9 +214,16 @@ class GuildAuditLogEntry(AuditLogEntry):
     .. versionadded:: 4.4.0
 
     A class object representing the event ``GUILD_AUDIT_LOG_ENTRY_CREATE``.
-    A derivation of AuditLogEntry.
+    A derivation of :class:`.AuditLogEntry`.
 
     :ivar Snowflake guild_id: The guild ID of event.
+    :ivar Optional[str] target_id: ID of the affected entity (webhook, user, role, etc.)
+    :ivar Optional[List[AuditLogChange]] changes: Changes made to the target_id
+    :ivar Optional[Snowflake] user_id: User or app that made the changes
+    :ivar Snowflake id: ID of the entry
+    :ivar AuditLogEvents action_type: Type of action that occurred
+    :ivar OptionalAuditEntryInfo options: Additional info for certain event types
+    :ivar str reason: Reason for the change (1-512 characters)
     """
 
     guild_id: Snowflake = field(converter=Snowflake)

--- a/interactions/api/models/gw.py
+++ b/interactions/api/models/gw.py
@@ -222,8 +222,8 @@ class GuildAuditLogEntry(AuditLogEntry):
     :ivar Optional[Snowflake] user_id: User or app that made the changes
     :ivar Snowflake id: ID of the entry
     :ivar AuditLogEvents action_type: Type of action that occurred
-    :ivar OptionalAuditEntryInfo options: Additional info for certain event types
-    :ivar str reason: Reason for the change (1-512 characters)
+    :ivar Optional[AuditEntryInfo] options: Additional info for certain event types
+    :ivar Optional[str] reason: Reason for the change (1-512 characters)
     """
 
     guild_id: Snowflake = field(converter=Snowflake)


### PR DESCRIPTION
## About

#1221 doesn't adds (im bad reviewer i know) docs about fields for the `GuildAuditLogEntry`

## Checklist

- [ ] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.
- [ ] I have added the `versionadded`, `versionchanged` and `deprecated` to any new or changed user-facing function I committed.
<!-- If you are unsure what the next version is, feel free to ask in #unstable at https://discord.gg/interactions -->

### Pull-Request specification

I've made this pull request: (check all that apply)
  - [x] For the documentation
  - [ ] To add a new feature
  - [ ] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [ ] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

<!--- Expand this when more comes up--->
