### PR TITLE
fix: null values for `message_reference` after serializing

### DIFF
--- a/interactions/api/models/message.py
+++ b/interactions/api/models/message.py
@@ -111,7 +111,7 @@ class MessageActivity(DictSerializerMixin):
 
 
 @define()
-class MessageReference(DictSerializerMixin):
+class MessageReference(ClientSerializerMixin):
     """
     A class object representing the "referenced"/replied message.
 


### PR DESCRIPTION
## About

Idk how it's supposed to work but it works lol

## Checklist

- [ ] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.
- [ ] I have added the `versionadded`, `versionchanged` and `deprecated` to any new or changed user-facing function I committed.
<!-- If you are unsure what the next version is, feel free to ask in #unstable at https://discord.gg/interactions -->

### Pull-Request specification

I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [ ] To add a new feature
  - [ ] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [x] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

<!--- Expand this when more comes up--->
