### PR TITLE
feat: Add command enhancements

### DIFF
--- a/interactions/client/mixins/send.py
+++ b/interactions/client/mixins/send.py
@@ -95,3 +95,48 @@ class SendMixin:
             if delete_after:
                 await message.delete(delay=delete_after)
             return message
+        
+    async def respond(
+        self,
+        content: Optional[str] = None,
+        *,
+        embeds: Optional[Union[Iterable[Union["Embed", dict]], Union["Embed", dict]]] = None,
+        embed: Optional[Union["Embed", dict]] = None,
+        components: Optional[
+            Union[
+                Iterable[Iterable[Union["BaseComponent", dict]]],
+                Iterable[Union["BaseComponent", dict]],
+                "BaseComponent",
+                dict,
+            ]
+        ] = None,
+        stickers: Optional[
+            Union[Iterable[Union["Sticker", "Snowflake_Type"]], "Sticker", "Snowflake_Type"]
+        ] = None,
+        allowed_mentions: Optional[Union["AllowedMentions", dict]] = None,
+        reply_to: Optional[Union["MessageReference", "Message", dict, "Snowflake_Type"]] = None,
+        files: Optional[Union["UPLOADABLE_TYPE", Iterable["UPLOADABLE_TYPE"]]] = None,
+        file: Optional["UPLOADABLE_TYPE"] = None,
+        tts: bool = False,
+        suppress_embeds: bool = False,
+        flags: Optional[Union[int, "MessageFlags"]] = None,
+        delete_after: Optional[float] = None,
+        **kwargs: Any,
+    ) -> "Message":
+        """An alias of the send method for messages."""
+        return await self.send(
+            content,
+            embeds=embeds,
+            embed=embed,
+            components=components,
+            stickers=stickers,
+            allowed_mentions=allowed_mentions,
+            reply_to=reply_to,
+            files=files,
+            file=file,
+            tts=tts,
+            suppress_embeds=suppress_embeds,
+            flags=flags,
+            delete_after=delete_after,
+            **kwargs
+        )

--- a/interactions/client/mixins/send.py
+++ b/interactions/client/mixins/send.py
@@ -95,7 +95,7 @@ class SendMixin:
             if delete_after:
                 await message.delete(delay=delete_after)
             return message
-        
+
     async def respond(
         self,
         content: Optional[str] = None,
@@ -138,5 +138,5 @@ class SendMixin:
             suppress_embeds=suppress_embeds,
             flags=flags,
             delete_after=delete_after,
-            **kwargs
+            **kwargs,
         )

--- a/interactions/models/internal/application_commands.py
+++ b/interactions/models/internal/application_commands.py
@@ -697,7 +697,7 @@ def _unpack_helper(iterable: typing.Iterable[str]) -> list[str]:
 
 
 def slash_command(
-    name: str | LocalisedName,
+    name: Absent[str | LocalisedName] = MISSING,
     *,
     description: Absent[str | LocalisedDesc] = MISSING,
     scopes: Absent[List["Snowflake_Type"]] = MISSING,
@@ -746,13 +746,14 @@ def slash_command(
                 perm = perm | func.default_member_permissions
             else:
                 perm = func.default_member_permissions
-
+        
+        _name = name if name not in ["", MISSING] else func.__name__
         _description = description
         if _description is MISSING:
             _description = func.__doc__ if func.__doc__ else "No Description Set"
 
         cmd = SlashCommand(
-            name=name,
+            name=_name,
             group_name=group_name,
             group_description=group_description,
             sub_cmd_name=sub_cmd_name,
@@ -772,7 +773,7 @@ def slash_command(
 
 
 def subcommand(
-    base: str | LocalisedName,
+    base: Absent[str | LocalisedName] = MISSING,
     *,
     subcommand_group: Optional[str | LocalisedName] = None,
     name: Optional[str | LocalisedName] = None,
@@ -814,12 +815,13 @@ def subcommand(
         if not asyncio.iscoroutinefunction(func):
             raise ValueError("Commands must be coroutines")
 
+        _base = base if base not in ["", MISSING] else func.__name__
         _description = description
         if _description is MISSING:
             _description = func.__doc__ if func.__doc__ else "No Description Set"
 
         cmd = SlashCommand(
-            name=base,
+            name=_base,
             description=(base_description or base_desc) or "No Description Set",
             group_name=subcommand_group,
             group_description=(subcommand_group_description or sub_group_desc)
@@ -839,7 +841,7 @@ def subcommand(
 
 
 def context_menu(
-    name: str | LocalisedName,
+    name: Absent[str | LocalisedName] = MISSING,
     context_type: "CommandTypes",
     scopes: Absent[List["Snowflake_Type"]] = MISSING,
     default_member_permissions: Optional["Permissions"] = None,

--- a/interactions/models/internal/application_commands.py
+++ b/interactions/models/internal/application_commands.py
@@ -746,7 +746,7 @@ def slash_command(
                 perm = perm | func.default_member_permissions
             else:
                 perm = func.default_member_permissions
-        
+
         _name = name if name not in ["", MISSING] else func.__name__
         _description = description
         if _description is MISSING:

--- a/interactions/models/internal/application_commands.py
+++ b/interactions/models/internal/application_commands.py
@@ -841,7 +841,7 @@ def subcommand(
 
 
 def context_menu(
-    name: Absent[str | LocalisedName] = MISSING,
+    name: str | LocalisedName,
     context_type: "CommandTypes",
     scopes: Absent[List["Snowflake_Type"]] = MISSING,
     default_member_permissions: Optional["Permissions"] = None,


### PR DESCRIPTION
This proposal targets the `5.x` branch and allows commands to infer from the coroutine's name instead of requiring kwargs usage of the decorator.

Additionally, I added a `.respond()` alias to `.send()` for sending.