### PR TITLE
refactor(context): allow edit message from modal interaction

### DIFF
--- a/interactions/client/context.py
+++ b/interactions/client/context.py
@@ -1,8 +1,8 @@
 import asyncio
+from contextlib import suppress
 from datetime import datetime
 from logging import Logger
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
-from contextlib import suppress
 
 from ..api.error import LibraryException
 from ..api.models.channel import Channel, Thread
@@ -176,8 +176,13 @@ class _Context(ClientSerializerMixin):
         :return: The deferred message
         :rtype: Message
         """
-        if edit_origin and self.type in {InteractionType.APPLICATION_COMMAND, InteractionType.APPLICATION_COMMAND_AUTOCOMPLETE}:
-            raise LibraryException(message="You cannot defer with edit_origin parameter in this type of interaction")
+        if edit_origin and self.type in {
+            InteractionType.APPLICATION_COMMAND,
+            InteractionType.APPLICATION_COMMAND_AUTOCOMPLETE,
+        }:
+            raise LibraryException(
+                message="You cannot defer with edit_origin parameter in this type of interaction"
+            )
 
         if not self.responded:
             self.deferred = True
@@ -645,7 +650,6 @@ class CommandContext(_Context):
             _client=self._client,
             author={"_client": self._client, "id": None, "username": None, "discriminator": None},
         )
-
 
     async def populate(self, choices: Union[Choice, List[Choice]]) -> List[Choice]:
         """

--- a/interactions/client/context.py
+++ b/interactions/client/context.py
@@ -168,7 +168,7 @@ class _Context(ClientSerializerMixin):
         .. versionchanged:: 4.4.0
             Now returns the created message object
 
-        This "defers" a component response, allowing up
+        This "defers" an interaction response, allowing up
         to a 15-minute delay between invocation and responding.
 
         :param Optional[bool] ephemeral: Whether the deferred state is hidden or not.

--- a/interactions/client/context.py
+++ b/interactions/client/context.py
@@ -2,6 +2,7 @@ import asyncio
 from datetime import datetime
 from logging import Logger
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
+from contextlib import suppress
 
 from ..api.error import LibraryException
 from ..api.models.channel import Channel, Thread
@@ -160,6 +161,50 @@ class _Context(ClientSerializerMixin):
         res = await self._client.get_guild(int(self.guild_id))
         return Guild(**res, _client=self._client)
 
+    async def defer(
+        self, ephemeral: Optional[bool] = False, edit_origin: Optional[bool] = False
+    ) -> Message:
+        """
+        .. versionchanged:: 4.4.0
+            Now returns the created message object
+
+        This "defers" a component response, allowing up
+        to a 15-minute delay between invocation and responding.
+
+        :param Optional[bool] ephemeral: Whether the deferred state is hidden or not.
+        :param Optional[bool] edit_origin: Whether you want to edit the original message or send a followup message
+        :return: The deferred message
+        :rtype: Message
+        """
+        if edit_origin and self.type in {InteractionType.APPLICATION_COMMAND, InteractionType.APPLICATION_COMMAND_AUTOCOMPLETE}:
+            raise LibraryException(message="You cannot defer with edit_origin parameter in this type of interaction")
+
+        if not self.responded:
+            self.deferred = True
+            is_ephemeral: int = MessageFlags.EPHEMERAL.value if bool(ephemeral) else 0
+            # ephemeral doesn't change callback typings. just data json
+            self.callback = (
+                InteractionCallbackType.DEFERRED_UPDATE_MESSAGE
+                if edit_origin
+                else InteractionCallbackType.DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE
+            )
+
+            await self._client.create_interaction_response(
+                token=self.token,
+                application_id=int(self.id),
+                data={"type": self.callback.value, "data": {"flags": is_ephemeral}},
+            )
+
+            with suppress(LibraryException):
+                res = await self._client.get_original_interaction_response(
+                    self.token, str(self.application_id)
+                )
+                self.message = Message(**res, _client=self._client)
+
+            self.responded = True
+
+            return self.message
+
     async def send(
         self,
         content: Optional[str] = MISSING,
@@ -300,6 +345,9 @@ class _Context(ClientSerializerMixin):
         :param Optional[Union[ActionRow, Button, SelectMenu, List[Union[ActionRow, Button, SelectMenu]]]] components: A component, or list of components for the message.
         :return: The edited message.
         """
+
+        if self.message is None:
+            raise LibraryException(message="There is no message to edit.")
 
         payload = {}
 
@@ -541,55 +589,23 @@ class CommandContext(_Context):
                 else:
                     self.message = msg = Message(**res, _client=self._client)
         else:
-            try:
-                res = await self._client.edit_interaction_response(
-                    token=self.token,
-                    application_id=str(self.application_id),
-                    data=payload,
-                    files=files,
-                )
-            except LibraryException as e:
-                if e.code in {10015, 10018}:
-                    log.warning(f"You can't edit hidden messages." f"({e.message}).")
-                else:
-                    # if its not ephemeral or some other thing.
-                    raise e from e
-            else:
-                self.message = msg = Message(**res, _client=self._client)
-
-        return msg if msg is not None else Message(**payload, _client=self._client)
-
-    async def defer(self, ephemeral: Optional[bool] = False) -> Message:
-        """
-        .. versionchanged:: 4.4.0
-            Now returns the created message object
-
-        This "defers" an interaction response, allowing up
-        to a 15-minute delay between invocation and responding.
-
-        :param Optional[bool] ephemeral: Whether the deferred state is hidden or not.
-        :return: The deferred message
-        :rtype: Message
-        """
-        if not self.responded:
-            self.deferred = True
-            _ephemeral: int = MessageFlags.EPHEMERAL.value if ephemeral else 0
-            self.callback = InteractionCallbackType.DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE
+            self.callback = InteractionCallbackType.UPDATE_MESSAGE
             await self._client.create_interaction_response(
+                data={"type": self.callback.value, "data": payload},
+                files=files,
                 token=self.token,
                 application_id=int(self.id),
-                data={"type": self.callback.value, "data": {"flags": _ephemeral}},
             )
-            try:
-                _msg = await self._client.get_original_interaction_response(
+
+            with suppress(LibraryException):
+                res = await self._client.get_original_interaction_response(
                     self.token, str(self.application_id)
                 )
-            except LibraryException:
-                pass
-            else:
-                self.message = Message(**_msg, _client=self._client)
+                self.message = msg = Message(**res, _client=self._client)
+
             self.responded = True
-            return self.message
+
+        return msg or Message(**payload, _client=self._client)
 
     async def send(self, content: Optional[str] = MISSING, **kwargs) -> Message:
         payload, files = await super().send(content, **kwargs)
@@ -616,24 +632,20 @@ class CommandContext(_Context):
                 files=files,
             )
 
-            try:
-                _msg = await self._client.get_original_interaction_response(
+            with suppress(LibraryException):
+                res = await self._client.get_original_interaction_response(
                     self.token, str(self.application_id)
                 )
-            except LibraryException:
-                pass
-            else:
-                self.message = msg = Message(**_msg, _client=self._client)
+                self.message = msg = Message(**res, _client=self._client)
 
             self.responded = True
 
-        if msg is not None:
-            return msg
-        return Message(
+        return msg or Message(
             **payload,
             _client=self._client,
             author={"_client": self._client, "id": None, "username": None, "discriminator": None},
         )
+
 
     async def populate(self, choices: Union[Choice, List[Choice]]) -> List[Choice]:
         """
@@ -712,14 +724,12 @@ class ComponentContext(_Context):
                 application_id=int(self.id),
             )
 
-            try:
-                _msg = await self._client.get_original_interaction_response(
+            with suppress(LibraryException):
+                res = await self._client.get_original_interaction_response(
                     self.token, str(self.application_id)
                 )
-            except LibraryException:
-                pass
-            else:
-                self.message = msg = Message(**_msg, _client=self._client)
+
+                self.message = msg = Message(**res, _client=self._client)
 
             self.responded = True
         elif self.callback != InteractionCallbackType.DEFERRED_UPDATE_MESSAGE:
@@ -739,7 +749,7 @@ class ComponentContext(_Context):
             self.responded = True
             self.message = msg = Message(**res, _client=self._client)
 
-        return msg if msg is not None else Message(**payload, _client=self._client)
+        return msg or Message(**payload, _client=self._client)
 
     async def send(self, content: Optional[str] = MISSING, **kwargs) -> Message:
         payload, files = await super().send(content, **kwargs)
@@ -766,59 +776,15 @@ class ComponentContext(_Context):
                 files=files,
             )
 
-            try:
-                _msg = await self._client.get_original_interaction_response(
+            with suppress(LibraryException):
+                res = await self._client.get_original_interaction_response(
                     self.token, str(self.application_id)
                 )
-            except LibraryException:
-                pass
-            else:
-                self.message = msg = Message(**_msg, _client=self._client)
+                self.message = msg = Message(**res, _client=self._client)
 
             self.responded = True
 
         return msg if msg is not None else Message(**payload, _client=self._client)
-
-    async def defer(
-        self, ephemeral: Optional[bool] = False, edit_origin: Optional[bool] = False
-    ) -> Message:
-        """
-        .. versionchanged:: 4.4.0
-            Now returns the created message object
-
-        This "defers" a component response, allowing up
-        to a 15-minute delay between invocation and responding.
-
-        :param Optional[bool] ephemeral: Whether the deferred state is hidden or not.
-        :param Optional[bool] edit_origin: Whether you want to edit the original message or send a followup message
-        :return: The deferred message
-        :rtype: Message
-        """
-        if not self.responded:
-
-            self.deferred = True
-            _ephemeral: int = MessageFlags.EPHEMERAL.value if bool(ephemeral) else 0
-            # ephemeral doesn't change callback typings. just data json
-            if edit_origin:
-                self.callback = InteractionCallbackType.DEFERRED_UPDATE_MESSAGE
-            else:
-                self.callback = InteractionCallbackType.DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE
-
-            await self._client.create_interaction_response(
-                token=self.token,
-                application_id=int(self.id),
-                data={"type": self.callback.value, "data": {"flags": _ephemeral}},
-            )
-            try:
-                _msg = await self._client.get_original_interaction_response(
-                    self.token, str(self.application_id)
-                )
-            except LibraryException:
-                pass
-            else:
-                self.message = Message(**_msg, _client=self._client)
-            self.responded = True
-            return self.message
 
     async def disable_all_components(
         self, respond_to_interaction: Optional[bool] = True, **other_kwargs: Optional[dict]


### PR DESCRIPTION
## About

There is known bug (or we just don't support this feature) when you can't edit message from the modal interaction.
This pr fixes this bug by:
- Moving `ComponentContext.defer` to `_Context.defer` and removing `CommandContext.defer`. They are same but `ComponentContext` have `edit_origin` param. So now we can defer with `edit_origin` for modal.
- Refactored `CommandContext.edit` to make work with modals. Code partially copied from `ComponentContext.edit`.

Additionally:
- raises exceptions in some places.
- Use `with suppress(LibraryException)` instead of this cursed code:
```py
try:
    ...
except LibraryException:
    pass
else:
    ...
```
- Optimized conditions in return statements:
```py
# instead of
return msg if msg is not None else Message(...)
# use
return msg or Message(...)
```

## Checklist

- [x] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.
- [ ] I have added the `versionadded`, `versionchanged` and `deprecated` to any new or changed user-facing function I committed.
<!-- If you are unsure what the next version is, feel free to ask in #unstable at https://discord.gg/interactions -->

### Pull-Request specification

I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [ ] To add a new feature
  - [x] As a general enhancement
  - [x] As a refactor of the library/the library's code
  - [x] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

<!--- Expand this when more comes up--->
