### PR TITLE
fix: errenous critical log when `GUILD_MESSAGES` intent is used

### DIFF
--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -453,7 +453,7 @@ class Client:
                 ):
                     raise RuntimeError("Client not authorised for the GUILD_MEMBERS intent.")
                 if (
-                    self._intents.GUILD_MESSAGES in self._intents
+                    self._intents.GUILD_MESSAGE_CONTENT in self._intents
                     and self.me.flags.GATEWAY_MESSAGE_CONTENT not in self.me.flags
                     and self.me.flags.GATEWAY_MESSAGE_CONTENT_LIMITED not in self.me.flags
                 ):


### PR DESCRIPTION
## About

by default the `GUILD_MESSAGES` intent (unprivileged) was causing critical logs on startup about not having a message content privileged intent

This pull request is about (X), which does (Y).

## Checklist

- [X] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [X] I've ensured the change(s) work on `3.8.6` and higher.
- [X] I have added the `versionadded`, `versionchanged` and `deprecated` to any new or changed user-facing function I committed.
<!-- If you are unsure what the next version is, feel free to ask in #unstable at https://discord.gg/interactions -->

### Pull-Request specification

I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [ ] To add a new feature
  - [ ] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [X] To fix an existing bug
  - [X] To resolve #1289


This is:
  - [ ] A breaking change