### PR TITLE
fix: AttributeError in emoji conversion for options

### DIFF
--- a/interactions/models/discord/components.py
+++ b/interactions/models/discord/components.py
@@ -375,11 +375,13 @@ class StringSelectOption(BaseComponent):
 
     @classmethod
     def from_dict(cls, data: discord_typings.SelectMenuOptionData) -> "StringSelectOption":
+        emoji = process_emoji(data.get("emoji"))
+        emoji = PartialEmoji.from_dict(emoji) if emoji else None
         return cls(
             label=data["label"],
             value=data["value"],
             description=data.get("description"),
-            emoji=process_emoji(data.get("emoji")),
+            emoji=emoji,
             default=data.get("default", False),
         )
 


### PR DESCRIPTION
## About

This pull request is about fixing an attribute error, which occurs during the emoji conversion for options in components.

## Checklist

- [x] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.11`
- [ ] I have added the `versionadded`, `versionchanged` and `deprecated` to any new or changed user-facing function I committed.
<!-- If you are unsure what the next version is, feel free to ask in #unstable at https://discord.gg/interactions -->

### Pull-Request specification

I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [ ] To add a new feature
  - [ ] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [x] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

<!--- Expand this when more comes up--->

Code used to test
```py
@interactions.slash_command(
    name="test",
    description="A test command",
)
async def test_command(ctx: interactions.InteractionContext):
    await ctx.defer()
    options = [
        interactions.StringSelectOption(
            label=f"Option 1", value=f"option1", emoji="<:whatDidYouJustPost:929464862625652817>"
        ),
        interactions.StringSelectOption(
            label=f"Option 2", value=f"option2", emoji=":whatDidYouJustPost:929464862625652817"
        ),
        interactions.StringSelectOption(label=f"Option 3", value=f"option3", emoji="<a:loading:950666903540625418>"),
        interactions.StringSelectOption(label=f"Option 4", value=f"option4", emoji="a:loading:950666903540625418"),
        interactions.StringSelectOption(label=f"Option 5", value=f"option5", emoji="👋"),
        interactions.StringSelectOption(label=f"Option 6", value=f"option6"),
    ]

    select = interactions.StringSelectMenu(
        *options,
        placeholder="Select an option",
        min_values=1,
        max_values=1,
    )
    sent_message: interactions.Message = await ctx.send("Test", components=[select])

    # Now we seend another message and try to use the resolved message components.
    await ctx.send("Test 2", components=sent_message.components)
```

