### PR TITLE
fix: allow paginators to actually work

### DIFF
--- a/interactions/ext/paginators.py
+++ b/interactions/ext/paginators.py
@@ -23,12 +23,11 @@ from interactions import (
     BrandColors,
 )
 from interactions.client.utils.serializer import export_converter
-from interactions.models.discord.emoji import process_emoji
+from interactions.models.discord.emoji import process_emoji, PartialEmoji
 
 if TYPE_CHECKING:
     from interactions import Client
     from interactions.ext.prefixed_commands.context import PrefixedContext
-    from interactions.models.discord.emoji import PartialEmoji
 
 __all__ = ("Paginator",)
 
@@ -271,10 +270,12 @@ class Paginator:
             current = self.pages[self.page_index]
             output.append(
                 StringSelectMenu(
-                    [
-                        StringSelectOption(f"{i+1} {p.get_summary if isinstance(p, Page) else p.title}", str(i))
+                    *(
+                        StringSelectOption(
+                            label=f"{i+1} {p.get_summary if isinstance(p, Page) else p.title}", value=str(i)
+                        )
                         for i, p in enumerate(self.pages)
-                    ],
+                    ),
                     custom_id=f"{self._uuid}|select",
                     placeholder=f"{self.page_index+1} {current.get_summary if isinstance(current, Page) else current.title}",
                     max_values=1,
@@ -285,8 +286,8 @@ class Paginator:
         if self.show_first_button:
             output.append(
                 Button(
-                    self.default_button_color,
-                    emoji=self.first_button_emoji,
+                    style=self.default_button_color,
+                    emoji=PartialEmoji.from_dict(process_emoji(self.first_button_emoji)),
                     custom_id=f"{self._uuid}|first",
                     disabled=disable or self.page_index == 0,
                 )
@@ -294,8 +295,8 @@ class Paginator:
         if self.show_back_button:
             output.append(
                 Button(
-                    self.default_button_color,
-                    emoji=self.back_button_emoji,
+                    style=self.default_button_color,
+                    emoji=PartialEmoji.from_dict(process_emoji(self.back_button_emoji)),
                     custom_id=f"{self._uuid}|back",
                     disabled=disable or self.page_index == 0,
                 )
@@ -304,8 +305,8 @@ class Paginator:
         if self.show_callback_button:
             output.append(
                 Button(
-                    self.default_button_color,
-                    emoji=self.callback_button_emoji,
+                    style=self.default_button_color,
+                    emoji=PartialEmoji.from_dict(process_emoji(self.callback_button_emoji)),
                     custom_id=f"{self._uuid}|callback",
                     disabled=disable,
                 )
@@ -314,8 +315,8 @@ class Paginator:
         if self.show_next_button:
             output.append(
                 Button(
-                    self.default_button_color,
-                    emoji=self.next_button_emoji,
+                    style=self.default_button_color,
+                    emoji=PartialEmoji.from_dict(process_emoji(self.next_button_emoji)),
                     custom_id=f"{self._uuid}|next",
                     disabled=disable or self.page_index >= len(self.pages) - 1,
                 )
@@ -323,8 +324,8 @@ class Paginator:
         if self.show_last_button:
             output.append(
                 Button(
-                    self.default_button_color,
-                    emoji=self.last_button_emoji,
+                    style=self.default_button_color,
+                    emoji=PartialEmoji.from_dict(process_emoji(self.last_button_emoji)),
                     custom_id=f"{self._uuid}|last",
                     disabled=disable or self.page_index >= len(self.pages) - 1,
                 )

--- a/interactions/ext/prefixed_commands/__init__.py
+++ b/interactions/ext/prefixed_commands/__init__.py
@@ -1,6 +1,6 @@
 from .command import *
 from .context import *
 
-# from .help import *
+from .help import *
 from .manager import *
 from .utils import *


### PR DESCRIPTION
## About

This pull request fixes paginators by conforming them to the new methods of making components. This also uncomments the help file for prefixed commands, seeing as it should work now.

(Note: this will throw an error - currently, the `SendMixin` is a bit broken in that it expects `_client`, while some `Context`s use `client`. Of course, one should be standardized, but I'm not sure what, so I'm not going to PR a fix for that.)

## Checklist

- [x] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.
- [ ] I have added the `versionadded`, `versionchanged` and `deprecated` to any new or changed user-facing function I committed.
<!-- If you are unsure what the next version is, feel free to ask in #unstable at https://discord.gg/interactions -->

### Pull-Request specification

I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [ ] To add a new feature
  - [ ] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [x] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

<!--- Expand this when more comes up--->
