### PR TITLE
fix: adjust cmd-related deco typehints

### DIFF
--- a/interactions/client/const.py
+++ b/interactions/client/const.py
@@ -38,7 +38,7 @@ import logging
 import sys
 from collections import defaultdict
 from importlib.metadata import version as _v
-from typing import TypeVar, Union
+from typing import TypeVar, Union, Callable, Coroutine
 
 __all__ = (
     "__version__",
@@ -206,3 +206,4 @@ GUILD_WELCOME_MESSAGES = (
 T = TypeVar("T")
 T_co = TypeVar("T_co", covariant=True)
 Absent = Union[T, Missing]
+AsyncCallable = Callable[..., Coroutine]


### PR DESCRIPTION
## About

This pull request adjusts various command-related decorators in v5 to be properly typehinted. Previously, a lot of otherwise valid situations would error out.

## Checklist

- [x] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.
- [ ] I have added the `versionadded`, `versionchanged` and `deprecated` to any new or changed user-facing function I committed.
<!-- If you are unsure what the next version is, feel free to ask in #unstable at https://discord.gg/interactions -->

### Pull-Request specification

I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [ ] To add a new feature
  - [x] As a general enhancement
  - [x] As a refactor of the library/the library's code
  - [ ] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

<!--- Expand this when more comes up--->
