### PR TITLE
fix: check `Client._http` is not a string before logout

### DIFF
--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -486,7 +486,8 @@ class Client:
         self._websocket._closing_lock.set()  # Toggles the "ready-to-shutdown" state for the bot.
         # And subsequently, the processes will close itself.
 
-        await self._http._req._session.close()  # Closes the HTTP session associated with the client.
+        if isinstance(self._http, HTTPClient):
+            await self._http._req._session.close()  # Closes the HTTP session associated with the client.
 
     async def _login(self) -> None:
         """Makes a login with the Discord API."""
@@ -1620,7 +1621,8 @@ class Client:
 
     async def _logout(self) -> None:
         await self._websocket.close()
-        await self._http._req.close()
+        if isinstance(self._http, HTTPClient):
+            await self._http._req.close()
 
     async def wait_for(
         self,


### PR DESCRIPTION
## About

There is case when exception was raised before http client was set.

```py
Traceback (most recent call last):
  File "/config/.local/lib/python3.10/site-packages/interactions/client/bot.py", line 202, in start
    self._loop.run_until_complete(self._logout())
  File "/usr/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
    return future.result()
  File "/config/.local/lib/python3.10/site-packages/interactions/client/bot.py", line 1623, in _logout
    await self._http._req.close()
AttributeError: 'str' object has no attribute '_req'
```

## Checklist

- [ ] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [ ] I've ensured the change(s) work on `3.8.6` and higher.
- [ ] I have added the `versionadded`, `versionchanged` and `deprecated` to any new or changed user-facing function I committed.
<!-- If you are unsure what the next version is, feel free to ask in #unstable at https://discord.gg/interactions -->

### Pull-Request specification

I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [ ] To add a new feature
  - [ ] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [x] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

<!--- Expand this when more comes up--->
