### PR TITLE
fix: `client`, `command` and `extension` are missed in `on_command`

### DIFF
--- a/interactions/api/gateway/client.py
+++ b/interactions/api/gateway/client.py
@@ -404,7 +404,6 @@ class WebSocketClient:
                     _option = self.__sub_command_context(option, _context)
                     __kwargs.update(_option)
 
-            self._dispatch.dispatch("on_command", _context)
         elif data["type"] == InteractionType.MESSAGE_COMPONENT:
             _name = f"component_{_context.data.custom_id}"
 

--- a/interactions/client/models/command.py
+++ b/interactions/client/models/command.py
@@ -897,6 +897,8 @@ class Command(DictSerializerMixin):
             ctx.command = self
             ctx.extension = self.extension
 
+            self.listener.dispatch("on_command", ctx)
+
             try:
                 if self.extension:
                     return await coro(self.extension, ctx, *args, **kwargs)


### PR DESCRIPTION
## About

This pull request moves `on_command` event dispatching to other place where command's func is called. Resolves #1133 

## Checklist

- [ ] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.
- [ ] I have added the `versionadded`, `versionchanged` and `deprecated` to any new or changed user-facing function I committed.
<!-- If you are unsure what the next version is, feel free to ask in #unstable at https://discord.gg/interactions -->

### Pull-Request specification

I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [ ] To add a new feature
  - [ ] As a general enhancement
  - [x] As a refactor of the library/the library's code
  - [x] To fix an existing bug
  - [x] To resolve #1133 


This is:
  - [ ] A breaking change

<!--- Expand this when more comes up--->
