### PR TITLE
feat: add reset_with_key and get_cooldown_time_with_key

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -34,7 +34,7 @@ In addition to core functionality, interactions.py provides a range of optional 
 
 So the base library doesn't do what you want? No problem! With builtin extensions, you are able to extend the functionality of the library. And if none of those pique your interest, there are a myriad of other extension libraries available.
 
-Just type `bot.load_extension("extension")`
+Just type `bot.load("extension")`
 
 ---
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -34,7 +34,7 @@ In addition to core functionality, interactions.py provides a range of optional 
 
 So the base library doesn't do what you want? No problem! With builtin extensions, you are able to extend the functionality of the library. And if none of those pique your interest, there are a myriad of other extension libraries available.
 
-Just type `bot.load("extension")`
+Just type `bot.load_extension("extension")`
 
 ---
 

--- a/interactions/models/internal/cooldowns.py
+++ b/interactions/models/internal/cooldowns.py
@@ -401,8 +401,7 @@ class Cooldown:
         cooldown = await self.get_cooldown_with_key(key, create=create)
         if cooldown is not None:
             return cooldown.get_cooldown_time()
-        else:
-            return 0
+        return 0
 
     async def on_cooldown(self, context: "BaseContext") -> bool:
         """
@@ -457,8 +456,7 @@ class Cooldown:
         if cooldown is not None:
             cooldown.reset()
             return True
-        else:
-            return False
+        return False
 
 
 class MaxConcurrency:

--- a/interactions/models/internal/cooldowns.py
+++ b/interactions/models/internal/cooldowns.py
@@ -398,13 +398,11 @@ class Cooldown:
             key: The key to get the cooldown system for
             create: Whether to create a new cooldown system if one does not exist
         """
-
         cooldown = await self.get_cooldown_with_key(key, create=create)
         if cooldown is not None:
             return cooldown.get_cooldown_time()
         else:
             return 0
-
 
     async def on_cooldown(self, context: "BaseContext") -> bool:
         """
@@ -455,7 +453,6 @@ class Cooldown:
         Returns:
             True if the key existed and was reset successfully, False if the key didn't exist.
         """
-
         cooldown = await self.get_cooldown_with_key(key)
         if cooldown is not None:
             cooldown.reset()

--- a/interactions/models/internal/cooldowns.py
+++ b/interactions/models/internal/cooldowns.py
@@ -341,7 +341,7 @@ class Cooldown:
             return cooldown
         return self.cooldown_repositories.get(await self.bucket(context))
 
-    async def get_cooldown_with_key(self, key: Any, *, create: bool = False) -> typing.Optional["CooldownSystem"]:
+    def get_cooldown_with_key(self, key: Any, *, create: bool = False) -> typing.Optional["CooldownSystem"]:
         """
         Get the cooldown system for the command.
 
@@ -398,7 +398,7 @@ class Cooldown:
             key: The key to get the cooldown system for
             create: Whether to create a new cooldown system if one does not exist
         """
-        cooldown = await self.get_cooldown_with_key(key, create=create)
+        cooldown = self.get_cooldown_with_key(key, create=create)
         if cooldown is not None:
             return cooldown.get_cooldown_time()
         return 0
@@ -417,7 +417,7 @@ class Cooldown:
         cooldown = await self.get_cooldown(context)
         return cooldown.on_cooldown()
 
-    async def reset_all(self) -> None:
+    def reset_all(self) -> None:
         """
         Resets this cooldown system to its initial state.
 
@@ -425,7 +425,6 @@ class Cooldown:
         for this command to their initial states
 
         """
-        # this doesnt need to be async, but for consistency, it is
         self.cooldown_repositories = {}
 
     async def reset(self, context: "BaseContext") -> None:
@@ -452,7 +451,7 @@ class Cooldown:
         Returns:
             True if the key existed and was reset successfully, False if the key didn't exist.
         """
-        cooldown = await self.get_cooldown_with_key(key)
+        cooldown = self.get_cooldown_with_key(key)
         if cooldown is not None:
             cooldown.reset()
             return True

--- a/interactions/models/internal/cooldowns.py
+++ b/interactions/models/internal/cooldowns.py
@@ -417,7 +417,7 @@ class Cooldown:
         cooldown = await self.get_cooldown(context)
         return cooldown.on_cooldown()
 
-    def reset_all(self) -> None:
+    async def reset_all(self) -> None:
         """
         Resets this cooldown system to its initial state.
 
@@ -425,6 +425,7 @@ class Cooldown:
         for this command to their initial states
 
         """
+        # this doesnt need to be async, but for consistency, it is
         self.cooldown_repositories = {}
 
     async def reset(self, context: "BaseContext") -> None:

--- a/interactions/models/internal/cooldowns.py
+++ b/interactions/models/internal/cooldowns.py
@@ -341,7 +341,7 @@ class Cooldown:
             return cooldown
         return self.cooldown_repositories.get(await self.bucket(context))
 
-    def get_cooldown_with_key(self, key: Any, *, create: bool = False) -> typing.Optional["CooldownSystem"]:
+    async def get_cooldown_with_key(self, key: Any, *, create: bool = False) -> typing.Optional["CooldownSystem"]:
         """
         Get the cooldown system for the command.
 
@@ -387,6 +387,25 @@ class Cooldown:
         cooldown = await self.get_cooldown(context)
         return cooldown.get_cooldown_time()
 
+    async def get_cooldown_time_with_key(self, key: Any, *, create: bool = False) -> float:
+        """
+        Get the remaining cooldown time with a key instead of the context.
+
+        Note:
+            The preferred way to get the cooldown system is to use `get_cooldown` as it will use the context to get the correct key.
+
+        Args:
+            key: The key to get the cooldown system for
+            create: Whether to create a new cooldown system if one does not exist
+        """
+
+        cooldown = await self.get_cooldown_with_key(key, create=create)
+        if cooldown is not None:
+            return cooldown.get_cooldown_time()
+        else:
+            return 0
+
+
     async def on_cooldown(self, context: "BaseContext") -> bool:
         """
         Returns the cooldown state of the command.
@@ -422,6 +441,27 @@ class Cooldown:
         """
         cooldown = await self.get_cooldown(context)
         cooldown.reset()
+
+    async def reset_with_key(self, key: Any) -> bool:
+        """
+        Resets the cooldown for the bucket associated with the provided key.
+
+        Note:
+            The preferred way to reset the cooldown system is to use `reset_cooldown` as it will use the context to reset the correct cooldown.
+
+        Args:
+            key: The key to reset the cooldown system for
+
+        Returns:
+            True if the key existed and was reset successfully, False if the key didn't exist.
+        """
+
+        cooldown = await self.get_cooldown_with_key(key)
+        if cooldown is not None:
+            cooldown.reset()
+            return True
+        else:
+            return False
 
 
 class MaxConcurrency:

--- a/interactions/models/internal/cooldowns.py
+++ b/interactions/models/internal/cooldowns.py
@@ -387,7 +387,7 @@ class Cooldown:
         cooldown = await self.get_cooldown(context)
         return cooldown.get_cooldown_time()
 
-    async def get_cooldown_time_with_key(self, key: Any, *, create: bool = False) -> float:
+    def get_cooldown_time_with_key(self, key: Any, *, create: bool = False) -> float:
         """
         Get the remaining cooldown time with a key instead of the context.
 
@@ -439,7 +439,7 @@ class Cooldown:
         cooldown = await self.get_cooldown(context)
         cooldown.reset()
 
-    async def reset_with_key(self, key: Any) -> bool:
+    def reset_with_key(self, key: Any) -> bool:
         """
         Resets the cooldown for the bucket associated with the provided key.
 


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [x] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [x] Other: For consistency, get_cooldown_with_key is async

## Description
<!-- Provide a clear and concise description of the purpose of this PR and why it should be merged -->
<!-- If your code adds or changes features, a usage example would be helpful -->
Cooldown resets with keys was a problem I had earlier; this solution is useful.
I made get_cooldown_with_key async for consistency as I said, so one doesn't have to remember which one is which.

`await command.cooldown.reset_with_key(other_user)`
`await command.cooldown.get_cooldown_time_with_key(other_user)`

vsc pylance did NOT complain.

## Changes
<!-- List the changes you have made in a bullet-point format -->
- made get_cooldown_with_key async
-  added reset_with_key
- added get_cooldown_time_with_key

## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->
none

## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->

none
## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x` (I don't have an installation of this.)
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files (couldn't install idk why but vsc pylance gave no problems) (Github pre-commit workflow)
- [x] I've tested my changes on supported Python versions (3.11)
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
