### PR TITLE
feat!: make ctx.author return member or user

### DIFF
--- a/interactions/models/internal/context.py
+++ b/interactions/models/internal/context.py
@@ -169,19 +169,19 @@ class BaseContext(metaclass=abc.ABCMeta):
         return self.client.cache.get_guild(self.guild_id)
 
     @property
-    def author(self) -> "interactions.User":
-        """The user that invoked this context."""
-        return self.client.cache.get_user(self.author_id)
-
-    @property
     def user(self) -> "interactions.User":
-        """The user that invoked this context. (Alias for author)"""
+        """The user that invoked this context."""
         return self.client.cache.get_user(self.author_id)
 
     @property
     def member(self) -> typing.Optional["interactions.Member"]:
         """The member object that invoked this context."""
         return self.client.cache.get_member(self.guild_id, self.author_id)
+
+    @property
+    def author(self) -> "interactions.Member | interactions.User":
+        """The member or user that invoked this context."""
+        return self.member or self.user
 
     @property
     def channel(self) -> "interactions.TYPE_MESSAGEABLE_CHANNEL":


### PR DESCRIPTION
## About

This pull request makes it so `ctx.author` can return `Member | User` instead of exclusively `User`. Technically breaking, but I don't feel like this warrants the explosion emoji so early in development.

## Checklist

- [x] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.
- [x] I have added the `versionadded`, `versionchanged` and `deprecated` to any new or changed user-facing function I committed.
<!-- If you are unsure what the next version is, feel free to ask in #unstable at https://discord.gg/interactions -->

### Pull-Request specification

I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [ ] To add a new feature
  - [x] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [ ] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [x] A breaking change

<!--- Expand this when more comes up--->
