### PR TITLE
fix: copy checks when inheriting

### DIFF
--- a/interactions/models/internal/application_commands.py
+++ b/interactions/models/internal/application_commands.py
@@ -721,7 +721,7 @@ class SlashCommand(InteractionCommand):
             group_description=description,
             scopes=self.scopes,
             dm_permission=self.dm_permission,
-            checks=self.checks if inherit_checks else [],
+            checks=self.checks.copy() if inherit_checks else [],
         )
 
     def subcommand(
@@ -758,7 +758,7 @@ class SlashCommand(InteractionCommand):
                 callback=call,
                 scopes=self.scopes,
                 nsfw=nsfw,
-                checks=self.checks if inherit_checks else [],
+                checks=self.checks.copy() if inherit_checks else [],
             )
 
         return wrapper


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
When inheriting checks, slash commands would pass in their own checks to the subcommand. This makes sense logically, however, what wasn't being caught was that these were being passed *by reference*, and so *any edit to the checks in one subcommand would affect potentially EVERY command.*

This PR fixes that by passing in a copy instead, preventing this bug.

*This PR is arguably very urgent. The bug introduces unsafe behavior that could have devastating consequences if users don't understand it.*

## Changes
- Pass in a copy of the checks list when making groups/subcommands if inheriting.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios

- Make subcommands with the default options (`inherit_checks` should be `True`). Any of the methods will do.
- Add a check to one subcommand.
- Verify that the other subcommands have the same check.

## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [x] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
