### PR TITLE
feat: allow resuming session from cold boot

### DIFF
--- a/interactions/models/discord/color.py
+++ b/interactions/models/discord/color.py
@@ -43,6 +43,8 @@ class Color:
                 self.hex = color
             else:
                 self.value = BrandColors[color].value
+        elif isinstance(color, dict):
+            self.value = color["value"]
         else:
             raise TypeError
 

--- a/interactions/models/discord/guild.py
+++ b/interactions/models/discord/guild.py
@@ -229,8 +229,16 @@ class Guild(BaseGuild):
     _thread_ids: Set[Snowflake_Type] = attrs.field(repr=False, factory=set)
     _member_ids: Set[Snowflake_Type] = attrs.field(repr=False, factory=set)
     _role_ids: Set[Snowflake_Type] = attrs.field(repr=False, factory=set)
-    _chunk_cache: list = attrs.field(repr=False, factory=list)
-    _channel_gui_positions: Dict[Snowflake_Type, int] = attrs.field(repr=False, factory=dict)
+    _chunk_cache: list = attrs.field(repr=False, factory=list, metadata=no_export_meta)
+    _channel_gui_positions: Dict[Snowflake_Type, int] = attrs.field(repr=False, factory=dict, metadata=no_export_meta)
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = super().to_dict()
+        data["owner_id"] = self._owner_id
+        data["channels"] = [c.to_dict() for c in self.channels]
+        data["threads"] = [t.to_dict() for t in self.threads]
+        data["roles"] = [r.to_dict() for r in self.roles]
+        return data
 
     @classmethod
     def _process_dict(cls, data: Dict[str, Any], client: "Client") -> Dict[str, Any]:

--- a/interactions/models/discord/user.py
+++ b/interactions/models/discord/user.py
@@ -330,6 +330,12 @@ class Member(DiscordObject, _SendDMMixin):
 
         return data
 
+    def to_dict(self) -> Dict[str, Any]:
+        data = super().to_dict()
+        data["roles"] = data.pop("role_ids", [])
+        data.pop("_user_ref", None)
+        return data
+
     def update_from_dict(self, data) -> None:
         if "guild_id" not in data:
             data["guild_id"] = self._guild_id


### PR DESCRIPTION
## About

Prototype implementation to allow bots to resume their session after a graceful shutdown. 

Usage:
```python
bot = Client(
    resume_state_path="data",
    ...)

async def some_cmd(...):
    await bot.stop(resumable=True)
```

This works by serializing all pertinent information to a JSON file at the specified path - then deserializing this on startup. Once deserialized, `startup` and `ready` events fire as normal. 

## Checklist

- [x] The ``pre-commit`` code linter has been run over all edited files to ensure the code is linted.
- [x] I've ensured the change(s) work on `3.8.6` and higher.
- [ ] I have added the `versionadded`, `versionchanged` and `deprecated` to any new or changed user-facing function I committed.
<!-- If you are unsure what the next version is, feel free to ask in #unstable at https://discord.gg/interactions -->

### Pull-Request specification

I've made this pull request: (check all that apply)
  - [ ] For the documentation
  - [x] To add a new feature
  - [ ] As a general enhancement
  - [ ] As a refactor of the library/the library's code
  - [ ] To fix an existing bug
  - [ ] To resolve #ISSUENUMBER


This is:
  - [ ] A breaking change

<!--- Expand this when more comes up--->
