### PR TITLE
change logging: compare attributes

### DIFF
--- a/interactions/client/bot.py
+++ b/interactions/client/bot.py
@@ -250,7 +250,7 @@ class Client:
 
         option_attrs: List[str] = [name for name in Option.__slots__ if not name.startswith("_")]
         choice_attrs: List[str] = [name for name in Choice.__slots__ if not name.startswith("_")]
-        log.info(f"Current attributes to compare: {', '.join(attrs)}.")
+        log.debug(f"Current attributes to compare: {', '.join(attrs)}.")
         clean: bool = True
 
         _command: dict = {}


### PR DESCRIPTION
change logging from info to debug of comparing attributes in __compare_sync()

## About

Changing logging type to debug.
In general usage this logging might not needed for info.

## Checklist

- [ ] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [ ] I've ensured the change(s) work on `3.8.6` and higher.
- [ ] I have added the `versionadded`, `versionchanged` and `deprecated` to any new or changed user-facing function I committed.
<!-- If you are unsure what the next version is, feel free to ask in #unstable at https://discord.gg/interactions -->

### Pull-Request specification

I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [ ] To add a new feature
  - [ ] As a general enhancement
  - [x] As a refactor of the library/the library's code
  - [ ] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

<!--- Expand this when more comes up--->
