### PR TITLE
feat: rate limit improvements 

### DIFF
--- a/interactions/api/http/http_client.py
+++ b/interactions/api/http/http_client.py
@@ -111,6 +111,11 @@ class BucketLock:
     def __repr__(self) -> str:
         return f"<BucketLock: {self.bucket_hash or 'Generic'}, limit: {self.limit}, remaining: {self.remaining}, delta: {self.delta}>"
 
+    @property
+    def locked(self) -> bool:
+        """Returns whether the bucket is locked."""
+        return self._semaphore is not None and self._semaphore.locked()
+
     def ingest_ratelimit_header(self, header: CIMultiDictProxy) -> None:
         """
         Ingests the ratelimit header.

--- a/interactions/api/http/http_requests/channels.py
+++ b/interactions/api/http/http_requests/channels.py
@@ -33,7 +33,7 @@ class ChannelRequests(CanRequest):
             channel
 
         """
-        result = await self.request(Route("GET", f"/channels/{int(channel_id)}"))
+        result = await self.request(Route("GET", "/channels/{channel_id}", channel_id=channel_id))
         return cast(discord_typings.ChannelData, result)
 
     @overload
@@ -109,7 +109,9 @@ class ChannelRequests(CanRequest):
         }
         params = dict_filter_none(params)
 
-        result = await self.request(Route("GET", f"/channels/{int(channel_id)}/messages"), params=params)
+        result = await self.request(
+            Route("GET", "/channels/{channel_id}/messages", channel_id=channel_id), params=params
+        )
         return cast(list[discord_typings.MessageData], result)
 
     async def create_guild_channel(
@@ -168,7 +170,9 @@ class ChannelRequests(CanRequest):
             )
         payload = dict_filter_none(payload)
 
-        result = await self.request(Route("POST", f"/guilds/{int(guild_id)}/channels"), payload=payload, reason=reason)
+        result = await self.request(
+            Route("POST", "/guilds/{guild_id}/channels", guild_id=guild_id), payload=payload, reason=reason
+        )
         return cast(discord_typings.ChannelData, result)
 
     async def move_channel(
@@ -200,7 +204,9 @@ class ChannelRequests(CanRequest):
         }
         payload = dict_filter_none(payload)
 
-        await self.request(Route("PATCH", f"/guilds/{int(guild_id)}/channels"), payload=payload, reason=reason)
+        await self.request(
+            Route("PATCH", "/guilds/{guild_id}/channels", guild_id=guild_id), payload=payload, reason=reason
+        )
 
     async def modify_channel(
         self, channel_id: "Snowflake_Type", data: dict, reason: str | None = None
@@ -217,7 +223,9 @@ class ChannelRequests(CanRequest):
             Channel object on success
 
         """
-        result = await self.request(Route("PATCH", f"/channels/{int(channel_id)}"), payload=data, reason=reason)
+        result = await self.request(
+            Route("PATCH", "/channels/{channel_id}", channel_id=channel_id), payload=data, reason=reason
+        )
         return cast(discord_typings.ChannelData, result)
 
     async def delete_channel(self, channel_id: "Snowflake_Type", reason: str | None = None) -> None:
@@ -229,7 +237,7 @@ class ChannelRequests(CanRequest):
             reason: An optional reason for the audit log
 
         """
-        await self.request(Route("DELETE", f"/channels/{int(channel_id)}"), reason=reason)
+        await self.request(Route("DELETE", "/channels/{channel_id}", channel_id=channel_id), reason=reason)
 
     async def get_channel_invites(self, channel_id: "Snowflake_Type") -> list[discord_typings.InviteData]:
         """
@@ -242,7 +250,7 @@ class ChannelRequests(CanRequest):
             List of invite objects
 
         """
-        result = await self.request(Route("GET", f"/channels/{int(channel_id)}/invites"))
+        result = await self.request(Route("GET", "/channels/{channel_id}/invites", channel_id=channel_id))
         return cast(list[discord_typings.InviteData], result)
 
     @overload
@@ -336,7 +344,7 @@ class ChannelRequests(CanRequest):
         payload = dict_filter_none(payload)
 
         result = await self.request(
-            Route("POST", f"/channels/{int(channel_id)}/invites"), payload=payload, reason=reason
+            Route("POST", "/channels/{channel_id}/invites", channel_id=channel_id), payload=payload, reason=reason
         )
         return cast(discord_typings.InviteData, result)
 
@@ -361,13 +369,14 @@ class ChannelRequests(CanRequest):
 
         """
         params: PAYLOAD_TYPE = {
+            "invite_code": invite_code,
             "with_counts": with_counts,
             "with_expiration": with_expiration,
             "guild_scheduled_event_id": int(scheduled_event_id) if scheduled_event_id else None,
         }
         params = dict_filter_none(params)
 
-        result = await self.request(Route("GET", f"/invites/{invite_code}", params=params))
+        result = await self.request(Route("GET", "/invites/{invite_code}", params=params))
         return cast(discord_typings.InviteData, result)
 
     async def delete_invite(self, invite_code: str, reason: str | None = None) -> discord_typings.InviteData:
@@ -382,7 +391,7 @@ class ChannelRequests(CanRequest):
             The deleted invite object
 
         """
-        result = await self.request(Route("DELETE", f"/invites/{invite_code}"), reason=reason)
+        result = await self.request(Route("DELETE", "/invites/{invite_code}", invite_code=invite_code), reason=reason)
         return cast(discord_typings.InviteData, result)
 
     async def edit_channel_permission(
@@ -409,7 +418,12 @@ class ChannelRequests(CanRequest):
         payload: PAYLOAD_TYPE = {"allow": allow, "deny": deny, "type": perm_type}
 
         await self.request(
-            Route("PUT", f"/channels/{int(channel_id)}/permissions/{int(overwrite_id)}"),
+            Route(
+                "PUT",
+                "/channels/{channel_id}/permissions/{overwrite_id}",
+                channel_id=channel_id,
+                overwrite_id=overwrite_id,
+            ),
             payload=payload,
             reason=reason,
         )
@@ -429,7 +443,10 @@ class ChannelRequests(CanRequest):
             reason: An optional reason for the audit log
 
         """
-        await self.request(Route("DELETE", f"/channels/{int(channel_id)}/{int(overwrite_id)}"), reason=reason)
+        await self.request(
+            Route("DELETE", "/channels/{channel_id}/{overwrite_id}", channel_id=channel_id, overwrite_id=overwrite_id),
+            reason=reason,
+        )
 
     async def follow_news_channel(
         self, channel_id: "Snowflake_Type", webhook_channel_id: "Snowflake_Type"
@@ -447,7 +464,9 @@ class ChannelRequests(CanRequest):
         """
         payload = {"webhook_channel_id": int(webhook_channel_id)}
 
-        result = await self.request(Route("POST", f"/channels/{int(channel_id)}/followers"), payload=payload)
+        result = await self.request(
+            Route("POST", "/channels/{channel_id}/followers", channel_id=channel_id), payload=payload
+        )
         return cast(discord_typings.FollowedChannelData, result)
 
     async def trigger_typing_indicator(self, channel_id: "Snowflake_Type") -> None:
@@ -458,7 +477,7 @@ class ChannelRequests(CanRequest):
             channel_id: The id of the channel to "type" in
 
         """
-        await self.request(Route("POST", f"/channels/{int(channel_id)}/typing"))
+        await self.request(Route("POST", "/channels/{channel_id}/typing", channel_id=channel_id))
 
     async def get_pinned_messages(self, channel_id: "Snowflake_Type") -> list[discord_typings.MessageData]:
         """
@@ -471,7 +490,7 @@ class ChannelRequests(CanRequest):
             A list of pinned message objects
 
         """
-        result = await self.request(Route("GET", f"/channels/{int(channel_id)}/pins"))
+        result = await self.request(Route("GET", "/channels/{channel_id}/pins", channel_id=channel_id))
         return cast(list[discord_typings.MessageData], result)
 
     async def create_stage_instance(
@@ -514,7 +533,7 @@ class ChannelRequests(CanRequest):
             A stage instance.
 
         """
-        result = await self.request(Route("GET", f"/stage-instances/{int(channel_id)}"))
+        result = await self.request(Route("GET", "/stage-instances/{channel_id}", channel_id=channel_id))
         return cast(discord_typings.StageInstanceData, result)
 
     async def modify_stage_instance(
@@ -540,7 +559,7 @@ class ChannelRequests(CanRequest):
         payload: PAYLOAD_TYPE = {"topic": topic, "privacy_level": privacy_level}
         payload = dict_filter_none(payload)
         result = await self.request(
-            Route("PATCH", f"/stage-instances/{int(channel_id)}"), payload=payload, reason=reason
+            Route("PATCH", "/stage-instances/{channel_id}", channel_id=channel_id), payload=payload, reason=reason
         )
         return cast(discord_typings.StageInstanceData, result)
 
@@ -553,7 +572,7 @@ class ChannelRequests(CanRequest):
             reason: The reason for the deletion
 
         """
-        await self.request(Route("DELETE", f"/stage-instances/{int(channel_id)}"), reason=reason)
+        await self.request(Route("DELETE", "/stage-instances/{channel_id}", channel_id=channel_id), reason=reason)
 
     async def create_tag(
         self,
@@ -582,7 +601,9 @@ class ChannelRequests(CanRequest):
         }
         payload = dict_filter_none(payload)
 
-        result = await self.request(Route("POST", f"/channels/{int(channel_id)}/tags"), payload=payload)
+        result = await self.request(
+            Route("POST", "/channels/{channel_id}/tags", channel_id=channel_id), payload=payload
+        )
         return cast(discord_typings.ChannelData, result)
 
     async def edit_tag(
@@ -614,7 +635,9 @@ class ChannelRequests(CanRequest):
         }
         payload = dict_filter_none(payload)
 
-        result = await self.request(Route("PUT", f"/channels/{int(channel_id)}/tags/{int(tag_id)}"), payload=payload)
+        result = await self.request(
+            Route("PUT", "/channels/{channel_id}/tags/{tag_id}", channel_id=channel_id, tag_id=tag_id), payload=payload
+        )
         return cast(discord_typings.ChannelData, result)
 
     async def delete_tag(self, channel_id: "Snowflake_Type", tag_id: "Snowflake_Type") -> discord_typings.ChannelData:
@@ -625,5 +648,7 @@ class ChannelRequests(CanRequest):
             channel_id: The ID of the forum channel to delete tag it.
             tag_id: The ID of the tag to delete
         """
-        result = await self.request(Route("DELETE", f"/channels/{int(channel_id)}/tags/{int(tag_id)}"))
+        result = await self.request(
+            Route("DELETE", "/channels/{channel_id}/tags/{tag_id}", channel_id=channel_id, tag_id=tag_id)
+        )
         return cast(discord_typings.ChannelData, result)

--- a/interactions/api/http/http_requests/emojis.py
+++ b/interactions/api/http/http_requests/emojis.py
@@ -24,7 +24,7 @@ class EmojiRequests(CanRequest):
             List of emoji objects
 
         """
-        result = await self.request(Route("GET", f"/guilds/{int(guild_id)}/emojis"))
+        result = await self.request(Route("GET", "/guilds/{guild_id}/emojis", guild_id=guild_id))
         return cast(list[discord_typings.EmojiData], result)
 
     async def get_guild_emoji(
@@ -41,7 +41,9 @@ class EmojiRequests(CanRequest):
             PartialEmoji object
 
         """
-        result = await self.request(Route("GET", f"/guilds/{int(guild_id)}/emojis/{int(emoji_id)}"))
+        result = await self.request(
+            Route("GET", "/guilds/{guild_id}/emojis/{emoji_id}", guild_id=guild_id, emoji_id=emoji_id)
+        )
         return cast(discord_typings.EmojiData, result)
 
     async def create_guild_emoji(
@@ -59,7 +61,10 @@ class EmojiRequests(CanRequest):
             The created emoji object
 
         """
-        result = await self.request(Route("POST", f"/guilds/{int(guild_id)}/emojis"), payload=payload, reason=reason)
+        result = await self.request(
+            Route("POST", "/guilds/{guild_id}/emojis", guild_id=guild_id), payload=payload, reason=reason
+        )
+
         return cast(discord_typings.EmojiData, result)
 
     async def modify_guild_emoji(
@@ -83,7 +88,7 @@ class EmojiRequests(CanRequest):
 
         """
         result = await self.request(
-            Route("PATCH", f"/guilds/{int(guild_id)}/emojis/{int(emoji_id)}"),
+            Route("PATCH", "/guilds/{guild_id}/emojis/{emoji_id}", guild_id=guild_id, emoji_id=emoji_id),
             payload=payload,
             reason=reason,
         )
@@ -101,4 +106,7 @@ class EmojiRequests(CanRequest):
             reason: The reason for this deletion
 
         """
-        await self.request(Route("DELETE", f"/guilds/{int(guild_id)}/emojis/{int(emoji_id)}"), reason=reason)
+        await self.request(
+            Route("DELETE", "/guilds/{guild_id}/emojis/{emoji_id}", guild_id=guild_id, emoji_id=emoji_id),
+            reason=reason,
+        )

--- a/interactions/api/http/http_requests/guild.py
+++ b/interactions/api/http/http_requests/guild.py
@@ -54,8 +54,8 @@ class GuildRequests(CanRequest):
             a guild object
 
         """
-        params = {"with_counts": int(with_counts)}
-        result = await self.request(Route("GET", f"/guilds/{int(guild_id)}"), params=params)
+        params = {"guild_id": guild_id, "with_counts": int(with_counts)}
+        result = await self.request(Route("GET", "/guilds/{guild_id}"), params=params)
         return cast(discord_typings.GuildData, result)
 
     async def get_guild_preview(self, guild_id: "Snowflake_Type") -> discord_typings.GuildPreviewData:
@@ -69,7 +69,7 @@ class GuildRequests(CanRequest):
             guild preview object
 
         """
-        result = await self.request(Route("GET", f"/guilds/{int(guild_id)}/preview"))
+        result = await self.request(Route("GET", "/guilds/{guild_id}/preview", guild_id=guild_id))
         return cast(discord_typings.GuildPreviewData, result)
 
     async def get_channels(self, guild_id: "Snowflake_Type") -> list[discord_typings.ChannelData]:
@@ -83,7 +83,7 @@ class GuildRequests(CanRequest):
             List of channels
 
         """
-        result = await self.request(Route("GET", f"/guilds/{int(guild_id)}/channels"))
+        result = await self.request(Route("GET", "/guilds/{guild_id}/channels", guild_id=guild_id))
         return cast(list[discord_typings.ChannelData], result)
 
     async def get_roles(self, guild_id: "Snowflake_Type") -> list[discord_typings.RoleData]:
@@ -97,7 +97,7 @@ class GuildRequests(CanRequest):
             List of roles
 
         """
-        result = await self.request(Route("GET", f"/guilds/{int(guild_id)}/roles"))
+        result = await self.request(Route("GET", "/guilds/{guild_id}/roles", guild_id=guild_id))
         return cast(list[discord_typings.RoleData], result)
 
     async def modify_guild(
@@ -140,7 +140,7 @@ class GuildRequests(CanRequest):
 
         # only do the request if there is something to modify
         if payload:
-            await self.request(Route("PATCH", f"/guilds/{int(guild_id)}"), payload=payload, reason=reason)
+            await self.request(Route("PATCH", "/guilds/{guild_id}", guild_id=guild_id), payload=payload, reason=reason)
 
     async def delete_guild(self, guild_id: "Snowflake_Type") -> None:
         """
@@ -150,7 +150,7 @@ class GuildRequests(CanRequest):
             guild_id: The ID of the guild that we want to delete
 
         """
-        await self.request(Route("DELETE", f"/guilds/{int(guild_id)}"))
+        await self.request(Route("DELETE", "/guilds/{guild_id}", guild_id=guild_id))
 
     async def add_guild_member(
         self,
@@ -187,8 +187,7 @@ class GuildRequests(CanRequest):
         payload = dict_filter_none(payload)
 
         result = await self.request(
-            Route("PUT", f"/guilds/{int(guild_id)}/members/{int(user_id)}"),
-            payload=payload,
+            Route("PUT", "/guilds/{guild_id}/members/{user_id}", guild_id=guild_id, user_id=user_id), payload=payload
         )
         return cast(discord_typings.GuildMemberData, result)
 
@@ -204,7 +203,9 @@ class GuildRequests(CanRequest):
             reason: The reason for this action
 
         """
-        await self.request(Route("DELETE", f"/guilds/{int(guild_id)}/members/{int(user_id)}"), reason=reason)
+        await self.request(
+            Route("DELETE", "/guilds/{guild_id}/members/{user_id}", guild_id=guild_id, user_id=user_id), reason=reason
+        )
 
     async def get_guild_bans(
         self,
@@ -233,7 +234,7 @@ class GuildRequests(CanRequest):
         }
         params = dict_filter_none(params)
 
-        result = await self.request(Route("GET", f"/guilds/{int(guild_id)}/bans"), params=params)
+        result = await self.request(Route("GET", "/guilds/{guild_id}/bans", guild_id=guild_id), params=params)
         return cast(list[discord_typings.BanData], result)
 
     async def get_guild_ban(self, guild_id: "Snowflake_Type", user_id: "Snowflake_Type") -> discord_typings.BanData:
@@ -251,7 +252,9 @@ class GuildRequests(CanRequest):
             NotFound: if no ban exists
 
         """
-        result = await self.request(Route("GET", f"/guilds/{int(guild_id)}/bans/{int(user_id)}"))
+        result = await self.request(
+            Route("GET", "/guilds/{guild_id}/bans/{user_id}", guild_id=guild_id, user_id=user_id)
+        )
         return cast(discord_typings.BanData, result)
 
     async def create_guild_ban(
@@ -273,7 +276,7 @@ class GuildRequests(CanRequest):
         """
         payload = {"delete_message_seconds": delete_message_seconds}
         await self.request(
-            Route("PUT", f"/guilds/{int(guild_id)}/bans/{int(user_id)}"),
+            Route("PUT", "/guilds/{guild_id}/bans/{user_id}", guild_id=guild_id, user_id=user_id),
             payload=payload,
             reason=reason,
         )
@@ -290,7 +293,9 @@ class GuildRequests(CanRequest):
             reason: The reason for this action
 
         """
-        await self.request(Route("DELETE", f"/guilds/{int(guild_id)}/bans/{int(user_id)}"), reason=reason)
+        await self.request(
+            Route("DELETE", "/guilds/{guild_id}/bans/{user_id}", guild_id=guild_id, user_id=user_id), reason=reason
+        )
 
     async def get_guild_prune_count(
         self,
@@ -316,7 +321,7 @@ class GuildRequests(CanRequest):
         }
         params = dict_filter_none(params)
 
-        result = await self.request(Route("GET", f"/guilds/{int(guild_id)}/prune"), params=params)
+        result = await self.request(Route("GET", "/guilds/{guild_id}/prune", guild_id=guild_id), params=params)
         return cast(dict, result)  # todo revisit, create TypedDict for pruned
 
     async def begin_guild_prune(
@@ -348,7 +353,9 @@ class GuildRequests(CanRequest):
         }
         payload = dict_filter_none(payload)
 
-        result = await self.request(Route("POST", f"/guilds/{int(guild_id)}/prune"), payload=payload, reason=reason)
+        result = await self.request(
+            Route("POST", "/guilds/{guild_id}/prune", guild_id=guild_id), payload=payload, reason=reason
+        )
         return cast(dict, result)  # todo revisit, create TypedDict for pruned
 
     async def get_guild_invites(self, guild_id: "Snowflake_Type") -> list[discord_typings.InviteData]:
@@ -362,7 +369,7 @@ class GuildRequests(CanRequest):
             List of invite objects
 
         """
-        result = await self.request(Route("GET", f"/guilds/{int(guild_id)}/invites"))
+        result = await self.request(Route("GET", "/guilds/{guild_id}/invites", guild_id=guild_id))
         return cast(list[discord_typings.InviteData], result)
 
     async def create_guild_role(
@@ -380,7 +387,9 @@ class GuildRequests(CanRequest):
             Role object
 
         """
-        result = await self.request(Route("POST", f"/guilds/{int(guild_id)}/roles"), payload=payload, reason=reason)
+        result = await self.request(
+            Route("POST", "/guilds/{guild_id}/roles", guild_id=guild_id), payload=payload, reason=reason
+        )
         return cast(discord_typings.RoleData, result)
 
     async def modify_guild_role_positions(
@@ -407,7 +416,9 @@ class GuildRequests(CanRequest):
         payload: PAYLOAD_TYPE = [
             {"id": int(role["id"]), "position": int(role["position"])} for role in position_changes
         ]
-        result = await self.request(Route("PATCH", f"/guilds/{int(guild_id)}/roles"), payload=payload, reason=reason)
+        result = await self.request(
+            Route("PATCH", "/guilds/{guild_id}/roles", guild_id=guild_id), payload=payload, reason=reason
+        )
         return cast(list[discord_typings.RoleData], result)
 
     async def modify_guild_role(
@@ -431,7 +442,7 @@ class GuildRequests(CanRequest):
 
         """
         result = await self.request(
-            Route("PATCH", f"/guilds/{int(guild_id)}/roles/{int(role_id)}"),
+            Route("PATCH", "/guilds/{guild_id}/roles/{role_id}", guild_id=guild_id, role_id=role_id),
             payload=payload,
             reason=reason,
         )
@@ -449,7 +460,9 @@ class GuildRequests(CanRequest):
             guild_id: The ID of the guild
 
         """
-        await self.request(Route("DELETE", f"/guilds/{int(guild_id)}/roles/{int(role_id)}"), reason=reason)
+        await self.request(
+            Route("DELETE", "/guilds/{guild_id}/roles/{role_id}", guild_id=guild_id, role_id=role_id), reason=reason
+        )
 
     async def get_audit_log(
         self,
@@ -484,7 +497,7 @@ class GuildRequests(CanRequest):
         }
         params = dict_filter_none(params)
 
-        result = await self.request(Route("GET", f"/guilds/{int(guild_id)}/audit-logs"), params=params)
+        result = await self.request(Route("GET", "/guilds/{guild_id}/audit-logs", guild_id=guild_id), params=params)
         return cast(discord_typings.AuditLogData, result)
 
     async def get_guild_voice_regions(self, guild_id: "Snowflake_Type") -> list[discord_typings.VoiceRegionData]:
@@ -498,7 +511,7 @@ class GuildRequests(CanRequest):
             List of voice region objects
 
         """
-        result = await self.request(Route("GET", f"/guilds/{int(guild_id)}/regions"))
+        result = await self.request(Route("GET", "/guilds/{guild_id}/regions", guild_id=guild_id))
         return cast(list[discord_typings.VoiceRegionData], result)
 
     async def get_guild_integrations(self, guild_id: "Snowflake_Type") -> list[discord_typings.IntegrationData]:
@@ -512,7 +525,7 @@ class GuildRequests(CanRequest):
             list of integration objects
 
         """
-        result = await self.request(Route("GET", f"/guilds/{int(guild_id)}/integrations"))
+        result = await self.request(Route("GET", "/guilds/{guild_id}/integrations", guild_id=guild_id))
         return cast(list[discord_typings.IntegrationData], result)
 
     async def delete_guild_integration(
@@ -531,7 +544,12 @@ class GuildRequests(CanRequest):
 
         """
         await self.request(
-            Route("DELETE", f"/guilds/{int(guild_id)}/integrations/{int(integration_id)}"),
+            Route(
+                "DELETE",
+                "/guilds/{guild_id}/integrations/{integration_id}",
+                guild_id=guild_id,
+                integration_id=integration_id,
+            ),
             reason=reason,
         )
 
@@ -546,7 +564,7 @@ class GuildRequests(CanRequest):
             guild widget object
 
         """
-        result = await self.request(Route("GET", f"/guilds/{int(guild_id)}/widget"))
+        result = await self.request(Route("GET", "/guilds/{guild_id}/widget", guild_id=guild_id))
         return cast(discord_typings.GuildWidgetSettingsData, result)
 
     async def get_guild_widget(self, guild_id: "Snowflake_Type") -> discord_typings.GuildWidgetData:
@@ -560,7 +578,7 @@ class GuildRequests(CanRequest):
             Guild widget
 
         """
-        result = await self.request(Route("GET", f"/guilds/{int(guild_id)}/widget.json"))
+        result = await self.request(Route("GET", "/guilds/{guild_id}/widget.json", guild_id=guild_id))
         return cast(discord_typings.GuildWidgetData, result)
 
     async def get_guild_widget_image(self, guild_id: "Snowflake_Type", style: str | None = None) -> str:
@@ -577,7 +595,9 @@ class GuildRequests(CanRequest):
             A url pointing to this image
 
         """
-        route = Route("GET", f"/guilds/{int(guild_id)}/widget.png{f'?style={style}' if style else ''}")
+        route = Route(
+            "GET", "/guilds/{guild_id}/widget.png{style}", guild_id=guild_id, style="?style={style}" if style else ""
+        )
         return route.url
 
     async def get_guild_welcome_screen(self, guild_id: "Snowflake_Type") -> discord_typings.WelcomeScreenData:
@@ -590,7 +610,7 @@ class GuildRequests(CanRequest):
             Welcome screen object
 
         """
-        result = await self.request(Route("GET", f"/guilds/{int(guild_id)}/welcome-screen"))
+        result = await self.request(Route("GET", "/guilds/{guild_id}/welcome-screen", guild_id=guild_id))
         return cast(discord_typings.WelcomeScreenData, result)
 
     async def get_guild_vanity_url(self, guild_id: "Snowflake_Type") -> dict:
@@ -604,7 +624,7 @@ class GuildRequests(CanRequest):
             Returns a partial invite object. Code is None if a vanity url for the guild is not set.
 
         """
-        result = await self.request(Route("GET", f"/guilds/{int(guild_id)}/vanity-url"))
+        result = await self.request(Route("GET", "/guilds/{guild_id}/vanity-url", guild_id=guild_id))
         return cast(dict, result)  # todo create typing?
 
     async def get_guild_channels(
@@ -619,7 +639,7 @@ class GuildRequests(CanRequest):
         Returns:
             A list of channels in this guild. Does not include threads.
         """
-        result = await self.request(Route("GET", f"/guilds/{int(guild_id)}/channels"))
+        result = await self.request(Route("GET", "/guilds/{guild_id}/channels", guild_id=guild_id))
         return cast(list[discord_typings.ChannelData], result)
 
     async def modify_guild_widget(
@@ -646,7 +666,7 @@ class GuildRequests(CanRequest):
         }
         payload = dict_filter_none(payload)
 
-        result = await self.request(Route("PATCH", f"/guilds/{int(guild_id)}/widget"), payload=payload)
+        result = await self.request(Route("PATCH", "/guilds/{guild_id}/widget", guild_id=guild_id), payload=payload)
         return cast(discord_typings.GuildWidgetData, result)
 
     async def modify_guild_welcome_screen(
@@ -674,7 +694,9 @@ class GuildRequests(CanRequest):
             "welcome_channels": [int(channel) for channel in welcome_channels],
             "description": description,
         }
-        result = await self.request(Route("PATCH", f"/guilds/{int(guild_id)}/welcome-screen"), payload=payload)
+        result = await self.request(
+            Route("PATCH", "/guilds/{guild_id}/welcome-screen", guild_id=guild_id), payload=payload
+        )
         return cast(discord_typings.WelcomeScreenData, result)
 
     async def modify_current_user_voice_state(
@@ -701,7 +723,7 @@ class GuildRequests(CanRequest):
         }
         payload = dict_filter_none(payload)
 
-        await self.request(Route("PATCH", f"/guilds/{int(guild_id)}/voice-states/@me"), payload=payload)
+        await self.request(Route("PATCH", "/guilds/{guild_id}/voice-states/@me", guild_id=guild_id), payload=payload)
 
     async def modify_user_voice_state(
         self,
@@ -726,7 +748,10 @@ class GuildRequests(CanRequest):
         }
         payload = dict_filter_none(payload)
 
-        await self.request(Route("PATCH", f"/guilds/{int(guild_id)}/voice-states/{user_id}"), payload=payload)
+        await self.request(
+            Route("PATCH", "/guilds/{guild_id}/voice-states/{user_id}", guild_id=guild_id, user_id=user_id),
+            payload=payload,
+        )
 
     async def create_guild(
         self,
@@ -780,7 +805,9 @@ class GuildRequests(CanRequest):
         """
         payload = {"name": name, "icon": icon}
 
-        result = await self.request(Route("POST", f"/guilds/templates/{template_code}"), payload=payload)
+        result = await self.request(
+            Route("POST", "/guilds/templates/{template_code}", template_code=template_code), payload=payload
+        )
         return cast(discord_typings.GuildData, result)
 
     async def get_guild_templates(self, guild_id: "Snowflake_Type") -> list[discord_typings.GuildTemplateData]:
@@ -794,7 +821,7 @@ class GuildRequests(CanRequest):
             An array of guild templates
 
         """
-        result = await self.request(Route("GET", f"/guilds/{int(guild_id)}/templates"))
+        result = await self.request(Route("GET", "/guilds/{guild_id}/templates", guild_id=guild_id))
         return cast(list[discord_typings.GuildTemplateData], result)
 
     async def create_guild_template(
@@ -815,7 +842,7 @@ class GuildRequests(CanRequest):
         payload = {"name": name, "description": description}
         payload = dict_filter_none(payload)
 
-        result = await self.request(Route("POST", f"/guilds/{int(guild_id)}/templates"), payload=payload)
+        result = await self.request(Route("POST", "/guilds/{guild_id}/templates", guild_id=guild_id), payload=payload)
         return cast(discord_typings.GuildTemplateData, result)
 
     async def sync_guild_template(
@@ -832,7 +859,9 @@ class GuildRequests(CanRequest):
             The updated guild template
 
         """
-        result = await self.request(Route("PUT", f"/guilds/{int(guild_id)}/templates/{template_code}"))
+        result = await self.request(
+            Route("PUT", "/guilds/{guild_id}/templates/{template_code}", guild_id=guild_id, template_code=template_code)
+        )
         return cast(discord_typings.GuildTemplateData, result)
 
     async def modify_guild_template(
@@ -859,7 +888,10 @@ class GuildRequests(CanRequest):
         payload = dict_filter_none(payload)
 
         result = await self.request(
-            Route("PATCH", f"/guilds/{int(guild_id)}/templates/{template_code}"), payload=payload
+            Route(
+                "PATCH", "/guilds/{guild_id}/templates/{template_code}", guild_id=guild_id, template_code=template_code
+            ),
+            payload=payload,
         )
         return cast(discord_typings.GuildTemplateData, result)
 
@@ -878,7 +910,11 @@ class GuildRequests(CanRequest):
 
         """
         # why on earth does this return the deleted template object?
-        result = await self.request(Route("DELETE", f"/guilds/{int(guild_id)}/templates/{template_code}"))
+        result = await self.request(
+            Route(
+                "DELETE", "/guilds/{guild_id}/templates/{template_code}", guild_id=guild_id, template_code=template_code
+            )
+        )
         return cast(discord_typings.GuildTemplateData, result)
 
     async def get_auto_moderation_rules(
@@ -893,7 +929,7 @@ class GuildRequests(CanRequest):
         Returns:
             A list of auto moderation rules
         """
-        result = await self.request(Route("GET", f"/guilds/{int(guild_id)}/auto-moderation/rules"))
+        result = await self.request(Route("GET", "/guilds/{guild_id}/auto-moderation/rules", guild_id=guild_id))
         return cast(list[dict], result)
 
     async def get_auto_moderation_rule(
@@ -909,7 +945,9 @@ class GuildRequests(CanRequest):
         Returns:
             The auto moderation rule
         """
-        result = await self.request(Route("GET", f"/guilds/{int(guild_id)}/auto-moderation/rules/{int(rule_id)}"))
+        result = await self.request(
+            Route("GET", "/guilds/{guild_id}/auto-moderation/rules/{rule_id}", guild_id=guild_id, rule_id=rule_id)
+        )
         return cast(dict, result)
 
     async def create_auto_moderation_rule(
@@ -925,7 +963,9 @@ class GuildRequests(CanRequest):
         Returns:
             The created auto moderation rule
         """
-        result = await self.request(Route("POST", f"/guilds/{int(guild_id)}/auto-moderation/rules"), payload=payload)
+        result = await self.request(
+            Route("POST", "/guilds/{guild_id}/auto-moderation/rules", guild_id=guild_id), payload=payload
+        )
         return cast(dict, result)
 
     async def modify_auto_moderation_rule(
@@ -974,7 +1014,7 @@ class GuildRequests(CanRequest):
         payload = dict_filter_none(payload)
 
         result = await self.request(
-            Route("PATCH", f"/guilds/{int(guild_id)}/auto-moderation/rules/{int(rule_id)}"),
+            Route("PATCH", "/guilds/{guild_id}/auto-moderation/rules/{rule_id}", guild_id=guild_id, rule_id=rule_id),
             payload=payload,
             reason=reason,
         )
@@ -992,7 +1032,7 @@ class GuildRequests(CanRequest):
             reason: The reason for deleting this rule
         """
         result = await self.request(
-            Route("DELETE", f"/guilds/{int(guild_id)}/auto-moderation/rules/{int(rule_id)}"),
+            Route("DELETE", "/guilds/{guild_id}/auto-moderation/rules/{rule_id}", guild_id=guild_id, rule_id=rule_id),
             reason=reason,
         )
         return cast(dict, result)

--- a/interactions/api/http/http_requests/interactions.py
+++ b/interactions/api/http/http_requests/interactions.py
@@ -31,12 +31,22 @@ class InteractionRequests(CanRequest):
 
         """
         if guild_id == GLOBAL_SCOPE:
-            await self.request(Route("DELETE", f"/applications/{int(application_id)}/commands/{int(command_id)}"))
+            await self.request(
+                Route(
+                    "DELETE",
+                    "/applications/{application_id}/commands/{command_id}",
+                    application_id=application_id,
+                    command_id=command_id,
+                )
+            )
         else:
             await self.request(
                 Route(
                     "DELETE",
-                    f"/applications/{int(application_id)}/guilds/{int(guild_id)}/commands/{int(command_id)}",
+                    "/applications/{application_id}/guilds/{guild_id}/commands/{command_id}",
+                    application_id=application_id,
+                    guild_id=guild_id,
+                    command_id=command_id,
                 )
             )
 
@@ -60,11 +70,16 @@ class InteractionRequests(CanRequest):
         """
         if guild_id == GLOBAL_SCOPE:
             return await self.request(
-                Route("GET", f"/applications/{application_id}/commands"),
+                Route("GET", "/applications/{application_id}/commands", application_id=application_id),
                 params={"with_localizations": int(with_localisations)},
             )
         return await self.request(
-            Route("GET", f"/applications/{application_id}/guilds/{guild_id}/commands"),
+            Route(
+                "GET",
+                "/applications/{application_id}/guilds/{guild_id}/commands",
+                application_id=application_id,
+                guild_id=guild_id,
+            ),
             params={"with_localizations": int(with_localisations)},
         )
 
@@ -81,10 +96,10 @@ class InteractionRequests(CanRequest):
 
         """
         if guild_id == GLOBAL_SCOPE:
-            result = await self.request(Route("PUT", f"/applications/{app_id}/commands"), payload=data)
+            result = await self.request(Route("PUT", "/applications/{app_id}/commands", app_id=app_id), payload=data)
         else:
             result = await self.request(
-                Route("PUT", f"/applications/{app_id}/guilds/{int(guild_id)}/commands"),
+                Route("PUT", "/applications/{app_id}/guilds/{guild_id}/commands", app_id=app_id, guild_id=guild_id),
                 payload=data,
             )
         return cast(list[discord_typings.ApplicationCommandData], result)
@@ -104,10 +119,12 @@ class InteractionRequests(CanRequest):
             An application command object
         """
         if guild_id == GLOBAL_SCOPE:
-            result = await self.request(Route("POST", f"/applications/{app_id}/commands"), payload=command)
+            result = await self.request(
+                Route("POST", "/applications/{app_id}/commands", app_id=app_id), payload=command
+            )
         else:
             result = await self.request(
-                Route("POST", f"/applications/{app_id}/guilds/{int(guild_id)}/commands"),
+                Route("POST", "/applications/{app_id}/guilds/{guild_id}/commands", app_id=app_id, guild_id=guild_id),
                 payload=command,
             )
         return cast(discord_typings.ApplicationCommandData, result)
@@ -130,7 +147,12 @@ class InteractionRequests(CanRequest):
 
         """
         return await self.request(
-            Route("POST", f"/interactions/{interaction_id}/{token}/callback"),
+            Route(
+                "POST",
+                "/interactions/{interaction_id}/{webhook_token}/callback",
+                interaction_id=interaction_id,
+                webhook_token=token,
+            ),
             payload=payload,
             files=files,
         )
@@ -153,7 +175,11 @@ class InteractionRequests(CanRequest):
 
         """
         return await self.request(
-            Route("POST", f"/webhooks/{int(application_id)}/{token}"), payload=payload, files=files
+            Route(
+                "POST", "/webhooks/{application_id}/{webhook_token}", application_id=application_id, webhook_token=token
+            ),
+            payload=payload,
+            files=files,
         )
 
     async def edit_interaction_message(
@@ -179,7 +205,13 @@ class InteractionRequests(CanRequest):
 
         """
         result = await self.request(
-            Route("PATCH", f"/webhooks/{int(application_id)}/{token}/messages/{message_id}"),
+            Route(
+                "PATCH",
+                "/webhooks/{application_id}/{webhook_token}/messages/{message_id}",
+                application_id=application_id,
+                webhook_token=token,
+                message_id=message_id,
+            ),
             payload=payload,
             files=files,
         )
@@ -200,7 +232,15 @@ class InteractionRequests(CanRequest):
             message_id: The target message to delete. Defaults to @original which represents the initial response message.
 
         """
-        return await self.request(Route("DELETE", f"/webhooks/{int(application_id)}/{token}/messages/{message_id}"))
+        return await self.request(
+            Route(
+                "DELETE",
+                "/webhooks/{application_id}/{webhook_token}/messages/{message_id}",
+                application_id=application_id,
+                webhook_token=token,
+                message_id=message_id,
+            )
+        )
 
     async def get_interaction_message(
         self, application_id: "Snowflake_Type", token: str, message_id: str = "@original"
@@ -217,7 +257,15 @@ class InteractionRequests(CanRequest):
             The message data.
 
         """
-        result = await self.request(Route("GET", f"/webhooks/{int(application_id)}/{token}/messages/{message_id}"))
+        result = await self.request(
+            Route(
+                "GET",
+                "/webhooks/{application_id}/{webhook_token}/messages/{message_id}",
+                application_id=application_id,
+                webhook_token=token,
+                message_id=message_id,
+            )
+        )
         return cast(discord_typings.MessageData, result)
 
     async def edit_application_command_permissions(
@@ -243,7 +291,7 @@ class InteractionRequests(CanRequest):
         result = await self.request(
             Route(
                 "PUT",
-                f"/applications/{int(application_id)}/guilds/{int(scope)}/commands/{int(command_id)}/permissions",
+                f"/applications/{application_id}/guilds/{scope}/commands/{command_id}/permissions",
             ),
             payload=permissions,
         )
@@ -270,7 +318,7 @@ class InteractionRequests(CanRequest):
         result = await self.request(
             Route(
                 "GET",
-                f"/applications/{int(application_id)}/guilds/{int(scope)}/commands/{int(command_id)}/permissions",
+                f"/applications/{application_id}/guilds/{scope}/commands/{command_id}/permissions",
             )
         )
         return cast(list[discord_typings.ApplicationCommandPermissionsData], result)
@@ -292,7 +340,7 @@ class InteractionRequests(CanRequest):
         result = await self.request(
             Route(
                 "GET",
-                f"/applications/{int(application_id)}/guilds/{int(scope)}/commands/permissions",
+                f"/applications/{application_id}/guilds/{scope}/commands/permissions",
             )
         )
         return cast(list[discord_typings.GuildApplicationCommandPermissionData], result)

--- a/interactions/api/http/http_requests/interactions.py
+++ b/interactions/api/http/http_requests/interactions.py
@@ -291,7 +291,10 @@ class InteractionRequests(CanRequest):
         result = await self.request(
             Route(
                 "PUT",
-                f"/applications/{application_id}/guilds/{scope}/commands/{command_id}/permissions",
+                "/applications/{application_id}/guilds/{guild_id}/commands/{command_id}/permissions",
+                application_id=application_id,
+                guild_id=scope,
+                command_id=command_id,
             ),
             payload=permissions,
         )
@@ -318,7 +321,10 @@ class InteractionRequests(CanRequest):
         result = await self.request(
             Route(
                 "GET",
-                f"/applications/{application_id}/guilds/{scope}/commands/{command_id}/permissions",
+                "/applications/{application_id}/guilds/{guild_id}/commands/{command_id}/permissions",
+                application_id=application_id,
+                guild_id=scope,
+                command_id=command_id,
             )
         )
         return cast(list[discord_typings.ApplicationCommandPermissionsData], result)
@@ -340,7 +346,9 @@ class InteractionRequests(CanRequest):
         result = await self.request(
             Route(
                 "GET",
-                f"/applications/{application_id}/guilds/{scope}/commands/permissions",
+                "/applications/{application_id}/guilds/{guild_id}/commands/permissions",
+                application_id=application_id,
+                guild_id=scope,
             )
         )
         return cast(list[discord_typings.GuildApplicationCommandPermissionData], result)

--- a/interactions/api/http/http_requests/members.py
+++ b/interactions/api/http/http_requests/members.py
@@ -28,7 +28,9 @@ class MemberRequests(CanRequest):
             user_id: The user id to grab
 
         """
-        result = await self.request(Route("GET", f"/guilds/{int(guild_id)}/members/{int(user_id)}"))
+        result = await self.request(
+            Route("GET", "/guilds/{guild_id}/members/{user_id}", guild_id=guild_id, user_id=user_id)
+        )
         return cast(discord_typings.GuildMemberData, result)
 
     async def list_members(
@@ -49,7 +51,7 @@ class MemberRequests(CanRequest):
         }
         payload = dict_filter_none(payload)
 
-        result = await self.request(Route("GET", f"/guilds/{int(guild_id)}/members"), params=payload)
+        result = await self.request(Route("GET", "/guilds/{guild_id}/members", guild_id=guild_id), params=payload)
         return cast(list[discord_typings.GuildMemberData], result)
 
     async def search_guild_members(
@@ -65,7 +67,7 @@ class MemberRequests(CanRequest):
 
         """
         result = await self.request(
-            Route("GET", f"/guilds/{int(guild_id)}/members/search"),
+            Route("GET", "/guilds/{guild_id}/members/search", guild_id=guild_id),
             params={"query": query, "limit": limit},
         )
         return cast(list[discord_typings.GuildMemberData], result)
@@ -117,7 +119,7 @@ class MemberRequests(CanRequest):
             payload["communication_disabled_until"] = communication_disabled_until
 
         result = await self.request(
-            Route("PATCH", f"/guilds/{int(guild_id)}/members/{int(user_id)}"),
+            Route("PATCH", "/guilds/{guild_id}/members/{user_id}", guild_id=guild_id, user_id=user_id),
             payload=payload,
             reason=reason,
         )
@@ -140,7 +142,7 @@ class MemberRequests(CanRequest):
         """
         payload: PAYLOAD_TYPE = {"nick": None if isinstance(nickname, Missing) else nickname}
         await self.request(
-            Route("PATCH", f"/guilds/{int(guild_id)}/members/@me"),
+            Route("PATCH", "/guilds/{guild_id}/members/@me", guild_id=guild_id),
             payload=payload,
             reason=reason,
         )
@@ -163,7 +165,13 @@ class MemberRequests(CanRequest):
 
         """
         await self.request(
-            Route("PUT", f"/guilds/{int(guild_id)}/members/{int(user_id)}/roles/{int(role_id)}"),
+            Route(
+                "PUT",
+                "/guilds/{guild_id}/members/{user_id}/roles/{role_id}",
+                guild_id=guild_id,
+                user_id=user_id,
+                role_id=role_id,
+            ),
             reason=reason,
         )
 
@@ -185,6 +193,12 @@ class MemberRequests(CanRequest):
 
         """
         await self.request(
-            Route("DELETE", f"/guilds/{int(guild_id)}/members/{int(user_id)}/roles/{int(role_id)}"),
+            Route(
+                "DELETE",
+                "/guilds/{guild_id}/members/{user_id}/roles/{role_id}",
+                guild_id=guild_id,
+                user_id=user_id,
+                role_id=role_id,
+            ),
             reason=reason,
         )

--- a/interactions/api/http/http_requests/messages.py
+++ b/interactions/api/http/http_requests/messages.py
@@ -33,7 +33,7 @@ class MessageRequests(CanRequest):
 
         """
         result = await self.request(
-            Route("POST", f"/channels/{int(channel_id)}/messages"), payload=payload, files=files
+            Route("POST", "/channels/{channel_id}/messages", channel_id=channel_id), payload=payload, files=files
         )
         return cast(discord_typings.MessageData, result)
 
@@ -50,7 +50,9 @@ class MessageRequests(CanRequest):
 
         """
         await self.request(
-            Route("DELETE", f"/channels/{int(channel_id)}/messages/{int(message_id)}"),
+            Route(
+                "DELETE", "/channels/{channel_id}/messages/{message_id}", channel_id=channel_id, message_id=message_id
+            ),
             reason=reason,
         )
 
@@ -72,7 +74,7 @@ class MessageRequests(CanRequest):
         payload = {"messages": [int(message_id) for message_id in message_ids]}
 
         await self.request(
-            Route("POST", f"/channels/{int(channel_id)}/messages/bulk-delete"),
+            Route("POST", "/channels/{channel_id}/messages/bulk-delete", channel_id=channel_id),
             payload=payload,
             reason=reason,
         )
@@ -91,7 +93,9 @@ class MessageRequests(CanRequest):
             message or None
 
         """
-        result = await self.request(Route("GET", f"/channels/{int(channel_id)}/messages/{int(message_id)}"))
+        result = await self.request(
+            Route("GET", "/channels/{channel_id}/messages/{message_id}", channel_id=channel_id, message_id=message_id)
+        )
         return cast(discord_typings.MessageData, result)
 
     async def pin_message(self, channel_id: "Snowflake_Type", message_id: "Snowflake_Type") -> None:
@@ -103,7 +107,9 @@ class MessageRequests(CanRequest):
             message_id: Message to pin
 
         """
-        await self.request(Route("PUT", f"/channels/{int(channel_id)}/pins/{int(message_id)}"))
+        await self.request(
+            Route("PUT", "/channels/{channel_id}/pins/{message_id}", channel_id=channel_id, message_id=message_id)
+        )
 
     async def unpin_message(self, channel_id: "Snowflake_Type", message_id: "Snowflake_Type") -> None:
         """
@@ -114,7 +120,9 @@ class MessageRequests(CanRequest):
             message_id: Message to unpin
 
         """
-        await self.request(Route("DELETE", f"/channels/{int(channel_id)}/pins/{int(message_id)}"))
+        await self.request(
+            Route("DELETE", "/channels/{channel_id}/pins/{message_id}", channel_id=channel_id, message_id=message_id)
+        )
 
     async def edit_message(
         self,
@@ -137,7 +145,9 @@ class MessageRequests(CanRequest):
 
         """
         result = await self.request(
-            Route("PATCH", f"/channels/{int(channel_id)}/messages/{int(message_id)}"),
+            Route(
+                "PATCH", "/channels/{channel_id}/messages/{message_id}", channel_id=channel_id, message_id=message_id
+            ),
             payload=payload,
             files=files,
         )
@@ -156,5 +166,12 @@ class MessageRequests(CanRequest):
             message object
 
         """
-        result = await self.request(Route("POST", f"/channels/{int(channel_id)}/messages/{int(message_id)}/crosspost"))
+        result = await self.request(
+            Route(
+                "POST",
+                "/channels/{channel_id}/messages/{message_id}/crosspost",
+                channel_id=channel_id,
+                message_id=message_id,
+            )
+        )
         return cast(discord_typings.MessageData, result)

--- a/interactions/api/http/http_requests/reactions.py
+++ b/interactions/api/http/http_requests/reactions.py
@@ -114,7 +114,14 @@ class ReactionRequests:
             message_id: The message to clear reactions from.
 
         """
-        return await self.request(Route("DELETE", f"/channels/{channel_id}/messages/{message_id}/reactions"))
+        return await self.request(
+            Route(
+                "DELETE",
+                "/channels/{channel_id}/messages/{message_id}/reactions",
+                channel_id=channel_id,
+                message_id=message_id,
+            )
+        )
 
     async def get_reactions(
         self,

--- a/interactions/api/http/http_requests/scheduled_events.py
+++ b/interactions/api/http/http_requests/scheduled_events.py
@@ -29,7 +29,12 @@ class ScheduledEventsRequests:
 
         """
         return await self.request(
-            Route("GET", f"/guilds/{guild_id}/scheduled-events?with_user_count={with_user_count}")
+            Route(
+                "GET",
+                "/guilds/{guild_id}/scheduled-events?with_user_count={with_user_count}",
+                guild_id=guild_id,
+                with_user_count=with_user_count,
+            )
         )
 
     async def get_scheduled_event(
@@ -51,7 +56,12 @@ class ScheduledEventsRequests:
 
         """
         return await self.request(
-            Route("GET", f"/guilds/{guild_id}/scheduled-events/{scheduled_event_id}"),
+            Route(
+                "GET",
+                "/guilds/{guild_id}/scheduled-events/{scheduled_event_id}",
+                guild_id=guild_id,
+                scheduled_event_id=scheduled_event_id,
+            ),
             params={"with_user_count": with_user_count},
         )
 
@@ -73,7 +83,9 @@ class ScheduledEventsRequests:
             Scheduled Event or None
 
         """
-        return await self.request(Route("POST", f"/guilds/{guild_id}/scheduled-events"), payload=payload, reason=reason)
+        return await self.request(
+            Route("POST", "/guilds/{guild_id}/scheduled-events", guild_id=guild_id), payload=payload, reason=reason
+        )
 
     async def modify_scheduled_event(
         self,
@@ -96,7 +108,12 @@ class ScheduledEventsRequests:
 
         """
         return await self.request(
-            Route("PATCH", f"/guilds/{guild_id}/scheduled-events/{scheduled_event_id}"),
+            Route(
+                "PATCH",
+                "/guilds/{guild_id}/scheduled-events/{scheduled_event_id}",
+                guild_id=guild_id,
+                scheduled_event_id=scheduled_event_id,
+            ),
             payload=payload,
             reason=reason,
         )
@@ -117,7 +134,12 @@ class ScheduledEventsRequests:
 
         """
         return await self.request(
-            Route("DELETE", f"/guilds/{guild_id}/scheduled-events/{scheduled_event_id}"),
+            Route(
+                "DELETE",
+                "/guilds/{guild_id}/scheduled-events/{scheduled_event_id}",
+                guild_id=guild_id,
+                scheduled_event_id=scheduled_event_id,
+            ),
             reason=reason,
         )
 
@@ -147,6 +169,11 @@ class ScheduledEventsRequests:
         """
         params = {"limit": limit, "with_member": with_member, "before": before, "after": after}
         return await self.request(
-            Route("GET", f"/guilds/{guild_id}/scheduled-events/{scheduled_event_id}/users"),
+            Route(
+                "GET",
+                "/guilds/{guild_id}/scheduled-events/{scheduled_event_id}/users",
+                guild_id=guild_id,
+                scheduled_event_id=scheduled_event_id,
+            ),
             params=params,
         )

--- a/interactions/api/http/http_requests/stickers.py
+++ b/interactions/api/http/http_requests/stickers.py
@@ -27,7 +27,7 @@ class StickerRequests:
             Sticker or None
 
         """
-        return await self.request(Route("GET", f"/stickers/{sticker_id}"))
+        return await self.request(Route("GET", "/stickers/{sticker_id}", sticker_id=sticker_id))
 
     async def list_nitro_sticker_packs(self) -> List[discord_typings.StickerPackData]:
         """
@@ -50,7 +50,7 @@ class StickerRequests:
             List of Stickers or None
 
         """
-        return await self.request(Route("GET", f"/guilds/{guild_id}/stickers"))
+        return await self.request(Route("GET", "/guilds/{guild_id}/stickers", guild_id=guild_id))
 
     async def get_guild_sticker(
         self, guild_id: "Snowflake_Type", sticker_id: "Snowflake_Type"
@@ -66,7 +66,9 @@ class StickerRequests:
             Sticker or None
 
         """
-        return await self.request(Route("GET", f"/guilds/{guild_id}/stickers/{sticker_id}"))
+        return await self.request(
+            Route("GET", "/guilds/{guild_id}/stickers/{sticker_id}", guild_id=guild_id, sticker_id=sticker_id)
+        )
 
     async def create_guild_sticker(
         self,
@@ -89,7 +91,7 @@ class StickerRequests:
 
         """
         return await self.request(
-            Route("POST", f"/guilds/{guild_id}/stickers"),
+            Route("POST", "/guilds/{guild_id}/stickers", guild_id=guild_id),
             payload=payload,
             files=[file],
             reason=reason,
@@ -116,7 +118,7 @@ class StickerRequests:
 
         """
         return await self.request(
-            Route("PATCH", f"/guilds/{guild_id}/stickers/{sticker_id}"),
+            Route("PATCH", "/guilds/{guild_id}/stickers/{sticker_id}", guild_id=guild_id, sticker_id=sticker_id),
             payload=payload,
             reason=reason,
         )
@@ -139,4 +141,7 @@ class StickerRequests:
             Returns 204 No Content on success.
 
         """
-        return await self.request(Route("DELETE", f"/guilds/{guild_id}/stickers/{sticker_id}"), reason=reason)
+        return await self.request(
+            Route("DELETE", "/guilds/{guild_id}/stickers/{sticker_id}", guild_id=guild_id, sticker_id=sticker_id),
+            reason=reason,
+        )

--- a/interactions/api/http/http_requests/threads.py
+++ b/interactions/api/http/http_requests/threads.py
@@ -27,7 +27,7 @@ class ThreadRequests:
             thread_id: The thread to join.
 
         """
-        return await self.request(Route("PUT", f"/channels/{thread_id}/thread-members/@me"))
+        return await self.request(Route("PUT", "/channels/{thread_id}/thread-members/@me", thread_id=thread_id))
 
     async def leave_thread(self, thread_id: "Snowflake_Type") -> None:
         """
@@ -37,7 +37,7 @@ class ThreadRequests:
             thread_id: The thread to leave.
 
         """
-        return await self.request(Route("DELETE", f"/channels/{thread_id}/thread-members/@me"))
+        return await self.request(Route("DELETE", "/channels/{thread_id}/thread-members/@me", thread_id=thread_id))
 
     async def add_thread_member(self, thread_id: "Snowflake_Type", user_id: "Snowflake_Type") -> None:
         """
@@ -48,7 +48,9 @@ class ThreadRequests:
             user_id: The ID of the user to add
 
         """
-        return await self.request(Route("PUT", f"/channels/{thread_id}/thread-members/{user_id}"))
+        return await self.request(
+            Route("PUT", "/channels/{thread_id}/thread-members/{user_id}", thread_id=thread_id, user_id=user_id)
+        )
 
     async def remove_thread_member(self, thread_id: "Snowflake_Type", user_id: "Snowflake_Type") -> None:
         """
@@ -59,7 +61,9 @@ class ThreadRequests:
             user_id: The ID of the user to remove
 
         """
-        return await self.request(Route("DELETE", f"/channels/{thread_id}/thread-members/{user_id}"))
+        return await self.request(
+            Route("DELETE", "/channels/{thread_id}/thread-members/{user_id}", thread_id=thread_id, user_id=user_id)
+        )
 
     async def list_thread_members(self, thread_id: "Snowflake_Type") -> List[discord_typings.ThreadMemberData]:
         """
@@ -72,7 +76,7 @@ class ThreadRequests:
             a list of member objects
 
         """
-        return await self.request(Route("GET", f"/channels/{thread_id}/thread-members"))
+        return await self.request(Route("GET", "/channels/{thread_id}/thread-members", thread_id=thread_id))
 
     async def list_public_archived_threads(
         self,
@@ -97,7 +101,9 @@ class ThreadRequests:
             payload["limit"] = limit
         if before:
             payload["before"] = Timestamp.from_snowflake(before).isoformat()
-        return await self.request(Route("GET", f"/channels/{channel_id}/threads/archived/public"), params=payload)
+        return await self.request(
+            Route("GET", "/channels/{channel_id}/threads/archived/public", channel_id=channel_id), params=payload
+        )
 
     async def list_private_archived_threads(
         self,
@@ -122,7 +128,9 @@ class ThreadRequests:
             payload["limit"] = limit
         if before:
             payload["before"] = Timestamp.from_snowflake(before).isoformat()
-        return await self.request(Route("GET", f"/channels/{channel_id}/threads/archived/private"), params=payload)
+        return await self.request(
+            Route("GET", "/channels/{channel_id}/threads/archived/private", channel_id=channel_id), params=payload
+        )
 
     async def list_joined_private_archived_threads(
         self,
@@ -148,7 +156,7 @@ class ThreadRequests:
         if before:
             payload["before"] = before
         return await self.request(
-            Route("GET", f"/channels/{channel_id}/users/@me/threads/archived/private"),
+            Route("GET", "/channels/{channel_id}/users/@me/threads/archived/private", channel_id=channel_id),
             params=payload,
         )
 
@@ -163,7 +171,7 @@ class ThreadRequests:
             A list of active threads
 
         """
-        return await self.request(Route("GET", f"/guilds/{guild_id}/threads/active"))
+        return await self.request(Route("GET", "/guilds/{guild_id}/threads/active", guild_id=guild_id))
 
     async def create_thread(
         self,
@@ -194,13 +202,20 @@ class ThreadRequests:
         payload = {"name": name, "auto_archive_duration": auto_archive_duration}
         if message_id:
             return await self.request(
-                Route("POST", f"/channels/{channel_id}/messages/{message_id}/threads"),
+                Route(
+                    "POST",
+                    "/channels/{channel_id}/messages/{message_id}/threads",
+                    channel_id=channel_id,
+                    message_id=message_id,
+                ),
                 payload=payload,
                 reason=reason,
             )
         payload["type"] = thread_type or ChannelType.GUILD_PUBLIC_THREAD
         payload["invitable"] = invitable
-        return await self.request(Route("POST", f"/channels/{channel_id}/threads"), payload=payload, reason=reason)
+        return await self.request(
+            Route("POST", "/channels/{channel_id}/threads", channel_id=channel_id), payload=payload, reason=reason
+        )
 
     async def create_forum_thread(
         self,
@@ -230,7 +245,7 @@ class ThreadRequests:
             The created thread object
         """
         return await self.request(
-            Route("POST", f"/channels/{channel_id}/threads"),
+            Route("POST", "/channels/{channel_id}/threads", channel_id=channel_id),
             payload={
                 "name": name,
                 "auto_archive_duration": auto_archive_duration,

--- a/interactions/api/http/http_requests/users.py
+++ b/interactions/api/http/http_requests/users.py
@@ -35,7 +35,7 @@ class UserRequests:
             The user object.
 
         """
-        return await self.request(Route("GET", f"/users/{user_id}"))
+        return await self.request(Route("GET", "/users/{user_id}", user_id=user_id))
 
     async def modify_client_user(self, payload: dict) -> discord_typings.UserData:
         """
@@ -64,7 +64,7 @@ class UserRequests:
             guild_id: The guild to leave from.
 
         """
-        return await self.request(Route("DELETE", f"/users/@me/guilds/{guild_id}"))
+        return await self.request(Route("DELETE", "/users/@me/guilds/{guild_id}", guild_id=guild_id))
 
     async def create_dm(self, recipient_id: "Snowflake_Type") -> discord_typings.DMChannelData:
         """
@@ -113,7 +113,7 @@ class UserRequests:
 
         """
         return await self.request(
-            Route("PUT", f"/channels/{channel_id}/recipients/{user_id}"),
+            Route("PUT", "/channels/{channel_id}/recipients/{user_id}", channel_id=channel_id, user_id=user_id),
             payload={"access_token": access_token, "nick": nick},
         )
 
@@ -126,7 +126,9 @@ class UserRequests:
             user_id: The ID of the user to remove
 
         """
-        return await self.request(Route("DELETE", f"/channels/{channel_id}/recipients/{user_id}"))
+        return await self.request(
+            Route("DELETE", "/channels/{channel_id}/recipients/{user_id}", channel_id=channel_id, user_id=user_id)
+        )
 
     async def modify_current_user_nick(self, guild_id: "Snowflake_Type", nickname: str = None) -> None:
         """
@@ -137,4 +139,6 @@ class UserRequests:
             nickname: The new nickname to use
 
         """
-        return await self.request(Route("PATCH", f"/guilds/{guild_id}/members/@me/nick"), payload={"nick": nickname})
+        return await self.request(
+            Route("PATCH", "/guilds/{guild_id}/members/@me/nick", guild_id=guild_id), payload={"nick": nickname}
+        )

--- a/interactions/api/http/http_requests/webhooks.py
+++ b/interactions/api/http/http_requests/webhooks.py
@@ -29,7 +29,7 @@ class WebhookRequests:
 
         """
         return await self.request(
-            Route("POST", f"/channels/{channel_id}/webhooks"),
+            Route("POST", "/channels/{channel_id}/webhooks", channel_id=channel_id),
             payload={"name": name, "avatar": avatar},
         )
 
@@ -44,7 +44,7 @@ class WebhookRequests:
             List of webhook objects
 
         """
-        return await self.request(Route("GET", f"/channels/{channel_id}/webhooks"))
+        return await self.request(Route("GET", "/channels/{channel_id}/webhooks", channel_id=channel_id))
 
     async def get_guild_webhooks(self, guild_id: "Snowflake_Type") -> List[discord_typings.WebhookData]:
         """
@@ -57,7 +57,7 @@ class WebhookRequests:
             List of webhook objects
 
         """
-        return await self.request(Route("GET", f"/guilds/{guild_id}/webhooks"))
+        return await self.request(Route("GET", "/guilds/{guild_id}/webhooks", guild_id=guild_id))
 
     async def get_webhook(self, webhook_id: "Snowflake_Type", webhook_token: str = None) -> discord_typings.WebhookData:
         """
@@ -142,7 +142,7 @@ class WebhookRequests:
 
         """
         return await self.request(
-            Route("POST", f"/webhooks/{webhook_id}/{webhook_token}"),
+            Route("POST", "/webhooks/{webhook_id}/{webhook_token}", webhook_id=webhook_id, webhook_token=webhook_token),
             params=dict_filter_none({"wait": "true" if wait else "false", "thread_id": thread_id}),
             payload=payload,
             files=files,
@@ -163,7 +163,15 @@ class WebhookRequests:
             A message object on success
 
         """
-        return await self.request(Route("GET", f"/webhooks/{webhook_id}/{webhook_token}/messages/{message_id}"))
+        return await self.request(
+            Route(
+                "GET",
+                "/webhooks/{webhook_id}/{webhook_token}/messages/{message_id}",
+                webhook_id=webhook_id,
+                webhook_token=webhook_token,
+                message_id=message_id,
+            )
+        )
 
     async def edit_webhook_message(
         self,
@@ -188,7 +196,13 @@ class WebhookRequests:
 
         """
         return await self.request(
-            Route("PATCH", f"/webhooks/{webhook_id}/{webhook_token}/messages/{message_id}"),
+            Route(
+                "PATCH",
+                "/webhooks/{webhook_id}/{webhook_token}/messages/{message_id}",
+                webhook_id=webhook_id,
+                webhook_token=webhook_token,
+                message_id=message_id,
+            ),
             payload=payload,
             files=files,
         )
@@ -205,4 +219,12 @@ class WebhookRequests:
             message_id: The ID of a message sent by this webhook
 
         """
-        return await self.request(Route("DELETE", f"/webhooks/{webhook_id}/{webhook_token}/messages/{message_id}"))
+        return await self.request(
+            Route(
+                "DELETE",
+                "/webhooks/{webhook_id}/{webhook_token}/messages/{message_id}",
+                webhook_id=webhook_id,
+                webhook_token=webhook_token,
+                message_id=message_id,
+            )
+        )

--- a/interactions/api/http/http_requests/webhooks.py
+++ b/interactions/api/http/http_requests/webhooks.py
@@ -71,9 +71,9 @@ class WebhookRequests:
             Webhook object
 
         """
-        endpoint = f"/webhooks/{webhook_id}{f'/{webhook_token}' if webhook_token else ''}"
+        endpoint = "/webhooks/{webhook_id}{f'/{webhook_token}' if webhook_token else ''}"
 
-        return await self.request(Route("GET", endpoint))
+        return await self.request(Route("GET", endpoint, webhook_id=webhook_id, webhook_token=webhook_token))
 
     async def modify_webhook(
         self,
@@ -94,10 +94,10 @@ class WebhookRequests:
             webhook_token: The token for the webhook
 
         """
-        endpoint = f"/webhooks/{webhook_id}{f'/{webhook_token}' if webhook_token else ''}"
+        endpoint = "/webhooks/{webhook_id}{f'/{webhook_token}' if webhook_token else ''}"
 
         return await self.request(
-            Route("PATCH", endpoint),
+            Route("PATCH", endpoint, webhook_id=webhook_id, webhook_token=webhook_token),
             payload={"name": name, "avatar": avatar, "channel_id": channel_id},
         )
 
@@ -113,9 +113,9 @@ class WebhookRequests:
             Webhook object
 
         """
-        endpoint = f"/webhooks/{webhook_id}{f'/{webhook_token}' if webhook_token else ''}"
+        endpoint = "/webhooks/{webhook_id}{f'/{webhook_token}' if webhook_token else ''}"
 
-        return await self.request(Route("DELETE", endpoint))
+        return await self.request(Route("DELETE", endpoint, webhook_id=webhook_id, webhook_token=webhook_token))
 
     async def execute_webhook(
         self,


### PR DESCRIPTION
## About

This PR rewrites all http methods to pass their params correctly, meaning rate limit buckets are properly generated and shared. 

Additionally, this also rewrites the BucketLock to allow for concurrent requests to the API, rather than queuing them sequentially, improving HTTPClient throughput for large bots. Smaller bots are very unlikely to notice a difference. 

## Checklist

- [x] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.
- [ ] I have added the `versionadded`, `versionchanged` and `deprecated` to any new or changed user-facing function I committed.
<!-- If you are unsure what the next version is, feel free to ask in #unstable at https://discord.gg/interactions -->

### Pull-Request specification

I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [ ] To add a new feature
  - [x] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [ ] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

<!--- Expand this when more comes up--->
