### PR TITLE
fix: incorrect type annotation for `async_startup_tasks`

### DIFF
--- a/interactions/client/client.py
+++ b/interactions/client/client.py
@@ -393,7 +393,7 @@ class Client(
         self.waits: Dict[str, List] = {}
         self.owner_ids: set[Snowflake_Type] = set(owner_ids)
 
-        self.async_startup_tasks: list[tuple[Coroutine, Iterable[Any], dict[str:Any]]] = []
+        self.async_startup_tasks: list[tuple[Callable[..., Coroutine], Iterable[Any], dict[str, Any]]] = []
         """A list of coroutines to run during startup"""
 
         # callbacks


### PR DESCRIPTION
## About

This pull request is about (X), which does (Y).

## Checklist

- [ ] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.
- [ ] I have added the `versionadded`, `versionchanged` and `deprecated` to any new or changed user-facing function I committed.
<!-- If you are unsure what the next version is, feel free to ask in #unstable at https://discord.gg/interactions -->

### Pull-Request specification

I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [ ] To add a new feature
  - [ ] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [ ] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

<!--- Expand this when more comes up--->
