### PR TITLE
fix(context): `edit` method doesn't properly works after `send`

### DIFF
--- a/interactions/client/context.py
+++ b/interactions/client/context.py
@@ -555,17 +555,13 @@ class CommandContext(_Context):
         msg = None
 
         if self.deferred or self.responded:
-            try:
-                res = await self._client.edit_interaction_response(
-                    data=payload,
-                    files=files,
-                    token=self.token,
-                    application_id=str(self.application_id),
-                )
-            except LibraryException as e:
-                raise e from e
-            else:
-                self.message = msg = Message(**res, _client=self._client)
+            res = await self._client.edit_interaction_response(
+                data=payload,
+                files=files,
+                token=self.token,
+                application_id=str(self.application_id),
+            )
+            self.message = msg = Message(**res, _client=self._client)
         else:
             self.callback = InteractionCallbackType.UPDATE_MESSAGE
             await self._client.create_interaction_response(

--- a/interactions/client/context.py
+++ b/interactions/client/context.py
@@ -554,15 +554,18 @@ class CommandContext(_Context):
         payload, files = await super().edit(content, **kwargs)
         msg = None
 
-        if self.deferred:
+        if self.deferred or self.responded:
             if (
                 hasattr(self.message, "id")
                 and self.message.id is not None
                 and self.message.flags != 64
             ):
                 try:
-                    res = await self._client.edit_message(
-                        int(self.channel_id), int(self.message.id), payload=payload, files=files
+                    res = await self._client.edit_interaction_response(
+                        data=payload,
+                        files=files,
+                        token=self.token,
+                        application_id=str(self.application_id),
                     )
                 except LibraryException as e:
                     if e.code in {10015, 10018}:

--- a/interactions/client/context.py
+++ b/interactions/client/context.py
@@ -555,45 +555,21 @@ class CommandContext(_Context):
         msg = None
 
         if self.deferred or self.responded:
-            if (
-                hasattr(self.message, "id")
-                and self.message.id is not None
-                and self.message.flags != 64
-            ):
-                try:
-                    res = await self._client.edit_interaction_response(
-                        data=payload,
-                        files=files,
-                        token=self.token,
-                        application_id=str(self.application_id),
-                    )
-                except LibraryException as e:
-                    if e.code in {10015, 10018}:
-                        log.warning(f"You can't edit hidden messages." f"({e.message}).")
-                    else:
-                        # if its not ephemeral or some other thing.
-                        raise e from e
+            try:
+                res = await self._client.edit_interaction_response(
+                    data=payload,
+                    files=files,
+                    token=self.token,
+                    application_id=str(self.application_id),
+                )
+            except LibraryException as e:
+                if e.code in {10015, 10018}:
+                    log.warning(f"You can't edit hidden messages." f"({e.message}).")
                 else:
-                    self.message = msg = Message(**res, _client=self._client)
+                    # if its not ephemeral or some other thing.
+                    raise e from e
             else:
-                try:
-                    res = await self._client.edit_interaction_response(
-                        token=self.token,
-                        application_id=str(self.application_id),
-                        data=payload,
-                        files=files,
-                        message_id=self.message.id
-                        if self.message and self.message.flags != 64
-                        else "@original",
-                    )
-                except LibraryException as e:
-                    if e.code in {10015, 10018}:
-                        log.warning(f"You can't edit hidden messages." f"({e.message}).")
-                    else:
-                        # if its not ephemeral or some other thing.
-                        raise e from e
-                else:
-                    self.message = msg = Message(**res, _client=self._client)
+                self.message = msg = Message(**res, _client=self._client)
         else:
             self.callback = InteractionCallbackType.UPDATE_MESSAGE
             await self._client.create_interaction_response(

--- a/interactions/client/context.py
+++ b/interactions/client/context.py
@@ -561,8 +561,11 @@ class CommandContext(_Context):
                 and self.message.flags != 64
             ):
                 try:
-                    res = await self._client.edit_message(
-                        int(self.channel_id), int(self.message.id), payload=payload, files=files
+                    res = await self._client.edit_interaction_response(
+                        data=payload,
+                        files=files,
+                        token=self.token,
+                        application_id=str(self.application_id),
                     )
                 except LibraryException as e:
                     if e.code in {10015, 10018}:

--- a/interactions/client/context.py
+++ b/interactions/client/context.py
@@ -563,11 +563,7 @@ class CommandContext(_Context):
                     application_id=str(self.application_id),
                 )
             except LibraryException as e:
-                if e.code in {10015, 10018}:
-                    log.warning(f"You can't edit hidden messages." f"({e.message}).")
-                else:
-                    # if its not ephemeral or some other thing.
-                    raise e from e
+                raise e from e
             else:
                 self.message = msg = Message(**res, _client=self._client)
         else:


### PR DESCRIPTION
## About

This pull request is about Fixing edit after slash cmd
```py
@testbot1.command(name="test3", scope=scope, description="Super Test")
async def test3(ctx: CommandContext):
    await ctx.defer(ephemeral=True)
    await ctx.send("Test Start")
    # await testbot1._logout()
    await asyncio.sleep(10)
    await ctx.edit(
        "Test Done", components=Button(custom_id="Baka", label="Boo", style=ButtonStyle.PRIMARY)
    )
```
## Checklist

- [x] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.
- [ ] I have added the `versionadded`, `versionchanged` and `deprecated` to any new or changed user-facing function I committed.
<!-- If you are unsure what the next version is, feel free to ask in #unstable at https://discord.gg/interactions -->

### Pull-Request specification

I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [ ] To add a new feature
  - [ ] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [ ] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

<!--- Expand this when more comes up--->
