### PR TITLE
docs: fix typo in `typing` property

### DIFF
--- a/interactions/ext/prefixed_commands/context.py
+++ b/interactions/ext/prefixed_commands/context.py
@@ -69,7 +69,7 @@ class PrefixedContext(BaseContext, SendMixin):
 
     @property
     def typing(self) -> Typing:
-        """A context manager to send a typing state to the context's channel as long as long as the wrapped operation takes."""
+        """A context manager to send a typing state to the context's channel as long as the wrapped operation takes."""
         return self.channel.typing
 
     async def _send_http_request(self, message_payload: dict, files: Iterable["UPLOADABLE_TYPE"] | None = None) -> dict:


### PR DESCRIPTION
## About

Fixed typo in doc

## Checklist

- [x] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.
- [x] I have added the `versionadded`, `versionchanged` and `deprecated` to any new or changed user-facing function I committed.
<!-- If you are unsure what the next version is, feel free to ask in #unstable at https://discord.gg/interactions -->

### Pull-Request specification

I've made this pull request: (check all that apply)
  - [x] For the documentation
  - [ ] To add a new feature
  - [ ] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [ ] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

<!--- Expand this when more comes up--->
