### PR TITLE
fix: emoji deletion error on guild leave

### DIFF
--- a/interactions/client/smart_cache.py
+++ b/interactions/client/smart_cache.py
@@ -638,7 +638,7 @@ class GlobalCache:
             [self.delete_member(m.id, guild_id) for m in guild.members]
             [self.delete_role(r) for r in guild.roles]
             if self.enable_emoji_cache:  # todo: this is ungodly slow, find a better way to do this
-                for emoji in self.emoji_cache:
+                for emoji in self.emoji_cache.values():
                     if emoji._guild_id == guild_id:  # noqa
                         self.delete_emoji(emoji)
 

--- a/interactions/models/internal/context.py
+++ b/interactions/models/internal/context.py
@@ -598,7 +598,9 @@ class ContextMenuContext(InteractionContext, ModalMixin):
             raise RuntimeError("Interaction has already been responded to.")
 
         payload = {
-            "type": CallbackType.DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE if not edit_origin else CallbackType.DEFERRED_UPDATE_MESSAGE
+            "type": CallbackType.DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE
+            if not edit_origin
+            else CallbackType.DEFERRED_UPDATE_MESSAGE
         }
         if ephemeral:
             if edit_origin:


### PR DESCRIPTION
## About

Fixes the following error whenever the bot leaves a guild:
```
File "interactions\client\smart_cache.py", line 642, in delete_guild
    if emoji._guild_id == guild_id:  # noqa
       ^^^^^^^^^^^^^^^
AttributeError: 'Snowflake' object has no attribute '_guild_id'
```

## Checklist

- [ ] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.
- [ ] I have added the `versionadded`, `versionchanged` and `deprecated` to any new or changed user-facing function I committed.
<!-- If you are unsure what the next version is, feel free to ask in #unstable at https://discord.gg/interactions -->

### Pull-Request specification

I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [ ] To add a new feature
  - [ ] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [x] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER
