### PR TITLE
ci: Fix check-yaml pre-commit action

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,7 @@ repos:
     - id: check-yaml
       name: YAML Structure
       language: python
+      args: ['--unsafe']
     - id: check-toml
       name: TOML Structure
     - id: check-merge-conflict


### PR DESCRIPTION
## About

Switches check-yaml to syntax-only mode, which should stop it from complaining about mkdocs specific yaml tags.

## Checklist

- [x] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.
- [ ] I have added the `versionadded`, `versionchanged` and `deprecated` to any new or changed user-facing function I committed.
<!-- If you are unsure what the next version is, feel free to ask in #unstable at https://discord.gg/interactions -->

### Pull-Request specification

I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [ ] To add a new feature
  - [ ] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [x] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

<!--- Expand this when more comes up--->
