### PR TITLE
docs: add missed docs for role connection metadata

### DIFF
--- a/interactions/api/models/team.py
+++ b/interactions/api/models/team.py
@@ -163,6 +163,13 @@ class ApplicationRoleConnectionMetadata(DictSerializerMixin):
     .. versionadded:: 4.4.0
 
     A class object representing role connection metadata for the application/bot/client.
+
+    :ivar ApplicationRoleConnectionMetadataType type: The type of metadata value.
+    :ivar str key: The dictionary key for the metadata field.
+    :ivar str name: The name of the metadata field.
+    :ivar Optional[Dict[Union[str, Locale], str]] name_localizations: The translations of the name field.
+    :ivar str description: The description of the metadata field.
+    :ivar Optional[Dict[Union[str, Locale], str]] description_localizations: The translations of the description field.
     """
 
     type: ApplicationRoleConnectionMetadataType = field(


### PR DESCRIPTION
## About

This pr adds missed docs for `ApplicationRoleConnectionMetadata`. I'm bad reviewer ik

## Checklist

- [ ] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [ ] I've ensured the change(s) work on `3.8.6` and higher.
- [ ] I have added the `versionadded`, `versionchanged` and `deprecated` to any new or changed user-facing function I committed.
<!-- If you are unsure what the next version is, feel free to ask in #unstable at https://discord.gg/interactions -->

### Pull-Request specification

I've made this pull request: (check all that apply)
  - [x] For the documentation
  - [ ] To add a new feature
  - [ ] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [ ] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

<!--- Expand this when more comes up--->
