### PR TITLE
feat: re-add warning for prefix + no message content

### DIFF
--- a/interactions/ext/prefixed_commands/manager.py
+++ b/interactions/ext/prefixed_commands/manager.py
@@ -75,7 +75,7 @@ class PrefixedManager:
         ) and Intents.MESSAGE_CONTENT not in client.intents:
             client.logger.warning(
                 "Prefixed commands will not work since the required intent is not set -> Requires:"
-                f" {Intents.GUILD_MESSAGE_CONTENT.__repr__()} or usage of the default mention prefix as the prefix"
+                f" {Intents.MESSAGE_CONTENT.__repr__()} or usage of the default mention prefix as the prefix"
             )
 
         if default_prefix is None and generate_prefixes is None:

--- a/interactions/ext/prefixed_commands/manager.py
+++ b/interactions/ext/prefixed_commands/manager.py
@@ -14,6 +14,7 @@ from interactions.api.events.internal import (
 )
 from interactions.client.client import Client
 from interactions.client.utils.input_utils import get_args, get_first_word
+from interactions.models.discord.enums import Intents
 from interactions.models.discord.message import Message
 from interactions.models.internal.listener import listen
 from .command import PrefixedCommand
@@ -68,6 +69,12 @@ class PrefixedManager:
         self.prefixed_context = prefixed_context
         self.commands: dict[str, PrefixedCommand] = {}
         self._ext_command_list: defaultdict[str, set[str]] = defaultdict(set)
+
+        if (default_prefix or generate_prefixes) and Intents.GUILD_MESSAGE_CONTENT not in client.intents:
+            client.logger.warning(
+                "Prefixed commands will not work since the required intent is not set -> Requires:"
+                f" {Intents.GUILD_MESSAGE_CONTENT.__repr__()} or usage of the default mention prefix as the prefix"
+            )
 
         if default_prefix is None and generate_prefixes is None:
             # by default, use mentioning the bot as the prefix

--- a/interactions/ext/prefixed_commands/manager.py
+++ b/interactions/ext/prefixed_commands/manager.py
@@ -71,7 +71,7 @@ class PrefixedManager:
         self._ext_command_list: defaultdict[str, set[str]] = defaultdict(set)
 
         if (
-            default_prefix or (generate_prefixes != when_mentioned)
+            default_prefix or (generate_prefixes and generate_prefixes != when_mentioned)
         ) and Intents.GUILD_MESSAGE_CONTENT not in client.intents:
             client.logger.warning(
                 "Prefixed commands will not work since the required intent is not set -> Requires:"

--- a/interactions/ext/prefixed_commands/manager.py
+++ b/interactions/ext/prefixed_commands/manager.py
@@ -70,7 +70,9 @@ class PrefixedManager:
         self.commands: dict[str, PrefixedCommand] = {}
         self._ext_command_list: defaultdict[str, set[str]] = defaultdict(set)
 
-        if (default_prefix or generate_prefixes) and Intents.GUILD_MESSAGE_CONTENT not in client.intents:
+        if (
+            default_prefix or (generate_prefixes != when_mentioned)
+        ) and Intents.GUILD_MESSAGE_CONTENT not in client.intents:
             client.logger.warning(
                 "Prefixed commands will not work since the required intent is not set -> Requires:"
                 f" {Intents.GUILD_MESSAGE_CONTENT.__repr__()} or usage of the default mention prefix as the prefix"

--- a/interactions/ext/prefixed_commands/manager.py
+++ b/interactions/ext/prefixed_commands/manager.py
@@ -72,7 +72,7 @@ class PrefixedManager:
 
         if (
             default_prefix or (generate_prefixes and generate_prefixes != when_mentioned)
-        ) and Intents.GUILD_MESSAGE_CONTENT not in client.intents:
+        ) and Intents.MESSAGE_CONTENT not in client.intents:
             client.logger.warning(
                 "Prefixed commands will not work since the required intent is not set -> Requires:"
                 f" {Intents.GUILD_MESSAGE_CONTENT.__repr__()} or usage of the default mention prefix as the prefix"


### PR DESCRIPTION
## About

This pull request re-adds the warning that appears if you set a prefix while not having the `GUILD_MESSAGE_CONTENT` intent enabled. Nothing more to really say.

## Checklist

- [x] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.
- [ ] I have added the `versionadded`, `versionchanged` and `deprecated` to any new or changed user-facing function I committed.
<!-- If you are unsure what the next version is, feel free to ask in #unstable at https://discord.gg/interactions -->

### Pull-Request specification

I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [ ] To add a new feature
  - [x] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [ ] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

<!--- Expand this when more comes up--->
