### PR TITLE
fix: use python 3.10 for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
       language: python
       types: [file, python]
       exclude_types: ['image']
+      language_version: python3.10
     - id: trailing-whitespace
       name: Trailing Whitespace
       language: python
@@ -36,6 +37,7 @@ repos:
       language: python
       types: [file, python]
       args: [--line-length=100]
+      language_version: python3.10
   - repo: https://github.com/PyCQA/flake8
     rev: 6.0.0
     hooks:
@@ -54,6 +56,7 @@ repos:
         - flake8-deprecated
         - flake8-print
         - git+https://github.com/python-formate/flake8-dunder-all
+      language_version: python3.10
 #  - repo: https://github.com/pycqa/isort
 #    rev: 5.11.4
 #    hooks:

--- a/interactions/api/events/processors/guild_events.py
+++ b/interactions/api/events/processors/guild_events.py
@@ -10,8 +10,6 @@ from interactions.api.events.discord import (
     IntegrationCreate,
     IntegrationUpdate,
     IntegrationDelete,
-    BanCreate,
-    BanRemove,
     GuildStickersUpdate,
     WebhooksUpdate,
 )

--- a/interactions/client/client.py
+++ b/interactions/client/client.py
@@ -1319,7 +1319,6 @@ class Client(
                     added += 1
                 except TypeError:
                     self.logger.debug(f"Failed to add callback {func} from {location}")
-                    breakpoint()
                     continue
 
             self.logger.debug(f"{added} callbacks have been loaded from {location}.")

--- a/interactions/models/discord/components.py
+++ b/interactions/models/discord/components.py
@@ -1,25 +1,38 @@
 import uuid
 from abc import abstractmethod
-from typing import Any, Dict, Iterator, List, Optional, Sequence, TYPE_CHECKING, Union
+from typing import Any, Dict, Iterator, List, Optional, TYPE_CHECKING, Union
 
-import attrs
 import discord_typings
 
 from interactions.client.const import (
-    SELECTS_MAX_OPTIONS,
-    SELECT_MAX_NAME_LENGTH,
     ACTION_ROW_MAX_ITEMS,
     MISSING,
 )
 from interactions.client.mixins.serialization import DictSerializationMixin
-from interactions.client.utils import list_converter
-from interactions.client.utils.attr_utils import str_validator
-from interactions.client.utils.serializer import export_converter
 from interactions.models.discord.emoji import process_emoji
 from interactions.models.discord.enums import ButtonStyles, ComponentTypes, ChannelTypes
 
 if TYPE_CHECKING:
     from interactions.models.discord.emoji import PartialEmoji
+
+
+__all__ = (
+    "BaseComponent",
+    "InteractiveComponent",
+    "ActionRow",
+    "Button",
+    "BaseSelectMenu",
+    "StringSelectOption",
+    "StringSelectMenu",
+    "UserSelectMenu",
+    "RoleSelectMenu",
+    "MentionableSelectMenu",
+    "ChannelSelectMenu",
+    "process_components",
+    "spread_to_rows",
+    "get_components_ids",
+    "TYPE_COMPONENT_MAPPING",
+)
 
 
 class BaseComponent(DictSerializationMixin):
@@ -104,11 +117,10 @@ class ActionRow(BaseComponent):
     def __init__(self, *components: Dict | BaseComponent) -> None:
         if isinstance(components, (list, tuple)):
             # flatten user error
-            components = [c for c in components]
+            components = list(components)
 
         self.components: list[Dict | BaseComponent] = [
-            BaseComponent.from_dict_factory(c) if isinstance(c, dict) else c
-            for c in components
+            BaseComponent.from_dict_factory(c) if isinstance(c, dict) else c for c in components
         ]
 
         self.type: ComponentTypes = ComponentTypes.ACTION_ROW
@@ -127,11 +139,10 @@ class ActionRow(BaseComponent):
         """
         if isinstance(components, (list, tuple)):
             # flatten user error
-            components = [c for c in components]
+            components = list(components)
 
         self.components.extend(
-            BaseComponent.from_dict_factory(c) if isinstance(c, dict) else c
-            for c in components
+            BaseComponent.from_dict_factory(c) if isinstance(c, dict) else c for c in components
         )
 
     @classmethod
@@ -205,7 +216,7 @@ class Button(InteractiveComponent):
         custom_id: str = None,
         url: str | None = None,
         disabled: bool = False,
-    ):
+    ) -> None:
         self.style: ButtonStyles = style
         self.label: str | None = label
         self.emoji: "PartialEmoji | None" = emoji
@@ -272,7 +283,7 @@ class BaseSelectMenu(InteractiveComponent):
         max_values: int = 1,
         custom_id: str | None = None,
         disabled: bool = False,
-    ):
+    ) -> None:
         self.custom_id: str = custom_id or str(uuid.uuid4())
         self.placeholder: str | None = placeholder
         self.min_values: int = min_values
@@ -282,9 +293,7 @@ class BaseSelectMenu(InteractiveComponent):
         self.type: ComponentTypes = MISSING
 
     @classmethod
-    def from_dict(
-        cls, data: discord_typings.SelectMenuComponentData
-    ) -> "BaseSelectMenu":
+    def from_dict(cls, data: discord_typings.SelectMenuComponentData) -> "BaseSelectMenu":
         return cls(
             placeholder=data.get("placeholder"),
             min_values=data["min_values"],
@@ -324,7 +333,7 @@ class StringSelectOption(BaseComponent):
         description: str | None = None,
         emoji: "PartialEmoji | None" = None,
         default: bool = False,
-    ):
+    ) -> None:
         self.label: str = label
         self.value: str = value
         self.description: str | None = description
@@ -348,14 +357,10 @@ class StringSelectOption(BaseComponent):
         except TypeError:
             pass
 
-        raise TypeError(
-            f"Cannot convert {value} of type {type(value)} to a SelectOption"
-        )
+        raise TypeError(f"Cannot convert {value} of type {type(value)} to a SelectOption")
 
     @classmethod
-    def from_dict(
-        cls, data: discord_typings.SelectMenuOptionData
-    ) -> "StringSelectOption":
+    def from_dict(cls, data: discord_typings.SelectMenuOptionData) -> "StringSelectOption":
         return cls(
             label=data["label"],
             value=data["value"],
@@ -396,7 +401,7 @@ class StringSelectMenu(BaseSelectMenu):
         max_values: int = 1,
         custom_id: str | None = None,
         disabled: bool = False,
-    ):
+    ) -> None:
         super().__init__(
             placeholder=placeholder,
             min_values=min_values,
@@ -410,9 +415,7 @@ class StringSelectMenu(BaseSelectMenu):
         self.type: ComponentTypes = ComponentTypes.STRING_SELECT
 
     @classmethod
-    def from_dict(
-        cls, data: discord_typings.SelectMenuComponentData
-    ) -> "StringSelectMenu":
+    def from_dict(cls, data: discord_typings.SelectMenuComponentData) -> "StringSelectMenu":
         return cls(
             *data["options"],
             placeholder=data.get("placeholder"),
@@ -427,6 +430,7 @@ class StringSelectMenu(BaseSelectMenu):
             **super().to_dict(),
             "options": [option.to_dict() for option in self.options],
         }
+
 
 class UserSelectMenu(BaseSelectMenu):
     """
@@ -449,7 +453,7 @@ class UserSelectMenu(BaseSelectMenu):
         max_values: int = 1,
         custom_id: str | None = None,
         disabled: bool = False,
-    ):
+    ) -> None:
         super().__init__(
             placeholder=placeholder,
             min_values=min_values,
@@ -482,7 +486,7 @@ class RoleSelectMenu(BaseSelectMenu):
         max_values: int = 1,
         custom_id: str | None = None,
         disabled: bool = False,
-    ):
+    ) -> None:
         super().__init__(
             placeholder=placeholder,
             min_values=min_values,
@@ -503,7 +507,7 @@ class MentionableSelectMenu(BaseSelectMenu):
         max_values: int = 1,
         custom_id: str | None = None,
         disabled: bool = False,
-    ):
+    ) -> None:
         super().__init__(
             placeholder=placeholder,
             min_values=min_values,
@@ -525,7 +529,7 @@ class ChannelSelectMenu(BaseSelectMenu):
         max_values: int = 1,
         custom_id: str | None = None,
         disabled: bool = False,
-    ):
+    ) -> None:
         super().__init__(
             placeholder=placeholder,
             min_values=min_values,
@@ -538,9 +542,7 @@ class ChannelSelectMenu(BaseSelectMenu):
         self.type: ComponentTypes = ComponentTypes.CHANNEL_SELECT
 
     @classmethod
-    def from_dict(
-        cls, data: discord_typings.SelectMenuComponentData
-    ) -> "ChannelSelectMenu":
+    def from_dict(cls, data: discord_typings.SelectMenuComponentData) -> "ChannelSelectMenu":
         return cls(
             placeholder=data.get("placeholder"),
             min_values=data["min_values"],
@@ -666,9 +668,7 @@ def spread_to_rows(
     return rows
 
 
-def get_components_ids(
-    component: Union[str, dict, list, InteractiveComponent]
-) -> Iterator[str]:
+def get_components_ids(component: Union[str, dict, list, InteractiveComponent]) -> Iterator[str]:
     """
     Creates a generator with the `custom_id` of a component or list of components.
 
@@ -687,9 +687,7 @@ def get_components_ids(
     elif isinstance(component, dict):
         if component["type"] == ComponentTypes.actionrow:
             yield from (
-                comp["custom_id"]
-                for comp in component["components"]
-                if "custom_id" in comp
+                comp["custom_id"] for comp in component["components"] if "custom_id" in comp
             )
         elif "custom_id" in component:
             yield component["custom_id"]
@@ -697,15 +695,11 @@ def get_components_ids(
         yield c_id
     elif isinstance(component, ActionRow):
         yield from (
-            comp_id
-            for comp in component.components
-            for comp_id in get_components_ids(comp)
+            comp_id for comp in component.components for comp_id in get_components_ids(comp)
         )
 
     elif isinstance(component, list):
-        yield from (
-            comp_id for comp in component for comp_id in get_components_ids(comp)
-        )
+        yield from (comp_id for comp in component for comp_id in get_components_ids(comp))
     else:
         raise ValueError(
             f"Unknown component type of {component} ({type(component)}). "

--- a/interactions/models/internal/context.py
+++ b/interactions/models/internal/context.py
@@ -14,7 +14,12 @@ from interactions.client.mixins.modal import ModalMixin
 
 from interactions.client.errors import HTTPException
 from interactions.client.mixins.send import SendMixin
-from interactions.models.discord.enums import Permissions, MessageFlags, InteractionTypes, ComponentTypes
+from interactions.models.discord.enums import (
+    Permissions,
+    MessageFlags,
+    InteractionTypes,
+    ComponentTypes,
+)
 from interactions.models.discord.message import (
     AllowedMentions,
     Attachment,
@@ -63,15 +68,13 @@ class Resolved:
         attachments: A dictionary of attachments resolved from the interaction.
     """
 
-
-
-    def __init__(self):
+    def __init__(self) -> None:
         self.channels: dict[Snowflake, "interactions.TYPE_MESSAGEABLE_CHANNEL"] = {}
         self.members: dict[Snowflake, "interactions.Member"] = {}
         self.users: dict[Snowflake, "interactions.User"] = {}
-        self.roles: dict[Snowflake, "interactions.Role"]={}
-        self.messages: dict[Snowflake, "interactions.Message"]={}
-        self.attachments: dict[Snowflake, "interactions.Attachment"]={}
+        self.roles: dict[Snowflake, "interactions.Role"] = {}
+        self.messages: dict[Snowflake, "interactions.Message"] = {}
+        self.attachments: dict[Snowflake, "interactions.Attachment"] = {}
 
     def __bool__(self) -> bool:
         """Returns whether any resolved data is present."""
@@ -84,7 +87,7 @@ class Resolved:
             or bool(self.attachments)
         )
 
-    def get(self, snowflake: Snowflake, default: typing.Any =None) -> typing.Any:
+    def get(self, snowflake: Snowflake, default: typing.Any = None) -> typing.Any:
         """Returns the value of the given snowflake."""
         if channel := self.channels.get(snowflake):
             return channel
@@ -264,7 +267,7 @@ class BaseInteractionContext(BaseContext):
         instance.guild_locale = payload["guild_locale"]
         instance._context_type = payload.get("type", 0)
         instance.resolved = Resolved.from_dict(
-            client, payload['data'].get("resolved", {}), payload.get("guild_id")
+            client, payload["data"].get("resolved", {}), payload.get("guild_id")
         )
 
         instance.channel_id = Snowflake(payload["channel_id"])
@@ -278,7 +281,7 @@ class BaseInteractionContext(BaseContext):
 
         instance.guild_id = Snowflake(payload.get("guild_id"))
 
-        if payload['type'] == InteractionTypes.APPLICATION_COMMAND:
+        if payload["type"] == InteractionTypes.APPLICATION_COMMAND:
             instance.command_id = Snowflake(payload["data"]["id"])
             instance._command_name = payload["data"]["name"]
 
@@ -587,7 +590,12 @@ class ComponentContext(InteractionContext):
         instance.custom_id = payload["data"]["custom_id"]
         instance.component_type = payload["data"]["component_type"]
 
-        if instance.component_type in (ComponentTypes.USER_SELECT, ComponentTypes.CHANNEL_SELECT, ComponentTypes.ROLE_SELECT, ComponentTypes.MENTIONABLE_SELECT):
+        if instance.component_type in (
+            ComponentTypes.USER_SELECT,
+            ComponentTypes.CHANNEL_SELECT,
+            ComponentTypes.ROLE_SELECT,
+            ComponentTypes.MENTIONABLE_SELECT,
+        ):
             for i, value in enumerate(instance.values):
                 if re.match(r"\d{17,}", value):
                     key = Snowflake(value)
@@ -596,19 +604,29 @@ class ComponentContext(InteractionContext):
                         instance.values[i] = resolved
                     else:
                         searches = {
-                            "users": instance.component_type in (ComponentTypes.USER_SELECT, ComponentTypes.MENTIONABLE_SELECT),
-                            "members": instance.guild_id and instance.component_type in (ComponentTypes.USER_SELECT, ComponentTypes.MENTIONABLE_SELECT),
-                            "channels": instance.component_type in (ComponentTypes.CHANNEL_SELECT, ComponentTypes.MENTIONABLE_SELECT),
-                            "roles": instance.guild_id and instance.component_type in (ComponentTypes.ROLE_SELECT, ComponentTypes.MENTIONABLE_SELECT),
+                            "users": instance.component_type
+                            in (ComponentTypes.USER_SELECT, ComponentTypes.MENTIONABLE_SELECT),
+                            "members": instance.guild_id
+                            and instance.component_type
+                            in (ComponentTypes.USER_SELECT, ComponentTypes.MENTIONABLE_SELECT),
+                            "channels": instance.component_type
+                            in (ComponentTypes.CHANNEL_SELECT, ComponentTypes.MENTIONABLE_SELECT),
+                            "roles": instance.guild_id
+                            and instance.component_type
+                            in (ComponentTypes.ROLE_SELECT, ComponentTypes.MENTIONABLE_SELECT),
                         }
 
-                        if searches["members"] and (member := instance.client.cache.get_member(instance.guild_id, key)):
+                        if searches["members"] and (
+                            member := instance.client.cache.get_member(instance.guild_id, key)
+                        ):
                             instance.values[i] = member
                         elif searches["users"] and (user := instance.client.cache.get_user(key)):
                             instance.values[i] = user
                         elif searches["roles"] and (role := instance.client.cache.get_role(key)):
                             instance.values[i] = role
-                        elif searches["channels"] and (channel := instance.client.cache.get_channel(key)):
+                        elif searches["channels"] and (
+                            channel := instance.client.cache.get_channel(key)
+                        ):
                             instance.values[i] = channel
         return instance
 

--- a/main.py
+++ b/main.py
@@ -51,8 +51,9 @@ async def components(ctx):
     await ctx.send("Select menus", components=selects)
     await ctx.send(
         "Buttons",
-        components=[interactions.Button(label="test", style=interactions.ButtonStyles.PRIMARY)]
+        components=[interactions.Button(label="test", style=interactions.ButtonStyles.PRIMARY)],
     )
+
 
 @listen()
 async def on_component(event: interactions.events.Component):
@@ -62,5 +63,6 @@ async def on_component(event: interactions.events.Component):
         await ctx.send(f"Selected {ctx.values}")
     else:
         await ctx.send(f"Clicked {ctx.custom_id}")
+
 
 bot.start(os.environ["TOKEN"])


### PR DESCRIPTION
## About

This pull request specifies to use Python 3.10 for some parts of the pre-commit, allowing pre-commit to work on files that have match statements or the like. This also brought up some errors, which I took a bit of time to fix.

## Checklist

- [x] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.
- [ ] I have added the `versionadded`, `versionchanged` and `deprecated` to any new or changed user-facing function I committed.
<!-- If you are unsure what the next version is, feel free to ask in #unstable at https://discord.gg/interactions -->

### Pull-Request specification

I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [ ] To add a new feature
  - [ ] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [x] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

<!--- Expand this when more comes up--->
