### PR TITLE
feat: add set_video for Embed

### DIFF
--- a/interactions/models/discord/embed.py
+++ b/interactions/models/discord/embed.py
@@ -6,16 +6,17 @@ from attrs.validators import instance_of
 from attrs.validators import optional as v_optional
 
 from interactions.client.const import (
-    EMBED_MAX_NAME_LENGTH,
-    EMBED_MAX_FIELDS,
-    EMBED_MAX_DESC_LENGTH,
-    EMBED_TOTAL_MAX,
     EMBED_FIELD_VALUE_LENGTH,
+    EMBED_MAX_DESC_LENGTH,
+    EMBED_MAX_FIELDS,
+    EMBED_MAX_NAME_LENGTH,
+    EMBED_TOTAL_MAX,
 )
 from interactions.client.mixins.serialization import DictSerializationMixin
-from interactions.client.utils.attr_converters import optional as c_optional, list_converter
+from interactions.client.utils.attr_converters import list_converter
+from interactions.client.utils.attr_converters import optional as c_optional
 from interactions.client.utils.attr_converters import timestamp_converter
-from interactions.client.utils.serializer import no_export_meta, export_converter
+from interactions.client.utils.serializer import export_converter, no_export_meta
 from interactions.models.discord.color import Color, process_color
 from interactions.models.discord.enums import EmbedType
 from interactions.models.discord.timestamp import Timestamp
@@ -340,6 +341,17 @@ class Embed(DictSerializationMixin):
 
         """
         self.thumbnail = EmbedAttachment(url=url)
+        return self
+
+    def set_video(self, url: str) -> "Embed":
+        """
+        Set the video of the embed.
+
+        Args:
+            url: the url of the video to use
+
+        """
+        self.video = EmbedAttachment(url=url)
         return self
 
     def set_image(self, url: str) -> "Embed":


### PR DESCRIPTION
## About

This pull request adds the `set_video` helper for Embed, which was missing :(

## Checklist

- [x] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.
- [ ] I have added the `versionadded`, `versionchanged` and `deprecated` to any new or changed user-facing function I committed.
<!-- If you are unsure what the next version is, feel free to ask in #unstable at https://discord.gg/interactions -->

### Pull-Request specification

I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [x] To add a new feature
  - [ ] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [ ] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

<!--- Expand this when more comes up--->
