### PR TITLE
Add single item list_converter support

### DIFF
--- a/interactions/api/voice/opus.py
+++ b/interactions/api/voice/opus.py
@@ -1,7 +1,6 @@
 import array
 import ctypes
 import ctypes.util
-import os
 import sys
 from enum import IntEnum
 from pathlib import Path

--- a/interactions/client/utils/attr_converters.py
+++ b/interactions/client/utils/attr_converters.py
@@ -1,7 +1,7 @@
 import inspect
 import typing
 from datetime import datetime
-from typing import Callable, Union
+from typing import Callable, Union, Any
 
 from interactions.client.const import MISSING
 from interactions.models.discord.timestamp import Timestamp
@@ -32,7 +32,11 @@ def timestamp_converter(value: Union[datetime, int, float, str]) -> Timestamp:
 def list_converter(converter) -> Callable[[list], list]:
     """Converts a list of values to a list of converted values"""
 
-    def convert_action(value: list) -> list:
+    def convert_action(value: Union[list, Any]) -> list:
+        if not isinstance(value, list):
+            """If only one single item was passed (without a list), then we only convert that one item instead of throwing an exception."""
+            return [converter(value)]
+
         return [converter(element) for element in value]
 
     return convert_action

--- a/interactions/models/discord/file.py
+++ b/interactions/models/discord/file.py
@@ -52,6 +52,7 @@ class File:
         if isinstance(self.file, (IOBase, BinaryIO)):
             self.file.close()
 
+
 UPLOADABLE_TYPE = Union[File, IOBase, BinaryIO, Path, str]
 
 

--- a/interactions/models/internal/context.py
+++ b/interactions/models/internal/context.py
@@ -745,7 +745,7 @@ class ComponentContext(InteractionContext, ModalMixin):
 
         message_data = None
         if self.deferred:
-            if not self.defer_edit_origin:
+            if not self.editing_origin:
                 get_logger().warning(
                     "If you want to edit the original message, and need to defer, you must set the `edit_origin` kwarg to True!"
                 )
@@ -754,7 +754,7 @@ class ComponentContext(InteractionContext, ModalMixin):
                 message_payload, self.client.app.id, self.token
             )
             self.deferred = False
-            self.defer_edit_origin = False
+            self.editing_origin = False
         else:
             payload = {"type": CallbackType.UPDATE_MESSAGE, "data": message_payload}
             await self.client.http.post_initial_response(payload, str(self.id), self.token, files=files or file)

--- a/interactions/models/internal/context.py
+++ b/interactions/models/internal/context.py
@@ -745,7 +745,7 @@ class ComponentContext(InteractionContext, ModalMixin):
 
         message_data = None
         if self.deferred:
-            if not self.editing_origin:
+            if not self.defer_edit_origin:
                 get_logger().warning(
                     "If you want to edit the original message, and need to defer, you must set the `edit_origin` kwarg to True!"
                 )
@@ -754,7 +754,7 @@ class ComponentContext(InteractionContext, ModalMixin):
                 message_payload, self.client.app.id, self.token
             )
             self.deferred = False
-            self.editing_origin = False
+            self.defer_edit_origin = False
         else:
             payload = {"type": CallbackType.UPDATE_MESSAGE, "data": message_payload}
             await self.client.http.post_initial_response(payload, str(self.id), self.token, files=files or file)


### PR DESCRIPTION
## About

I have recently switched from naff to i.py and I noticed that embed fields have changed.
Now you can pass multiple image objects now called "images", but for convenience I don't always want to create a list with only one entry, so I integrated it directly into the converter. Otherwise, you could only support that for images only but my intention was to support it "theoretically" globally.

## Checklist

- [ ] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.
- [ ] I have added the `versionadded`, `versionchanged` and `deprecated` to any new or changed user-facing function I committed.
<!-- If you are unsure what the next version is, feel free to ask in #unstable at https://discord.gg/interactions -->

### Pull-Request specification

I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [ ] To add a new feature
  - [x] As a general improvement
  - [x] As a refactor of the library/the library's code
  - [x] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER

<!--- Expand this when more comes up--->
