### PR TITLE
feat💥: make subcmds able to inherit checks from base cmds

### DIFF
--- a/interactions/ext/prefixed_commands/command.py
+++ b/interactions/ext/prefixed_commands/command.py
@@ -346,13 +346,6 @@ class PrefixedCommand(BaseCommand):
         ),
         default=True,
     )
-    hierarchical_checking: bool = attrs.field(
-        metadata=docs(
-            "If `True` and if the base of a subcommand, every subcommand underneath it will run this command's checks"
-            " and cooldowns before its own. Otherwise, only the subcommand's checks are checked."
-        ),
-        default=True,
-    )
     help: Optional[str] = attrs.field(repr=False, metadata=docs("The long help text for the command."), default=None)
     brief: Optional[str] = attrs.field(repr=False, metadata=docs("The short help text for the command."), default=None)
     parent: Optional["PrefixedCommand"] = attrs.field(
@@ -638,7 +631,7 @@ class PrefixedCommand(BaseCommand):
         enabled: bool = True,
         hidden: bool = False,
         ignore_extra: bool = True,
-        hierarchical_checking: bool = True,
+        inherit_checks: bool = True,
     ) -> Callable[..., Self]:
         """
         A decorator to declare a subcommand for a prefixed command.
@@ -654,8 +647,7 @@ class PrefixedCommand(BaseCommand):
             hidden: If `True`, the default help command (when it is added) does not show this in the help output.
             ignore_extra: If `True`, ignores extraneous strings passed to a command if all its requirements are met \
                 (e.g. ?foo a b c when only expecting a and b). Otherwise, an error is raised.
-            hierarchical_checking: If `True` and if the base of a subcommand, every subcommand underneath it will \
-                run this command's checks before its own. Otherwise, only the subcommand's checks are checked.
+            inherit_checks: If `True`, the subcommand will inherit its checks from the parent command.
         """
 
         def wrapper(func: Callable) -> Self:
@@ -670,7 +662,7 @@ class PrefixedCommand(BaseCommand):
                 enabled=enabled,
                 hidden=hidden,
                 ignore_extra=ignore_extra,
-                hierarchical_checking=hierarchical_checking,
+                checks=self.checks if inherit_checks else [],
             )
             self.add_command(cmd)
             return cmd
@@ -776,7 +768,6 @@ def prefixed_command(
     enabled: bool = True,
     hidden: bool = False,
     ignore_extra: bool = True,
-    hierarchical_checking: bool = True,
 ) -> Callable[..., PrefixedCommand]:
     """
     A decorator to declare a coroutine as a prefixed command.
@@ -792,8 +783,6 @@ def prefixed_command(
         hidden: If `True`, the default help command (when it is added) does not show this in the help output.
         ignore_extra: If `True`, ignores extraneous strings passed to a command if all its requirements are \
             met (e.g. ?foo a b c when only expecting a and b). Otherwise, an error is raised.
-        hierarchical_checking: If `True` and if the base of a subcommand, every subcommand underneath it will \
-            run this command's checks before its own. Otherwise, only the subcommand's checks are checked.
     """
 
     def wrapper(func: Callable) -> PrefixedCommand:
@@ -807,7 +796,6 @@ def prefixed_command(
             enabled=enabled,
             hidden=hidden,
             ignore_extra=ignore_extra,
-            hierarchical_checking=hierarchical_checking,
         )
 
     return wrapper

--- a/interactions/ext/prefixed_commands/manager.py
+++ b/interactions/ext/prefixed_commands/manager.py
@@ -324,18 +324,6 @@ class PrefixedManager:
             command = new_command
             content_parameters = content_parameters.removeprefix(first_word).strip()
 
-            if command.subcommands and command.hierarchical_checking:
-                try:
-                    await new_command._can_run(context)  # will error out if we can't run this command
-                except Exception as e:
-                    if new_command.error_callback:
-                        await new_command.error_callback(e, context)
-                    elif new_command.extension and new_command.extension.extension_error:
-                        await new_command.extension.extension_error(e, context)
-                    else:
-                        self.client.dispatch(CommandError(ctx=context, error=e))
-                    return
-
         if not isinstance(command, PrefixedCommand) or not command.enabled:
             return
 

--- a/interactions/models/internal/application_commands.py
+++ b/interactions/models/internal/application_commands.py
@@ -595,14 +595,16 @@ class SlashCommand(InteractionCommand):
         option_name = option_name.lower()
         return wrapper
 
-    def group(self, name: str = None, description: str = "No Description Set") -> "SlashCommand":
-
+    def group(
+        self, name: str = None, description: str = "No Description Set", inherit_checks: bool = True
+    ) -> "SlashCommand":
         return SlashCommand(
             name=self.name,
             description=self.description,
             group_name=name,
             group_description=description,
             scopes=self.scopes,
+            checks=self.checks if inherit_checks else [],
         )
 
     def subcommand(
@@ -613,6 +615,7 @@ class SlashCommand(InteractionCommand):
         group_description: Absent[LocalisedDesc | str] = MISSING,
         options: List[Union[SlashCommandOption, Dict]] = None,
         nsfw: bool = False,
+        inherit_checks: bool = True,
     ) -> Callable[..., "SlashCommand"]:
         def wrapper(call: Callable[..., Coroutine]) -> "SlashCommand":
             nonlocal sub_cmd_description
@@ -636,6 +639,7 @@ class SlashCommand(InteractionCommand):
                 callback=call,
                 scopes=self.scopes,
                 nsfw=nsfw,
+                checks=self.checks if inherit_checks else [],
             )
 
         return wrapper

--- a/interactions/models/internal/command.py
+++ b/interactions/models/internal/command.py
@@ -304,6 +304,10 @@ class BaseCommand(DictSerializationMixin, CallbackObject):
                 await self.max_concurrency.release(context)
             raise
 
+    def add_check(self, check: Callable[..., Awaitable[bool]]) -> None:
+        """Adds a check into the command."""
+        self.checks.append(check)
+
     def error(self, call: Callable[..., Coroutine]) -> Callable[..., Coroutine]:
         """A decorator to declare a coroutine as one that will be run upon an error."""
         if not asyncio.iscoroutinefunction(call):


### PR DESCRIPTION
## About

This pull request allows (and enables by default) for `SlashCommand`s and `PrefixedCommand`s to inherit checks from their base command definition, if they exist. Furthermore, this also adds an `add_check` function to `BaseCommand` to make it easier to add checks to base commands.

For example,
```python
async def a_check(ctx: interactions.InteractionContext):
    await ctx.send("base command test")
    return True

cmd = interactions.SlashCommand(name="test", description="test")
cmd.add_check(a_check)

@cmd.subcommand(sub_cmd_name="sub", sub_cmd_description="desc", inherit_checks=True)
async def sub(ctx: interactions.InteractionContext):
    await ctx.send("sub command")
```

will produce something like this:
![A demonstation of inherit checks working.](https://user-images.githubusercontent.com/25420078/217622680-37eb94f4-dbef-47dd-a5fb-eb96c4a65a0c.png)

💥 This also replaces `hierarchical_checking` in `PrefixedCommand`s with this. These two do pretty similar things, and I figured it was better to have consistency between the slash and prefixed commands. As an upside, it also makes prefixed command logic simpler.

## Checklist

- [x] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.
- [ ] I have added the `versionadded`, `versionchanged` and `deprecated` to any new or changed user-facing function I committed.
<!-- If you are unsure what the next version is, feel free to ask in #unstable at https://discord.gg/interactions -->

### Pull-Request specification

I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [x] To add a new feature
  - [x] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [ ] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [x] A breaking change

<!--- Expand this when more comes up--->
