### PR TITLE
fix: typehint Client.ext

### DIFF
--- a/interactions/client/client.py
+++ b/interactions/client/client.py
@@ -380,7 +380,7 @@ class Client(
         self._modal_callbacks: Dict[str, Callable[..., Coroutine]] = {}
         self.processors: Dict[str, Callable[..., Coroutine]] = {}
         self.__modules = {}
-        self.ext = {}
+        self.ext: Dict[str, Extension] = {}
         """A dictionary of mounted ext"""
         self.listeners: Dict[str, list[Listener]] = {}
         self.waits: Dict[str, List] = {}
@@ -1273,7 +1273,7 @@ class Client(
             self.add_listener(func)
         elif not isinstance(func, BaseCommand):
             raise TypeError("Invalid command type")
-        
+
         if not func.callback:
             # for group = SlashCommand(...) usage
             return


### PR DESCRIPTION
## About

Just a quick PR to typehint `Client.ext`. Also, pre-commit did a thing.

## Checklist

- [x] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.
- [ ] I have added the `versionadded`, `versionchanged` and `deprecated` to any new or changed user-facing function I committed.
<!-- If you are unsure what the next version is, feel free to ask in #unstable at https://discord.gg/interactions -->

### Pull-Request specification

I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [ ] To add a new feature
  - [x] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [x] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

<!--- Expand this when more comes up--->
