### PR TITLE
refactor(context): remove `ctx.message` overriding after defering interaction

### DIFF
--- a/interactions/client/context.py
+++ b/interactions/client/context.py
@@ -199,10 +199,15 @@ class _Context(ClientSerializerMixin):
                 application_id=int(self.id),
                 data={"type": self.callback.value, "data": {"flags": is_ephemeral}},
             )
+            with suppress(LibraryException):
+                res = await self._client.get_original_interaction_response(
+                    self.token, str(self.application_id)
+                )
+                _message = Message(**res, _client=self._client)
 
             self.responded = True
 
-            return self.message
+            return _message
 
     async def send(
         self,

--- a/interactions/client/context.py
+++ b/interactions/client/context.py
@@ -200,12 +200,6 @@ class _Context(ClientSerializerMixin):
                 data={"type": self.callback.value, "data": {"flags": is_ephemeral}},
             )
 
-            with suppress(LibraryException):
-                res = await self._client.get_original_interaction_response(
-                    self.token, str(self.application_id)
-                )
-                self.message = Message(**res, _client=self._client)
-
             self.responded = True
 
             return self.message


### PR DESCRIPTION
## About

Damego: This was added in v4.4.0 and a lot of people think it's a bug

## Checklist

- [x] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.
- [ ] I have added the `versionadded`, `versionchanged` and `deprecated` to any new or changed user-facing function I committed.
<!-- If you are unsure what the next version is, feel free to ask in #unstable at https://discord.gg/interactions -->

### Pull-Request specification

I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [ ] To add a new feature
  - [ ] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [ ] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

<!--- Expand this when more comes up--->
