### PR TITLE
feat: re-add prefixed commands

### DIFF
--- a/interactions/ext/prefixed_commands/__init__.py
+++ b/interactions/ext/prefixed_commands/__init__.py
@@ -1,0 +1,6 @@
+from .command import *
+from .context import *
+
+# from .help import *
+from .manager import *
+from .utils import *

--- a/interactions/ext/prefixed_commands/command.py
+++ b/interactions/ext/prefixed_commands/command.py
@@ -119,6 +119,9 @@ class PrefixedCommandParameter:
             param.kind,
         )
 
+    def __repr__(self) -> str:
+        return f"<PrefixedCommandParameter name={self.name!r}>"
+
     @property
     def optional(self) -> bool:
         """Is this parameter optional?"""

--- a/interactions/ext/prefixed_commands/command.py
+++ b/interactions/ext/prefixed_commands/command.py
@@ -1,0 +1,828 @@
+import functools
+import inspect
+import typing
+from collections import deque
+from types import NoneType, UnionType
+from typing import (
+    Optional,
+    Any,
+    Callable,
+    Annotated,
+    Literal,
+    Union,
+    TYPE_CHECKING,
+    Type,
+    TypeGuard,
+    Coroutine,
+)
+from typing_extensions import Self
+
+import attrs
+from naff.client.utils.attr_utils import docs
+from interactions.client.errors import BadArgument
+from interactions.client.const import MISSING
+from interactions.client.utils.input_utils import _quotes
+from interactions.client.utils.misc_utils import get_object_name, maybe_coroutine
+from interactions.models.internal.converters import (
+    _LiteralConverter,
+    NoArgumentConverter,
+    Greedy,
+    MODEL_TO_CONVERTER,
+)
+from interactions.models.internal.command import BaseCommand
+from interactions.models.internal.protocols import Converter
+
+if TYPE_CHECKING:
+    from .context import PrefixedContext
+
+__all__ = (
+    "PrefixedCommandParameter",
+    "PrefixedCommand",
+    "prefixed_command",
+)
+
+
+_STARTING_QUOTES = frozenset(_quotes.keys())
+
+
+class PrefixedCommandParameter:
+    """
+    An object representing parameters in a prefixed command.
+
+    This class should not be instantiated directly.
+    """
+
+    __slots__ = (
+        "name",
+        "default",
+        "type",
+        "kind",
+        "converters",
+        "greedy",
+        "union",
+        "variable",
+        "consume_rest",
+        "no_argument",
+    )
+
+    name: str
+    "The name of the parameter."
+    default: Any
+    "The default value of the parameter."
+    type: Type
+    "The type of the parameter."
+    kind: inspect._ParameterKind
+    """The kind of parameter this is as related to the function."""
+    converters: list[Callable[["PrefixedContext", str], Any]]
+    "A list of the converter functions for the parameter that convert to its type."
+    greedy: bool
+    "Is the parameter greedy?"
+    union: bool
+    "Is the parameter a union?"
+    variable: bool
+    "Was the parameter marked as a variable argument?"
+    consume_rest: bool
+    "Was the parameter marked to consume the rest of the input?"
+    no_argument: bool
+    "Does this parameter have a converter that subclasses `NoArgumentConverter`?"
+
+    def __init__(
+        self,
+        name: str,
+        default: Any = MISSING,
+        type: Type = None,
+        kind: inspect._ParameterKind = inspect._ParameterKind.POSITIONAL_OR_KEYWORD,
+        converters: Optional[list[Callable[["PrefixedContext", str], Any]]] = None,
+        greedy: bool = False,
+        union: bool = False,
+        variable: bool = False,
+        consume_rest: bool = False,
+        no_argument: bool = False,
+    ) -> None:
+        self.name = name
+        self.default = default
+        self.type = type
+        self.kind = kind
+        self.converters = converters or []
+        self.greedy = greedy
+        self.union = union
+        self.variable = variable
+        self.consume_rest = consume_rest
+        self.no_argument = no_argument
+
+    @classmethod
+    def from_param(cls, param: inspect.Parameter) -> Self:
+        return cls(
+            param.name,
+            param.default if param.default is not param.empty else MISSING,
+            param.annotation,
+            param.kind,
+        )
+
+    @property
+    def optional(self) -> bool:
+        """Is this parameter optional?"""
+        return self.default != MISSING
+
+
+class _PrefixedArgsIterator:
+    """
+    An iterator over the arguments of a prefixed command.
+
+    Has functions to control the iteration.
+    """
+
+    __slots__ = ("args", "index", "length")
+
+    def __init__(self, args: tuple[str, ...]) -> None:
+        self.args = args
+        self.index = 0
+        self.length = len(self.args)
+
+    def __iter__(self) -> Self:
+        return self
+
+    def __next__(self) -> str:
+        if self.index >= self.length:
+            raise StopIteration
+
+        result = self.args[self.index]
+        self.index += 1
+        return self._remove_quotes(result)
+
+    def _remove_quotes(self, arg: str) -> str:
+        # this removes quotes from the arguments themselves
+        return arg[1:-1] if arg[0] in _STARTING_QUOTES else arg
+
+    def _finish_args(self) -> tuple[str]:
+        result = self.args[self.index - 1 :]
+        self.index = self.length
+        return result
+
+    def get_rest_of_args(self) -> tuple[str]:
+        return tuple(self._remove_quotes(r) for r in self._finish_args())
+
+    def consume_rest(self) -> str:
+        return " ".join(self._finish_args())
+
+    def back(self, count: int = 1) -> None:
+        self.index -= count
+
+    def reset(self) -> None:
+        self.index = 0
+
+    @property
+    def finished(self) -> bool:
+        return self.index >= self.length
+
+
+def _check_for_no_arg(anno: Any) -> TypeGuard[NoArgumentConverter]:
+    return isinstance(anno, NoArgumentConverter) or (
+        inspect.isclass(anno) and issubclass(anno, NoArgumentConverter)
+    )
+
+
+def _convert_to_bool(argument: str) -> bool:
+    lowered = argument.lower()
+    if lowered in {"yes", "y", "true", "t", "1", "enable", "on"}:
+        return True
+    elif lowered in {"no", "n", "false", "f", "0", "disable", "off"}:
+        return False
+    else:
+        raise BadArgument(f"{argument} is not a recognised boolean option.")
+
+
+def _get_from_anno_type(anno: Annotated) -> Any:
+    """
+    Handles dealing with Annotated annotations, getting their (first) type annotation.
+
+    This allows correct type hinting with, say, Converters, for example.
+    """
+    # this is treated how it usually is during runtime
+    # the first argument is ignored and the rest is treated as is
+
+    return typing.get_args(anno)[1]
+
+
+def _get_converter(anno: type, name: str) -> Callable[["PrefixedContext", str], Any]:  # type: ignore
+    if typing.get_origin(anno) == Annotated:
+        anno = _get_from_anno_type(anno)
+
+    if isinstance(anno, Converter):
+        return BaseCommand._get_converter_function(anno, name)
+    elif converter := MODEL_TO_CONVERTER.get(anno, None):
+        return BaseCommand._get_converter_function(converter, name)
+    elif typing.get_origin(anno) is Literal:
+        literals = typing.get_args(anno)
+        return _LiteralConverter(literals).convert
+    elif inspect.isroutine(anno):
+        num_params = len(inspect.signature(anno).parameters.values())
+        match num_params:
+            case 2:
+                return anno
+            case 1:
+
+                async def _one_function_cmd(ctx, arg) -> Any:
+                    return await maybe_coroutine(anno, arg)
+
+                return _one_function_cmd
+            case 0:
+                ValueError(
+                    f"{get_object_name(anno)} for {name} has 0 arguments, which is unsupported."
+                )
+            case _:
+                ValueError(
+                    f"{get_object_name(anno)} for {name} has more than 2 arguments, which is unsupported."
+                )
+    elif anno == bool:
+        return lambda ctx, arg: _convert_to_bool(arg)
+    elif anno == inspect._empty:
+        return lambda ctx, arg: str(arg)
+    else:
+        return lambda ctx, arg: anno(arg)
+
+
+def _greedy_parse(greedy: Greedy, param: inspect.Parameter) -> Any:
+    default = param.default
+
+    if param.kind in {param.KEYWORD_ONLY, param.VAR_POSITIONAL}:
+        raise ValueError("Greedy[...] cannot be a variable or keyword-only argument.")
+
+    arg = typing.get_args(greedy)[0]
+
+    if typing.get_origin(arg) == Annotated:
+        arg = _get_from_anno_type(arg)
+
+    if typing.get_origin(arg) in {Union, UnionType}:
+        args = typing.get_args(arg)
+
+        if len(args) > 2 or NoneType not in args:
+            raise ValueError(f"Greedy[{repr(arg)}] is invalid.")
+
+        arg = args[0]
+        default = None
+
+    if arg in {NoneType, str, Greedy, Union, UnionType}:
+        raise ValueError(f"Greedy[{get_object_name(arg)}] is invalid.")
+
+    return arg, default
+
+
+async def _convert(
+    param: PrefixedCommandParameter, ctx: "PrefixedContext", arg: str
+) -> tuple[Any, bool]:
+    converted = MISSING
+    for converter in param.converters:
+        try:
+            converted = await maybe_coroutine(converter, ctx, arg)
+            break
+        except Exception as e:
+            if not param.union and not param.optional:
+                if isinstance(e, BadArgument):
+                    raise
+                raise BadArgument(str(e)) from e
+
+    used_default = False
+    if converted == MISSING:
+        if param.optional:
+            converted = param.default
+            used_default = True
+        else:
+            union_types = typing.get_args(param.type)
+            union_names = tuple(get_object_name(t) for t in union_types)
+            union_types_str = ", ".join(union_names[:-1]) + f", or {union_names[-1]}"
+            raise BadArgument(f'Could not convert "{arg}" into {union_types_str}.')
+
+    if param.no_argument:
+        # tells converter not to eat the current argument
+        used_default = True
+
+    return converted, used_default
+
+
+async def _greedy_convert(
+    param: PrefixedCommandParameter, ctx: "PrefixedContext", args: _PrefixedArgsIterator
+) -> tuple[list[Any] | Any, bool]:
+    args.back()
+    broke_off = False
+    greedy_args = []
+
+    for arg in args:
+        try:
+            greedy_arg, used_default = await _convert(param, ctx, arg)
+
+            if used_default:
+                raise BadArgument
+
+            greedy_args.append(greedy_arg)
+        except BadArgument:
+            broke_off = True
+            break
+
+    if not greedy_args:
+        if param.default:
+            greedy_args = param.default  # im sorry, typehinters
+        else:
+            raise BadArgument(f"Failed to find any arguments for {repr(param.type)}.")
+
+    return greedy_args, broke_off
+
+
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
+class PrefixedCommand(BaseCommand):
+    """Represents a command based off a message, usually denoted with a prefix."""
+
+    name: str = attrs.field(repr=False, metadata=docs("The name of the command."))
+    parameters: list[PrefixedCommandParameter] = attrs.field(
+        repr=False, metadata=docs("The parameters of the command."), factory=list
+    )
+    aliases: list[str] = attrs.field(
+        metadata=docs("The list of aliases the command can be invoked under."),
+        factory=list,
+    )
+    hidden: bool = attrs.field(
+        metadata=docs(
+            "If `True`, help commands should not show this in the help output (unless toggled to do so)."
+        ),
+        default=False,
+    )
+    ignore_extra: bool = attrs.field(
+        metadata=docs(
+            "If `True`, ignores extraneous strings passed to a command if all its requirements are met (e.g. ?foo a b c"
+            " when only expecting a and b). Otherwise, an error is raised. Defaults to True."
+        ),
+        default=True,
+    )
+    hierarchical_checking: bool = attrs.field(
+        metadata=docs(
+            "If `True` and if the base of a subcommand, every subcommand underneath it will run this command's checks"
+            " and cooldowns before its own. Otherwise, only the subcommand's checks are checked."
+        ),
+        default=True,
+    )
+    help: Optional[str] = attrs.field(
+        repr=False, metadata=docs("The long help text for the command."), default=None
+    )
+    brief: Optional[str] = attrs.field(
+        repr=False, metadata=docs("The short help text for the command."), default=None
+    )
+    parent: Optional["PrefixedCommand"] = attrs.field(
+        repr=False, metadata=docs("The parent command, if applicable."), default=None
+    )
+    subcommands: dict[str, "PrefixedCommand"] = attrs.field(
+        repr=False, metadata=docs("A dict of all subcommands for the command."), factory=dict
+    )
+    _usage: Optional[str] = attrs.field(repr=False, default=None)
+    _inspect_signature: Optional[inspect.Signature] = attrs.field(repr=False, default=None)
+
+    def __attrs_post_init__(self) -> None:
+        super().__attrs_post_init__()  # we want checks to work
+
+        # we have to do this afterwards as these rely on the callback
+        # and its own value, which is impossible to get with attrs
+        # methods, i think
+
+        if self.help:
+            self.help = inspect.cleandoc(self.help)
+        else:
+            self.help = inspect.getdoc(self.callback)
+            if isinstance(self.help, bytes):
+                self.help = self.help.decode("utf-8")
+
+        if self.brief is None:
+            self.brief = self.help.splitlines()[0] if self.help is not None else None
+
+    @property
+    def usage(self) -> str:
+        """
+        A string displaying how the command can be used.
+
+        If no string is set, it will default to the command's signature.
+        Useful for help commands.
+        """
+        return self._usage or self.signature
+
+    @usage.setter
+    def usage(self, usage: str) -> None:
+        self._usage = usage
+
+    @property
+    def qualified_name(self) -> str:
+        """Returns the full qualified name of this command."""
+        name_deq = deque()
+        command = self
+
+        while command.parent is not None:
+            name_deq.appendleft(command.name)
+            command = command.parent
+
+        name_deq.appendleft(command.name)
+        return " ".join(name_deq)
+
+    @property
+    def all_subcommands(self) -> frozenset[Self]:
+        """Returns all unique subcommands underneath this command."""
+        return frozenset(self.subcommands.values())
+
+    @property
+    def signature(self) -> str:
+        """Returns a POSIX-like signature useful for help command output."""
+        if not self.parameters:
+            return ""
+
+        results = []
+
+        for param in self.parameters:
+            anno = param.type
+            name = param.name
+
+            if typing.get_origin(anno) == Annotated:
+                anno = typing.get_args(anno)[1]
+
+            if not param.greedy and param.union:
+                union_args = typing.get_args(anno)
+                if len(union_args) == 2 and param.optional:
+                    anno = union_args[0]
+
+            if typing.get_origin(anno) is Literal:
+                # it's better to list the values it can be than display the variable name itself
+                name = "|".join(
+                    f'"{v}"' if isinstance(v, str) else str(v) for v in typing.get_args(anno)
+                )
+
+            # we need to do a lot of manipulations with the signature
+            # string, so using a deque as a string builder makes sense for performance
+            result_builder: deque[str] = deque()
+
+            if param.optional and param.default is not None:
+                # it would be weird making it look like name=None
+                result_builder.append(f"{name}={param.default}")
+            else:
+                result_builder.append(name)
+
+            if param.variable:
+                # this is inside the brackets
+                result_builder.append("...")
+
+            # surround the result with brackets
+            if param.optional:
+                result_builder.appendleft("[")
+                result_builder.append("]")
+            else:
+                result_builder.appendleft("<")
+                result_builder.append(">")
+
+            if param.greedy:
+                # this is outside the brackets, making it differentiable from
+                # a variable argument
+                result_builder.append("...")
+
+            results.append("".join(result_builder))
+
+        return " ".join(results)
+
+    @property
+    def is_subcommand(self) -> bool:
+        """Return whether this command is a subcommand or not."""
+        return bool(self.parent)
+
+    def _parse_parameters(self) -> None:
+        """
+        Parses the parameters that this command has into a form i.py can use.
+
+        This is purposely separated like this to allow "lazy parsing" - parsing
+        as the command is added to a bot rather than being parsed immediately.
+        This allows variables like "self" to be filtered out, and is useful for
+        potential future additions.
+        """
+        # clear out old parameters just in case
+        self.parameters = []
+
+        if not self._inspect_signature:
+            # we don't care about the ctx or self variables
+            if self.has_binding:
+                callback = functools.partial(self.callback, None, None)
+            else:
+                callback = functools.partial(self.callback, None)
+
+            self._inspect_signature = inspect.signature(callback)
+
+        params = self._inspect_signature.parameters
+
+        # this is used by keyword-only and variable args to make sure there isn't more than one of either
+        # mind you, we also don't want one keyword-only and one variable arg either
+        finished_params = False
+
+        for name, param in params.items():
+            if finished_params:
+                raise ValueError("Cannot have multiple keyword-only or variable arguments.")
+
+            cmd_param = PrefixedCommandParameter.from_param(param)
+            anno = param.annotation
+
+            if typing.get_origin(anno) == Greedy:
+                anno, default = _greedy_parse(anno, param)
+
+                if default is not param.empty:
+                    cmd_param.default = default
+                cmd_param.greedy = True
+
+            if typing.get_origin(anno) in {Union, UnionType}:
+                cmd_param.union = True
+                for arg in typing.get_args(anno):
+                    if _check_for_no_arg(anno):
+                        cmd_param.no_argument = True
+
+                    if arg != NoneType:
+                        converter = _get_converter(arg, name)
+                        cmd_param.converters.append(converter)
+                    elif not cmd_param.optional:  # d.py-like behavior
+                        cmd_param.default = None
+            else:
+                if _check_for_no_arg(anno):
+                    cmd_param.no_argument = True
+
+                converter = _get_converter(anno, name)
+                cmd_param.converters.append(converter)
+
+            match param.kind:
+                case param.KEYWORD_ONLY:
+                    if cmd_param.greedy:
+                        raise ValueError("Keyword-only arguments cannot be Greedy.")
+
+                    cmd_param.consume_rest = True
+                    finished_params = True
+                case param.VAR_POSITIONAL:
+                    if cmd_param.optional:
+                        # there's a lot of parser ambiguities here, so i'd rather not
+                        raise ValueError(
+                            "Variable arguments cannot have default values or be Optional."
+                        )
+                    if cmd_param.greedy:
+                        raise ValueError("Variable arguments cannot be Greedy.")
+
+                    cmd_param.variable = True
+                    finished_params = True
+
+            self.parameters.append(cmd_param)
+
+        # we need to deal with subcommands too
+        for command in self.all_subcommands:
+            command._parse_parameters()
+
+    def add_command(self, cmd: Self) -> None:
+        """
+        Adds a command as a subcommand to this command.
+
+        Args:
+            cmd: The command to add
+        """
+        cmd.parent = self  # just so we know this is a subcommand
+
+        if self.subcommands.get(cmd.name):
+            raise ValueError(
+                f"Duplicate command! Multiple commands share the name/alias: {self.qualified_name} {cmd.name}."
+            )
+        self.subcommands[cmd.name] = cmd
+
+        for alias in cmd.aliases:
+            if self.subcommands.get(alias):
+                raise ValueError(
+                    f"Duplicate command! Multiple commands share the name/alias: {self.qualified_name} {cmd.name}."
+                )
+            self.subcommands[alias] = cmd
+
+    def remove_command(self, name: str) -> None:
+        """
+        Removes a command as a subcommand from this command.
+
+        If an alias is specified, only the alias will be removed.
+
+        Args:
+            name: The command to remove.
+        """
+        command = self.subcommands.pop(name, None)
+
+        if command is None:
+            return
+
+        if name in command.aliases:
+            command.aliases.remove(name)
+            return
+
+        for alias in command.aliases:
+            self.subcommands.pop(alias, None)
+
+    def get_command(self, name: str) -> Optional[Self]:
+        """
+        Gets a subcommand from this command. Can get subcommands of subcommands if needed.
+
+        Args:
+            name: The command to search for.
+
+        Returns:
+            PrefixedCommand: The command object, if found.
+        """
+        if " " not in name:
+            return self.subcommands.get(name)
+
+        names = name.split()
+        if not names:
+            return None
+
+        cmd = self.subcommands.get(names[0])
+        if not cmd or not cmd.subcommands:
+            return cmd
+
+        for name in names[1:]:
+            try:
+                cmd = cmd.subcommands[name]
+            except (AttributeError, KeyError):
+                return None
+
+        return cmd
+
+    def subcommand(
+        self,
+        name: Optional[str] = None,
+        *,
+        aliases: Optional[list[str]] = None,
+        help: Optional[str] = None,
+        brief: Optional[str] = None,
+        usage: Optional[str] = None,
+        enabled: bool = True,
+        hidden: bool = False,
+        ignore_extra: bool = True,
+        hierarchical_checking: bool = True,
+    ) -> Callable[..., Self]:
+        """
+        A decorator to declare a subcommand for a prefixed command.
+
+        Args:
+            name: The name of the command. Defaults to the name of the coroutine.
+            aliases: The list of aliases the command can be invoked under.
+            help: The long help text for the command. Defaults to the docstring of the coroutine, if there is one.
+            brief: The short help text for the command. Defaults to the first line of the help text, if there is one.
+            usage: A string displaying how the command can be used. If no string is set, it will \
+                default to the command's signature. Useful for help commands.
+            enabled: Whether this command can be run at all.
+            hidden: If `True`, the default help command (when it is added) does not show this in the help output.
+            ignore_extra: If `True`, ignores extraneous strings passed to a command if all its requirements are met \
+                (e.g. ?foo a b c when only expecting a and b). Otherwise, an error is raised.
+            hierarchical_checking: If `True` and if the base of a subcommand, every subcommand underneath it will \
+                run this command's checks before its own. Otherwise, only the subcommand's checks are checked.
+        """
+
+        def wrapper(func: Callable) -> Self:
+            cmd = PrefixedCommand(
+                callback=func,
+                name=name or func.__name__,
+                aliases=aliases or [],
+                help=help,
+                brief=brief,
+                parent=self,
+                usage=usage,
+                enabled=enabled,
+                hidden=hidden,
+                ignore_extra=ignore_extra,
+                hierarchical_checking=hierarchical_checking,
+            )
+            self.add_command(cmd)
+            return cmd
+
+        return wrapper
+
+    async def call_callback(self, callback: Callable, ctx: "PrefixedContext") -> None:
+        """
+        Runs the callback of this command.
+
+        Args:
+            callback (Callable: The callback to run. This is provided for compatibility with internal.
+            ctx (internal.MessageContext): The context to use for this command.
+        """
+        # sourcery skip: remove-empty-nested-block, remove-redundant-if, remove-unnecessary-else
+        if len(self.parameters) == 0:
+            if ctx.args and not self.ignore_extra:
+                raise BadArgument(f"Too many arguments passed to {self.name}.")
+            return await self.call_with_binding(callback, ctx)
+        else:
+            # this is slightly costly, but probably worth it
+            new_args: list[Any] = []
+            kwargs: dict[str, Any] = {}
+            args = _PrefixedArgsIterator(tuple(ctx.args))
+            param_index = 0
+
+            for arg in args:
+                while param_index < len(self.parameters):
+                    param = self.parameters[param_index]
+
+                    if param.consume_rest:
+                        arg = args.consume_rest()
+
+                    if param.variable:
+                        args_to_convert = args.get_rest_of_args()
+                        new_arg = [await _convert(param, ctx, arg) for arg in args_to_convert]
+                        new_arg = tuple(arg[0] for arg in new_arg)
+                        new_args.extend(new_arg)
+                        param_index += 1
+                        break
+
+                    if param.greedy:
+                        greedy_args, broke_off = await _greedy_convert(param, ctx, args)
+
+                        new_args.append(greedy_args)
+                        param_index += 1
+                        if broke_off:
+                            args.back()
+
+                        if param.default:
+                            continue
+                        else:
+                            break
+
+                    converted, used_default = await _convert(param, ctx, arg)
+                    if param.kind in {
+                        inspect.Parameter.POSITIONAL_ONLY,
+                        inspect.Parameter.VAR_POSITIONAL,
+                    }:
+                        new_args.append(converted)
+                    else:
+                        kwargs[param.name] = converted
+                    param_index += 1
+
+                    if not used_default:
+                        break
+
+            if param_index < len(self.parameters):
+                for param in self.parameters[param_index:]:
+                    if param.no_argument:
+                        converted, _ = await _convert(param, ctx, None)  # type: ignore
+                        if not param.consume_rest:
+                            new_args.append(converted)
+                        else:
+                            kwargs[param.name] = converted
+                            break
+                        continue
+
+                    if not param.optional:
+                        raise BadArgument(f"{param.name} is a required argument that is missing.")
+                    else:
+                        if param.kind in {
+                            inspect.Parameter.POSITIONAL_ONLY,
+                            inspect.Parameter.VAR_POSITIONAL,
+                        }:
+                            new_args.append(param.default)
+                        else:
+                            kwargs[param.name] = param.default
+                            break
+            elif not self.ignore_extra and not args.finished:
+                raise BadArgument(f"Too many arguments passed to {self.name}.")
+
+            return await self.call_with_binding(callback, ctx, *new_args, **kwargs)
+
+
+def prefixed_command(
+    name: Optional[str] = None,
+    *,
+    aliases: Optional[list[str]] = None,
+    help: Optional[str] = None,
+    brief: Optional[str] = None,
+    usage: Optional[str] = None,
+    enabled: bool = True,
+    hidden: bool = False,
+    ignore_extra: bool = True,
+    hierarchical_checking: bool = True,
+) -> Callable[..., PrefixedCommand]:
+    """
+    A decorator to declare a coroutine as a prefixed command.
+
+    Args:
+        name: The name of the command. Defaults to the name of the coroutine.
+        aliases: The list of aliases the command can be invoked under.
+        help: The long help text for the command. Defaults to the docstring of the coroutine, if there is one.
+        brief: The short help text for the command. Defaults to the first line of the help text, if there is one.
+        usage: A string displaying how the command can be used. If no string is set, it will default to the \
+            command's signature. Useful for help commands.
+        enabled: Whether this command can be run at all.
+        hidden: If `True`, the default help command (when it is added) does not show this in the help output.
+        ignore_extra: If `True`, ignores extraneous strings passed to a command if all its requirements are \
+            met (e.g. ?foo a b c when only expecting a and b). Otherwise, an error is raised.
+        hierarchical_checking: If `True` and if the base of a subcommand, every subcommand underneath it will \
+            run this command's checks before its own. Otherwise, only the subcommand's checks are checked.
+    """
+
+    def wrapper(func: Callable) -> PrefixedCommand:
+        return PrefixedCommand(
+            callback=func,
+            name=name or func.__name__,
+            aliases=aliases or [],
+            help=help,
+            brief=brief,
+            usage=usage,
+            enabled=enabled,
+            hidden=hidden,
+            ignore_extra=ignore_extra,
+            hierarchical_checking=hierarchical_checking,
+        )
+
+    return wrapper

--- a/interactions/ext/prefixed_commands/context.py
+++ b/interactions/ext/prefixed_commands/context.py
@@ -1,0 +1,102 @@
+from typing import Optional, Union, Iterable, TYPE_CHECKING
+from typing_extensions import Self
+
+
+from interactions.client.mixins.send import SendMixin
+from interactions.client.client import Client
+from interactions.models.internal.context import BaseContext
+from interactions.models.discord.file import UPLOADABLE_TYPE
+from interactions.models.discord.message import Message
+from interactions.models.discord.embed import Embed
+from interactions.models.misc.context_manager import Typing
+
+if TYPE_CHECKING:
+    from .command import PrefixedCommand
+
+__all__ = ("PrefixedContext",)
+
+
+class PrefixedContext(BaseContext, SendMixin):
+    _message: Message
+
+    prefix: str
+    "The prefix used to invoke this command."
+    content_parameters: str
+    "The message content without the command and prefix."
+    command: "PrefixedCommand"
+    "The command this context invokes."
+
+    args: list[str]
+    "The arguments passed to the message."
+    kwargs: dict
+    "This is always empty, and is only here for compatibility with other types of commands."
+
+    @classmethod
+    def from_dict(cls, client: "Client", payload: dict) -> Self:
+        # this doesn't mean anything, so just implement it to make abc happy
+        raise NotImplementedError
+
+    @classmethod
+    def from_message(cls, client: "Client", message: Message) -> Self:
+        instance = cls(client=client)
+
+        # hack to work around BaseContext property
+        # since the message is the most important part of the context,
+        # we don't want to rely on the cache for it
+        instance._message = message
+
+        instance.message_id = message.id
+        instance.author_id = message._author_id
+        instance.channel_id = message._channel_id
+        instance.guild_id = message._guild_id
+
+        instance.prefix = ""
+        instance.content_parameters = ""
+        instance.command = None  # type: ignore
+        instance.args = []
+        instance.kwargs = {}
+        return instance
+
+    @property
+    def message(self) -> Message:
+        """The message that invoked this context."""
+        return self._message
+
+    @property
+    def invoke_target(self) -> str:
+        """The name of the command to be invoked."""
+        return self.command.name
+
+    @property
+    def typing(self) -> Typing:
+        """A context manager to send a typing state to the context's channel as long as long as the wrapped operation takes."""
+        return self.channel.typing
+
+    async def _send_http_request(
+        self, message_payload: dict, files: Iterable["UPLOADABLE_TYPE"] | None = None
+    ) -> dict:
+        return await self.client.http.create_message(message_payload, self.channel.id, files=files)
+
+    async def reply(
+        self,
+        content: Optional[str] = None,
+        embeds: Optional[Union[Iterable[Union[Embed, dict]], Union[Embed, dict]]] = None,
+        embed: Optional[Union[Embed, dict]] = None,
+        **kwargs,
+    ) -> Message:
+        """
+        Reply to the context's message. Takes all the same attributes as `send`.
+
+        Args:
+            content: Message text content.
+            embeds: Embedded rich content (up to 6000 characters).
+            embed: Embedded rich content (up to 6000 characters).
+            **kwargs: Additional options to pass to `send`.
+
+        Returns:
+            New message object.
+
+        """
+        return await self.send(
+            content=content, reply_to=self.message, embeds=embeds or embed, **kwargs
+        )

--- a/interactions/ext/prefixed_commands/manager.py
+++ b/interactions/ext/prefixed_commands/manager.py
@@ -45,6 +45,7 @@ class PrefixedManager:
         generate_prefixes: An asynchronous function \
             that takes in a `Client` and `Message` object and returns either a \
             string or an iterable of strings. Defaults to `None`.
+        prefixed_context: The object to instantiate for Prefixed Context
     """
 
     def __init__(
@@ -58,12 +59,14 @@ class PrefixedManager:
                 Coroutine[Any, Any, str | list[str]],
             ]
         ] = None,
+        prefixed_context: type[PrefixedContext] = PrefixedContext,
     ) -> None:
         # typehinting funkyness for better typehints
         client = cast(PrefixedInjectedClient, client)
 
         self.client = client
         self.default_prefix = default_prefix
+        self.prefixed_context = prefixed_context
         self.commands: dict[str, PrefixedCommand] = {}
         self._ext_command_list: defaultdict[str, set[str]] = defaultdict(set)
 
@@ -303,7 +306,7 @@ class PrefixedManager:
         if not prefix_used:
             return
 
-        context: PrefixedContext = PrefixedContext.from_message(self.client, message)
+        context = self.prefixed_context.from_message(self.client, message)
         context.prefix = prefix_used
 
         content_parameters = message.content.removeprefix(prefix_used).strip()
@@ -363,6 +366,7 @@ def setup(
             Coroutine[Any, Any, str | list[str]],
         ]
     ] = None,
+    prefixed_context: type[PrefixedContext] = PrefixedContext,
 ) -> PrefixedManager:
     """
     Sets up prefixed commands. It is recommended to use this function directly to do so.
@@ -373,10 +377,14 @@ def setup(
         generate_prefixes: An asynchronous function \
             that takes in a `Client` and `Message` object and returns either a \
             string or an iterable of strings. Defaults to `None`.
+        prefixed_context: The object to instantiate for Prefixed Context
 
     Returns:
         PrefixedManager: The class that deals with all things prefixed commands.
     """
     return PrefixedManager(
-        client, default_prefix=default_prefix, generate_prefixes=generate_prefixes
+        client,
+        default_prefix=default_prefix,
+        generate_prefixes=generate_prefixes,
+        prefixed_context=prefixed_context,
     )

--- a/interactions/ext/prefixed_commands/manager.py
+++ b/interactions/ext/prefixed_commands/manager.py
@@ -1,0 +1,382 @@
+import contextlib
+from asyncio import TimeoutError
+from typing import Optional, Callable, Any, Coroutine, cast, Iterable
+from collections import defaultdict
+from typing_extensions import Self
+
+from interactions.api.events.base import RawGatewayEvent
+from interactions.api.events.discord import MessageCreate
+from interactions.api.events.internal import (
+    CommandError,
+    CommandCompletion,
+    CallbackAdded,
+    ExtensionUnload,
+)
+from interactions.models.discord.message import Message
+from interactions.models.internal.listener import listen
+from interactions.client.client import Client
+from interactions.client.utils.input_utils import get_args, get_first_word
+
+from .utils import when_mentioned
+from .command import PrefixedCommand
+from .context import PrefixedContext
+
+__all__ = ("PrefixedInjectedClient", "PrefixedManager", "setup")
+
+
+class PrefixedInjectedClient(Client):
+    """
+    A semi-stub for a `Client` injected with prefixed commands.
+
+    This should only be used for type hinting.
+    """
+
+    prefixed: "PrefixedManager"
+    "The prefixed command manager for this client."
+
+
+class PrefixedManager:
+    """
+    The main part of the extension. Deals with injecting itself in the first place.
+
+    Parameters:
+        client: The client instance.
+        default_prefix: The default prefix to use. Defaults to `None`.
+        generate_prefixes: An asynchronous function \
+            that takes in a `Client` and `Message` object and returns either a \
+            string or an iterable of strings. Defaults to `None`.
+    """
+
+    def __init__(
+        self,
+        client: Client,
+        *,
+        default_prefix: Optional[str | list[str]] = None,
+        generate_prefixes: Optional[
+            Callable[
+                [Client, Message],
+                Coroutine[Any, Any, str | list[str]],
+            ]
+        ] = None,
+    ) -> None:
+        # typehinting funkyness for better typehints
+        client = cast(PrefixedInjectedClient, client)
+
+        self.client = client
+        self.default_prefix = default_prefix
+        self.commands: dict[str, PrefixedCommand] = {}
+        self._ext_command_list: defaultdict[str, set[str]] = defaultdict(set)
+
+        if default_prefix is None and generate_prefixes is None:
+            # by default, use mentioning the bot as the prefix
+            generate_prefixes = when_mentioned
+
+        self.generate_prefixes = (  # type: ignore
+            generate_prefixes if generate_prefixes is not None else self.generate_prefixes
+        )
+
+        self.client.prefixed = self
+
+        self._dispatch_prefixed_commands = self._dispatch_prefixed_commands.copy_with_binding(self)
+        self._register_command = self._register_command.copy_with_binding(self)
+        self._handle_ext_unload = self._handle_ext_unload.copy_with_binding(self)
+
+        self.client.add_listener(self._dispatch_prefixed_commands)
+        self.client.add_listener(self._register_command)
+        self.client.add_listener(self._handle_ext_unload)
+
+    async def generate_prefixes(self, client: Client, msg: Message) -> str | list[str]:
+        """
+        Generates a list of prefixes a prefixed command can have based on the client and message.
+
+        This can be overwritten by passing a function to generate_prefixes on initialization.
+
+        Args:
+            client: The client instance.
+            msg: The message sent.
+
+        Returns:
+            The prefix(es) to check for.
+        """
+        return self.default_prefix  # type: ignore
+
+    def add_command(self, command: PrefixedCommand) -> None:
+        """
+        Add a prefixed command to the manager.
+
+        Args:
+            command: The command to add.
+        """
+        if command.is_subcommand:
+            raise ValueError(
+                "You cannot add subcommands to the client - add the base command instead."
+            )
+
+        command._parse_parameters()
+
+        if self.commands.get(command.name):
+            raise ValueError(
+                f"Duplicate command! Multiple commands share the name/alias: {command.name}."
+            )
+        self.commands[command.name] = command
+
+        for alias in command.aliases:
+            if self.commands.get(alias):
+                raise ValueError(
+                    f"Duplicate command! Multiple commands share the name/alias: {alias}."
+                )
+            self.commands[alias] = command
+
+        if command.extension:
+            self._ext_command_list[command.extension.extension_name].add(command.name)
+            command.extension._commands.append(command)
+
+    def get_command(self, name: str) -> Optional[PrefixedCommand]:
+        """
+        Gets a prefixed command by the name/alias specified.
+
+        This function is able to resolve subcommands - fully qualified names can be used.
+        For example, passing in ``foo bar`` would get the subcommand ``bar`` from the
+        command ``foo``.
+
+        Args:
+            name: The name of the command to search for.
+
+        Returns:
+            The command object, if found.
+        """
+        if " " not in name:
+            return self.commands.get(name)
+
+        names = name.split()
+        if not names:
+            return None
+
+        cmd = self.commands.get(names[0])
+        if not cmd:
+            return cmd
+
+        for name in names[1:]:
+            try:
+                cmd = cmd.subcommands[name]
+            except (AttributeError, KeyError):
+                return None
+
+        return cmd
+
+    def _remove_cmd_and_aliases(self, name: str) -> None:
+        if cmd := self.commands.pop(name, None):
+            if cmd.extension:
+                self._ext_command_list[cmd.extension.extension_name].discard(cmd.name)
+                with contextlib.suppress(ValueError):
+                    cmd.extension._commands.remove(cmd)
+
+            for alias in cmd.aliases:
+                self.commands.pop(alias, None)
+
+    def remove_command(
+        self, name: str, delete_parent_if_empty: bool = False
+    ) -> Optional[PrefixedCommand]:
+        """
+        Removes a prefixed command if it exists.
+
+        If an alias is specified, only the alias will be removed.
+        This function is able to resolve subcommands - fully qualified names can be used.
+        For example, passing in ``foo bar`` would delete the subcommand ``bar``
+        from the command ``foo``.
+
+        Args:
+            name: The command to remove.
+            delete_parent_if_empty: Should the parent command be deleted if it \
+                ends up having no subcommands after deleting the command specified? \
+                Defaults to `False`.
+
+        Returns:
+            The command that was removed, if one was. If the command was not found,
+            this function returns `None`.
+        """
+        command = self.get_command(name)
+
+        if command is None:
+            return None
+
+        if name in command.aliases:
+            command.aliases.remove(name)
+            return command
+
+        if command.parent:
+            command.parent.remove_command(command.name)
+        else:
+            self._remove_cmd_and_aliases(command.name)
+
+        if delete_parent_if_empty:
+            while command.parent is not None and not command.parent.subcommands:
+                if command.parent.parent:
+                    _new_cmd = command.parent
+                    command.parent.parent.remove_command(command.parent.name)
+                    command = _new_cmd
+                else:
+                    self._remove_cmd_and_aliases(command.parent.name)
+                    break
+
+        return command
+
+    @listen("callback_added")
+    async def _register_command(self, event: CallbackAdded) -> None:
+        """Registers a prefixed command, if there is one given."""
+        if not isinstance(event.callback, PrefixedCommand):
+            return
+
+        cmd = event.callback
+        cmd.extension = event.extension
+
+        if not cmd.is_subcommand:
+            self.add_command(cmd)
+
+    @listen("extension_unload")
+    async def _handle_ext_unload(self, event: ExtensionUnload) -> None:
+        """Unregisters all prefixed commands in an extension as it is being unloaded."""
+        for name in self._ext_command_list[event.extension.extension_name]:
+            self.remove_command(name)
+
+    @listen("raw_message_create", is_default_listener=True)
+    async def _dispatch_prefixed_commands(self, event: RawGatewayEvent) -> None:
+        """Determine if a prefixed command is being triggered, and dispatch it."""
+        # don't waste time processing this if there are no prefixed commands
+        if not self.commands:
+            return
+
+        data = event.data
+
+        # many bots will not have the message content intent, and so will not have content
+        # for most messages. since there's nothing for prefixed commands to work off of,
+        # we might as well not waste time
+        if not data.get("content"):
+            return
+
+        # webhooks and users labeled with the bot property are bots, and should be ignored
+        if data.get("webhook_id") or data["author"].get("bot", False):
+            return
+
+        # now, we've done the basic filtering out, but everything from here on out relies
+        # on a proper message object, so now we either hope its already in the cache or wait
+        # on the processor
+
+        # first, let's check the cache...
+        message = self.client.cache.get_message(int(data["channel_id"]), int(data["id"]))
+
+        # this huge if statement basically checks if the message hasn't been fully processed by
+        # the processor yet, which would mean that these fields aren't fully filled
+        if message and (
+            (not message._guild_id and event.data.get("guild_id"))
+            or (message._guild_id and not message.guild)
+            or not message.channel
+        ):
+            message = None
+
+        # if we didn't get a message, then we know we should wait for the message create event
+        if not message:
+            try:
+                # i think 2 seconds is a very generous timeout limit
+                msg_event: MessageCreate = await self.client.wait_for(
+                    MessageCreate, checks=lambda e: int(e.message.id) == int(data["id"]), timeout=2
+                )
+                message = msg_event.message
+            except TimeoutError:
+                return
+
+        if not message.content:
+            return
+
+        # here starts the actual prefixed command parsing part
+        prefixes: str | Iterable[str] = await self.generate_prefixes(self.client, message)
+
+        if isinstance(prefixes, str):
+            # its easier to treat everything as if it may be an iterable
+            # rather than building a special case for this
+            prefixes = (prefixes,)  # type: ignore
+
+        prefix_used = next(
+            (prefix for prefix in prefixes if message.content.startswith(prefix)),
+            None,
+        )
+        if not prefix_used:
+            return
+
+        context: PrefixedContext = PrefixedContext.from_message(self.client, message)
+        context.prefix = prefix_used
+
+        content_parameters = message.content.removeprefix(prefix_used).strip()
+        command: "Self | PrefixedCommand" = self  # yes, this is a hack
+
+        while True:
+            first_word: str = get_first_word(content_parameters)  # type: ignore
+            if isinstance(command, PrefixedCommand):
+                new_command = command.subcommands.get(first_word)
+            else:
+                new_command = command.commands.get(first_word)
+            if not new_command or not new_command.enabled:
+                break
+
+            command = new_command
+            content_parameters = content_parameters.removeprefix(first_word).strip()
+
+            if command.subcommands and command.hierarchical_checking:
+                try:
+                    await new_command._can_run(
+                        context
+                    )  # will error out if we can't run this command
+                except Exception as e:
+                    if new_command.error_callback:
+                        await new_command.error_callback(e, context)
+                    elif new_command.extension and new_command.extension.extension_error:
+                        await new_command.extension.extension_error(e, context)
+                    else:
+                        self.client.dispatch(CommandError(ctx=context, error=e))
+                    return
+
+        if not isinstance(command, PrefixedCommand) or not command.enabled:
+            return
+
+        context.command = command
+        context.content_parameters = content_parameters.strip()
+        context.args = get_args(context.content_parameters)
+        try:
+            if self.client.pre_run_callback:
+                await self.client.pre_run_callback(context)
+            await command(context)
+            if self.client.post_run_callback:
+                await self.client.post_run_callback(context)
+        except Exception as e:
+            self.client.dispatch(CommandError(ctx=context, error=e))
+        finally:
+            self.client.dispatch(CommandCompletion(ctx=context))
+
+
+def setup(
+    client: Client,
+    *,
+    default_prefix: Optional[str | list[str]] = None,
+    generate_prefixes: Optional[
+        Callable[
+            [Client, Message],
+            Coroutine[Any, Any, str | list[str]],
+        ]
+    ] = None,
+) -> PrefixedManager:
+    """
+    Sets up prefixed commands. It is recommended to use this function directly to do so.
+
+    Parameters:
+        client: The client instance.
+        default_prefix: The default prefix to use. Defaults to `None`.
+        generate_prefixes: An asynchronous function \
+            that takes in a `Client` and `Message` object and returns either a \
+            string or an iterable of strings. Defaults to `None`.
+
+    Returns:
+        PrefixedManager: The class that deals with all things prefixed commands.
+    """
+    return PrefixedManager(
+        client, default_prefix=default_prefix, generate_prefixes=generate_prefixes
+    )

--- a/interactions/ext/prefixed_commands/utils.py
+++ b/interactions/ext/prefixed_commands/utils.py
@@ -1,0 +1,38 @@
+from typing import Callable, Any, Coroutine
+
+from interactions.client.client import Client
+from interactions.models.discord.message import Message
+
+__all__ = ("when_mentioned", "when_mentioned_or")
+
+
+async def when_mentioned(bot: Client, _) -> list[str]:
+    """
+    Returns a list of the bot's mentions.
+
+    Returns:
+        A list of the bot's possible mentions.
+    """
+    return [f"<@{bot.user.id}> ", f"<@!{bot.user.id}> "]  # type: ignore
+
+
+def when_mentioned_or(
+    *prefixes: str,
+) -> Callable[[Client, Message], Coroutine[Any, Any, list[str]]]:
+    """
+    Returns a list of the bot's mentions plus whatever prefixes are provided.
+
+    This is intended to be used with initializing prefixed commands. If you wish to use
+    it in your own function, you will need to do something similar to
+    `await when_mentioned_or(*prefixes)(bot, msg)`.
+
+    Args:
+        prefixes: Prefixes to include alongside mentions.
+    Returns:
+        A list of the bot's mentions plus whatever prefixes are provided.
+    """
+
+    async def _new_mention(bot: Client, _) -> list[str]:
+        return (await when_mentioned(bot, _)) + list(prefixes)
+
+    return _new_mention

--- a/interactions/models/internal/converters.py
+++ b/interactions/models/internal/converters.py
@@ -66,7 +66,7 @@ __all__ = (
     "CustomEmojiConverter",
     "MessageConverter",
     "Greedy",
-    "NAFF_MODEL_TO_CONVERTER",
+    "MODEL_TO_CONVERTER",
 )
 
 
@@ -582,7 +582,7 @@ class Greedy(List[T]):
     """A special marker class to mark an argument in a prefixed command to repeatedly convert until it fails to convert an argument."""
 
 
-NAFF_MODEL_TO_CONVERTER: dict[type, type[Converter]] = {
+MODEL_TO_CONVERTER: dict[type, type[Converter]] = {
     SnowflakeObject: SnowflakeConverter,
     BaseChannel: BaseChannelConverter,
     DMChannel: DMChannelConverter,


### PR DESCRIPTION
## About

This is more or less a straight port of [the prefixed command PR from NIFPY](https://github.com/interactions-py/NIFPY/pull/3) into here. I'd mostly suggest reading that, but:
- `PrefixedCommand` is back to being an `attrs` class.
- I decided to keep `BadArgument` and all of the converters where they were at as they technically had usage outside of prefixed commands (they're just converters and errors, after all).
- No docs still, and paginators are still broken.

## Checklist

- [x] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.
- [ ] I have added the `versionadded`, `versionchanged` and `deprecated` to any new or changed user-facing function I committed.
<!-- If you are unsure what the next version is, feel free to ask in #unstable at https://discord.gg/interactions -->

### Pull-Request specification

I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [x] To add a new feature
  - [x] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [ ] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [x] A breaking change (technically, the name change for the "model to converter" dict is breaking lol)

<!--- Expand this when more comes up--->
