### PR TITLE
fix: ValueError raised when having `file`

### DIFF
--- a/interactions/models/internal/context.py
+++ b/interactions/models/internal/context.py
@@ -768,7 +768,7 @@ class ComponentContext(InteractionContext, ModalMixin):
                 )
 
             message_data = await self.client.http.edit_interaction_message(
-                message_payload, self.client.app.id, self.token
+                message_payload, self.client.app.id, self.token, files=files or file
             )
             self.deferred = False
             self.editing_origin = False

--- a/interactions/models/internal/context.py
+++ b/interactions/models/internal/context.py
@@ -554,7 +554,10 @@ class InteractionContext(BaseInteractionContext, SendMixin):
         )
 
         if file:
-            files = (file, *files) if files else (file,)
+            if files:
+                files = [file, *files]
+            else:
+                files = [file]
         message_data = await self.client.http.edit_interaction_message(
             payload=message_payload,
             application_id=self.client.app.id,


### PR DESCRIPTION
## About

Title.

## Checklist

- [x] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.
- [ ] I have added the `versionadded`, `versionchanged` and `deprecated` to any new or changed user-facing function I committed.
<!-- If you are unsure what the next version is, feel free to ask in #unstable at https://discord.gg/interactions -->

### Pull-Request specification

I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [ ] To add a new feature
  - [ ] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [x] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

<!--- Expand this when more comes up--->
