### PR TITLE
feat: allow disabling autodefer through auto_defer methods

### DIFF
--- a/interactions/models/internal/application_commands.py
+++ b/interactions/models/internal/application_commands.py
@@ -1252,11 +1252,14 @@ def slash_default_member_permission(
     return wrapper
 
 
-def auto_defer(ephemeral: bool = False, time_until_defer: float = 0.0) -> Callable[[InterCommandT], InterCommandT]:
+def auto_defer(
+    enabled: bool = True, ephemeral: bool = False, time_until_defer: float = 0.0
+) -> Callable[[InterCommandT], InterCommandT]:
     """
     A decorator to add an auto defer to a application command.
 
     Args:
+        enabled: Should the command be deferred automatically
         ephemeral: Should the command be deferred as ephemeral
         time_until_defer: How long to wait before deferring automatically
 
@@ -1265,7 +1268,7 @@ def auto_defer(ephemeral: bool = False, time_until_defer: float = 0.0) -> Callab
     def wrapper(func: InterCommandT) -> InterCommandT:
         if hasattr(func, "cmd_id"):
             raise ValueError("auto_defer decorators must be positioned under a slash_command decorator")
-        func.auto_defer = AutoDefer(enabled=True, ephemeral=ephemeral, time_until_defer=time_until_defer)
+        func.auto_defer = AutoDefer(enabled=enabled, ephemeral=ephemeral, time_until_defer=time_until_defer)
         return func
 
     return wrapper

--- a/interactions/models/internal/extension.py
+++ b/interactions/models/internal/extension.py
@@ -167,7 +167,7 @@ class Extension:
         self.bot.dispatch(events.ExtensionUnload(self))
         self.bot.logger.debug(f"{self.name} has been drop")
 
-    def add_ext_auto_defer(self, enabled: bool = False, ephemeral: bool = False, time_until_defer: float = 0.0) -> None:
+    def add_ext_auto_defer(self, enabled: bool = True, ephemeral: bool = False, time_until_defer: float = 0.0) -> None:
         """
         Add a auto defer for all commands in this extension.
 

--- a/interactions/models/internal/extension.py
+++ b/interactions/models/internal/extension.py
@@ -167,16 +167,17 @@ class Extension:
         self.bot.dispatch(events.ExtensionUnload(self))
         self.bot.logger.debug(f"{self.name} has been drop")
 
-    def add_ext_auto_defer(self, ephemeral: bool = False, time_until_defer: float = 0.0) -> None:
+    def add_ext_auto_defer(self, enabled: bool = False, ephemeral: bool = False, time_until_defer: float = 0.0) -> None:
         """
         Add a auto defer for all commands in this extension.
 
         Args:
+            enabled: Should the command be deferred automatically
             ephemeral: Should the command be deferred as ephemeral
             time_until_defer: How long to wait before deferring automatically
 
         """
-        self.auto_defer = models.AutoDefer(enabled=True, ephemeral=ephemeral, time_until_defer=time_until_defer)
+        self.auto_defer = models.AutoDefer(enabled=enabled, ephemeral=ephemeral, time_until_defer=time_until_defer)
 
     def add_ext_check(self, coroutine: Callable[["BaseContext"], Awaitable[bool]]) -> None:
         """


### PR DESCRIPTION
## About

This pull request allows "disabling" auto-defers in a command or extension through the helper functions/decorators.

Say, if you had a bot-wide auto-defer (a very common setup), but you wanted one command to specifically *not* defer (for various reasons). Before, it would take this rather awkward code to achieve the trick:
```python
@slash_command(...)
async def cmd(...):
    ...

cmd.auto_defer = AutoDefer(enabled=False)
```

With this PR, it's made cleaner:
```python
@slash_command(...)
@auto_defer(enabled=False)
async def cmd(...):
    ...
```

A similar concept applies with extensions.

## Checklist

- [x] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.
- [ ] I have added the `versionadded`, `versionchanged` and `deprecated` to any new or changed user-facing function I committed.
<!-- If you are unsure what the next version is, feel free to ask in #unstable at https://discord.gg/interactions -->

### Pull-Request specification

I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [x] To add a new feature
  - [x] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [ ] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

<!--- Expand this when more comes up--->
