### PR TITLE
fix: adjust wait_for_component typehints

### DIFF
--- a/interactions/client/client.py
+++ b/interactions/client/client.py
@@ -1048,7 +1048,7 @@ class Client(
         ] = None,
         check: Optional[Callable] = None,
         timeout: Optional[float] = None,
-    ) -> "BaseComponent":
+    ) -> "events.Component":
         """
         Waits for a component to be sent to the bot.
 
@@ -1081,7 +1081,7 @@ class Client(
         if custom_ids and not all(isinstance(x, str) for x in custom_ids):
             custom_ids = [str(i) for i in custom_ids]
 
-        def _check(event: BaseComponent) -> bool:
+        def _check(event: events.Component) -> bool:
             ctx: ComponentContext = event.ctx
             # if custom_ids is empty or there is a match
             wanted_message = not message_ids or ctx.message.id in (


### PR DESCRIPTION
## About

This pull request fixes `wait_for_component` so that it notes that it returns the event, not the `BaseComponent` class itself.

I also adjusted an internal typehint to note that.

## Checklist

- [x] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.
- [ ] I have added the `versionadded`, `versionchanged` and `deprecated` to any new or changed user-facing function I committed.
<!-- If you are unsure what the next version is, feel free to ask in #unstable at https://discord.gg/interactions -->

### Pull-Request specification

I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [ ] To add a new feature
  - [ ] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [x] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

<!--- Expand this when more comes up--->
