### PR TITLE
docs: adjust and fix many parts of the docs

### DIFF
--- a/docs/src/API Reference/API Reference/models/Internal/active_voice_state.md
+++ b/docs/src/API Reference/API Reference/models/Internal/active_voice_state.md
@@ -1,12 +1,12 @@
 ??? Hint "Example Usage:"
     ```python
-    from interactions import slash_command, slash_option, OptionType, InteractionContext
+    from interactions import slash_command, slash_option, OptionType, SlashContext
     from interactions.api.voice.audio import AudioVolume
 
 
     @slash_command("play")
     @slash_option("song", "The song to play", OptionType.STRING, required=True)
-    async def test_cmd(ctx: InteractionContext, song: str):
+    async def test_cmd(ctx: SlashContext, song: str):
         await ctx.defer()
 
         if not ctx.voice_state:

--- a/docs/src/Guides/02 Creating Your Bot.md
+++ b/docs/src/Guides/02 Creating Your Bot.md
@@ -12,7 +12,7 @@ To make a bot on Discord, you must first create an application on Discord. Thank
 4. Give your application a name, and press `Create`
     <br>![Create Application Dialogue](../images/CreatingYourBot/CreateAnApplication.png "The Create Application Dialogue")
 
-    ??? note
+    ???+ note
         Don't worry if there isn't a `team` option, this only appears if you have a developer team.
         If you have a team and want to assign your bot to it, use this.
 
@@ -22,7 +22,7 @@ To make a bot on Discord, you must first create an application on Discord. Thank
 6. You now have a bot! You're going to want to press `Reset Token` to get your bot's token, so you can start coding
     <br>![A section that shows your bot and its token](../images/CreatingYourBot/BotUserToken.png "The bot display")
 
-    ??? note
+    ???+ note
         You may (or may not) be asked to enter your password or 2FA authentication code to confirm this action.
 
     !!! warning "Warning: Do not share your token!"

--- a/docs/src/Guides/04 Context Menus.md
+++ b/docs/src/Guides/04 Context Menus.md
@@ -14,6 +14,8 @@ These open up if you right-click a message and choose `Apps`.
 This example repeats the selected message:
 
 ```python
+from interactions import ContextMenuContext, Message, message_context_menu
+
 @message_context_menu(name="repeat")
 async def repeat(ctx: ContextMenuContext):
     message: Message = ctx.target
@@ -27,10 +29,12 @@ These open up if you right-click a user and choose `Apps`.
 This example pings the user:
 
 ```python
+from interactions import user_context_menu, Member
+
 @user_context_menu(name="ping")
 async def ping(ctx: ContextMenuContext):
     member: Member = ctx.target
     await ctx.send(member.mention)
 ```
-??? note
+???+ note
     Unlike Slash command names, context menu command names **can** be uppercase, contain special symbols and spaces.

--- a/docs/src/Guides/05 Components.md
+++ b/docs/src/Guides/05 Components.md
@@ -10,6 +10,8 @@ If you want to define the layout yourself, you have to put them in an `ActionRow
 
 === ":one: `ActionRow()`"
     ```python
+    from interactions import ActionRow, Button
+
     components: list[ActionRow] = [
         ActionRow(
             Button(
@@ -28,6 +30,8 @@ If you want to define the layout yourself, you have to put them in an `ActionRow
 
 === ":two: `spread_to_rows()`"
     ```python
+    from interactions import ActionRow, Button, spread_to_rows
+
     components: list[ActionRow] = spread_to_rows(
         Button(
             style=ButtonStyle.GREEN,
@@ -47,6 +51,8 @@ If you want to define the layout yourself, you have to put them in an `ActionRow
     We will put it in an `ActionRow` behind the scenes.
 
     ```python
+    from interactions import Button
+
     components = Button(
         style=ButtonStyle.GREEN,
         label="Click Me",
@@ -84,6 +90,8 @@ The colours correspond to the styles found in `ButtonStyle`. Click [here](/inter
 
 If you use `ButtonStyle.URL`, you can pass an url to the button with `url`. Users who click the button will get redirected to your url.
 ```python
+from interactions import ButtonStyle
+
 components = Button(
     style=ButtonStyle.URL,
     label="Click Me",
@@ -117,7 +125,7 @@ components = StringSelectMenu(
 
 await channel.send("Look a Select!", components=components)
 ```
-??? note
+???+ note
     You can only have upto 25 options in a Select
 
 Alternatively, you can use `RoleSelectMenu`, `UserSelectMenu` and `ChannelSelectMenu` to select roles, users and channels respectively. These select menus are very similar to `StringSelectMenu`, but they don't allow you to pass a list of options; it's all done behind the scenes.
@@ -142,6 +150,8 @@ When responding to a component you need to satisfy discord either by responding 
     In this example, we are checking that the username starts with "a" and clicks the button within 30 seconds.
     If it times out, we're just gonna disable it
     ```python
+    from asyncio import TimeoutError
+
     components = Button(
         custom_id="my_button_id",
         style=ButtonStyle.GREEN,
@@ -178,6 +188,8 @@ When responding to a component you need to satisfy discord either by responding 
     You can listen to the `on_component()` event and then handle your callback. This works even after restarts!
 
     ```python
+    from interactions.api.events import Component
+
     async def my_command(...):
         components = Button(
             custom_id="my_button_id",
@@ -204,6 +216,8 @@ When responding to a component you need to satisfy discord either by responding 
     You have to pass your `custom_id` to `@component_callback(custom_id)` for the library to be able to register the callback function to the wanted component.
 
     ```python
+    from interactions import component_callback, ComponentContext
+
     async def my_command(...):
         components = Button(
             custom_id="my_button_id",
@@ -225,6 +239,8 @@ When responding to a component you need to satisfy discord either by responding 
     For this example to work, the function name needs to be the same as the `custom_id` of the component.
 
     ```python
+    from interactions import ComponentCommand, ComponentContext
+
     async def my_command(...):
         components = Button(
             custom_id="my_button_id",
@@ -255,8 +271,11 @@ When responding to a component you need to satisfy discord either by responding 
     Ah, I see you are a masochist. You want to use regex to match your custom_ids. Well who am I to stop you?
 
     ```python
+    import re
+    from interactions import component_callback, ComponentContext
+
     @component_callback(re.compile(r"\w*"))
-    async def test_callback(ctx: interactions.ComponentContext):
+    async def test_callback(ctx: ComponentContext):
         await ctx.send(f"Clicked {ctx.custom_id}")
     ```
 

--- a/docs/src/Guides/08 Converters.md
+++ b/docs/src/Guides/08 Converters.md
@@ -27,12 +27,12 @@ class DatabaseEntry():
     required=True,
     opt_type=OptionType.STRING
 )
-async def my_command_function(ctx: InteractionContext, thing: DatabaseEntry):
+async def my_command_function(ctx: SlashContext, thing: DatabaseEntry):
     await ctx.send(f"***{thing.name}***\n{thing.description}\nScore: {thing.score}/10")
 
 # Prefixed Command:
 @prefixed_command()
-async def my_command_function(ctx: InteractionContext, thing: DatabaseEntry):
+async def my_command_function(ctx: SlashContext, thing: DatabaseEntry):
     await ctx.reply(f"***{thing.name}***\n{thing.description}\nScore: {thing.score}/10")
 ```
 
@@ -57,7 +57,7 @@ class UpperConverter(Converter):
     required=True,
     opt_type=OptionType.STRING
 )
-async def upper(ctx: InteractionContext, to_upper: UpperConverter):
+async def upper(ctx: SlashContext, to_upper: UpperConverter):
     await ctx.send(to_upper)
 
 # Prefixed Command:
@@ -118,7 +118,7 @@ class UpperConverter(Converter):
     required=True,
     opt_type=OptionType.STRING
 )
-async def upper(ctx: InteractionContext, to_upper: Annotated[str, UpperConverter]):
+async def upper(ctx: SlashContext, to_upper: Annotated[str, UpperConverter]):
     await ctx.send(to_upper)
 
 # Prefixed Command:

--- a/docs/src/Guides/08 Converters.md
+++ b/docs/src/Guides/08 Converters.md
@@ -43,6 +43,8 @@ As you can see, a converter can transparently convert what Discord sends you (a 
 You may also use the `Converter` class that `interactions.py` has as well.
 
 ```python
+from interactions import Converter
+
 class UpperConverter(Converter):
     async def convert(ctx: BaseContext, argument: str):
         return argument.upper()
@@ -102,6 +104,8 @@ A table of objects and their respective converter is as follows:
 Using `typing.Annotated` can allow you to have more proper typehints when using converters:
 
 ```python
+from typing import Annotated
+
 class UpperConverter(Converter):
     async def convert(ctx: BaseContext, argument: str):
         return argument.upper()

--- a/docs/src/Guides/10 Events.md
+++ b/docs/src/Guides/10 Events.md
@@ -30,18 +30,15 @@ Be aware that your `Intents` must be set to receive the event you are looking fo
 There are two ways to register events. **Decorators** are the recommended way to do this.
 
 === ":one: Decorators"
-    To use decorators, they need to be in the same file where you defined your `bot = Client()`.
-
     ```python
-    bot = Client(intents=Intents.DEFAULT)
+    from interactions import listen
+    from interactions.api.events import ChannelCreate
 
     @listen()
     async def on_channel_create(event: ChannelCreate):
         # this event is called when a channel is created in a guild where the bot is
 
         print(f"Channel created with name: {event.channel.name}")
-
-    bot.start("Put your token here")
     ```
 
     You can also use `@listen` with any function names:
@@ -67,6 +64,9 @@ There are two ways to register events. **Decorators** are the recommended way to
     You can also register the events manually. This gives you the most flexibility, but it's not the cleanest.
 
     ```python
+    from interactions import Listener
+    from interactions.api.events import ChannelCreate
+
     async def on_channel_create(event: ChannelCreate):
         # this event is called when a channel is created in a guild where the bot is
 

--- a/docs/src/Guides/100 Migration From D.py.md
+++ b/docs/src/Guides/100 Migration From D.py.md
@@ -27,5 +27,5 @@
      - If you wish to keep using prefixed commands (sometimes called message or text-based commands), you can use our prefixed command extension, which has an [extensive guide for them](/Guides/07 Creating Prefixed Commands). The syntax should be very similar to discord.py with a few exceptions.
      - If you were manually handling commands with `on_message`, you'll probably need to figure it out yourself, as this guide doesn't know how you wrote your parser.  Consider using the provided command handlers.
 
-??? Note
+???+ Note
     This guide was written based on the experiences of porting a small handful of bots.  There may be gotchas that we did not encounter.  If you run into anything you'd like to have known, let us know in our Discord, and we'll add it to this document.

--- a/docs/src/Guides/20 Extensions.md
+++ b/docs/src/Guides/20 Extensions.md
@@ -20,8 +20,6 @@ Below is an example of a bot, one with extensions, one without.
 
         import interactions.const
         from interactions.client import Client
-        from interactions.models.application_commands import slash_command, slash_option
-        from interactions.models.context import InteractionContext
         from interactions.models.discord_objects.components import Button, ActionRow
         from interactions.models.enums import ButtonStyle
         from interactions.models.enums import Intents

--- a/docs/src/Guides/23 Voice.md
+++ b/docs/src/Guides/23 Voice.md
@@ -48,7 +48,7 @@ from interactions.api.voice.audio import AudioVolume
 
 @interactions.slash_command("play", "play a song!")
 @interactions.slash_option("song", "The song to play", 3, True)
-async def play(self, ctx: interactions.InteractionContext, song: str):
+async def play(self, ctx: interactions.SlashContext, song: str):
     if not ctx.voice_state:
         # if we haven't already joined a voice channel
         # join the authors vc
@@ -78,7 +78,7 @@ from interactions.api.voice.audio import AudioVolume
 
 
 @interactions.slash_command("play", "play a song!")
-async def play_file(ctx: interactions.InteractionContext):
+async def play_file(ctx: interactions.SlashContext):
     audio = AudioVolume("some_file.wav")
     await ctx.voice_state.play(audio)
 ```
@@ -96,7 +96,7 @@ import asyncio
 import interactions
 
 @interactions.slash_command("record", "record some audio")
-async def record(ctx: interactions.InteractionContext):
+async def record(ctx: interactions.SlashContext):
     voice_state = await ctx.author.voice.channel.connect()
 
     # Start recording

--- a/docs/src/Guides/24 Localisation.md
+++ b/docs/src/Guides/24 Localisation.md
@@ -13,7 +13,7 @@ Let's take this nice and simple `hello` command
 import interactions
 
 @interactions.slash_command(name="hello")
-async def hello_cmd(ctx: interactions.InteractionContext):
+async def hello_cmd(ctx: interactions.SlashContext):
     await ctx.send(f"Hello {ctx.author.display_name}")
 ```
 This command was immensely popular, and now we have some 🇫🇷 French users. Wouldn't it be nice if we could speak their language.
@@ -23,7 +23,7 @@ import interactions
 from interactions import LocalisedName
 
 @interactions.slash_command(name=LocalisedName(english_us="hello", french="salut"))
-async def hello_cmd(ctx: interactions.InteractionContext):
+async def hello_cmd(ctx: interactions.SlashContext):
     await ctx.send(f"Hello {ctx.author.display_name}")
 ```
 All we need to do is set the field to a `Localised` object, and interactions.py and discord wil handle the rest for you.
@@ -34,7 +34,7 @@ import interactions
 from interactions import LocalisedName
 
 @interactions.slash_command(name=LocalisedName(english_us="hello", french="salut"))
-async def hello_cmd(ctx: interactions.InteractionContext):
+async def hello_cmd(ctx: interactions.SlashContext):
     await ctx.send(f"{ctx.invoked_name} {ctx.author.display_name}")
 ```
 Simply by changing `"hello"` to `ctx.invoked_name` the command will always use whatever the user typed to greet them.

--- a/docs/src/Guides/24 Localisation.md
+++ b/docs/src/Guides/24 Localisation.md
@@ -12,7 +12,6 @@ Let's take this nice and simple `hello` command
 ```python
 import interactions
 
-
 @interactions.slash_command(name="hello")
 async def hello_cmd(ctx: interactions.InteractionContext):
     await ctx.send(f"Hello {ctx.author.display_name}")
@@ -22,7 +21,6 @@ This command was immensely popular, and now we have some 🇫🇷 French users. 
 ```python
 import interactions
 from interactions import LocalisedName
-
 
 @interactions.slash_command(name=LocalisedName(english_us="hello", french="salut"))
 async def hello_cmd(ctx: interactions.InteractionContext):
@@ -34,7 +32,6 @@ For extra flavour lets make this command more dynamic.
 ```python
 import interactions
 from interactions import LocalisedName
-
 
 @interactions.slash_command(name=LocalisedName(english_us="hello", french="salut"))
 async def hello_cmd(ctx: interactions.InteractionContext):

--- a/docs/src/Guides/25 Error Tracking.md
+++ b/docs/src/Guides/25 Error Tracking.md
@@ -11,9 +11,10 @@ You're going to want to have some way of tracking if errors occur.
 The most obvious solution is to think "Well, I'm writing a Discord Bot.  Why not send my errors to a discord channel?"
 
 ```python
+from interactions.api.events import Error
 
 @listen()
-async def on_error(error):
+async def on_error(error: Error):
     await bot.get_channel(LOGGING_CHANNEL_ID).send(f"```\n{error.source}\n{error.error}\n```)
 ```
 

--- a/docs/src/Guides/26 Prefixed Commands.md
+++ b/docs/src/Guides/26 Prefixed Commands.md
@@ -35,16 +35,15 @@ If you wish to change this, you have two options in `setup`:
 To create a prefixed command, simply define an asynchronous function and use the `@prefixed_command()` (from `interactions.ext.prefixed_commands`) decorator above it.
 
 ```python
+from interactions.ext.prefixed_commands import prefixed_command, PrefixedContext
+
 @prefixed_command(name="my_command")
 async def my_command_function(ctx: PrefixedContext):
     await ctx.reply("Hello world!")
 ```
 
-??? note "Command Name"
+???+ note "Command Name"
     If `name` is not specified, `interactions.py` will automatically use the function's name as the command's name.
-
-??? note "Prefixed Context"
-    `PrefixedContext` also comes from `interactions.ext.prefixed_commands`. In fact, any function/object you see that is unique to prefixed commands is likely from there.
 
 If the bot's prefix was set to `!`, then a user could invoke it like so:
 
@@ -133,7 +132,7 @@ The result looks like this:
 
 ![Keyword-Only Parameter](../images/PrefixedCommands/KeywordParam.png "The above running with the arguments: hello world!")
 
-??? note "Quotes"
+???+ note "Quotes"
     If a user passes quotes into a keyword-only argument, then the resulting argument will have said quotes.
 
     ![Keyword-Only Quotes](../images/PrefixedCommands/KeywordParamWithQuotes.png "The above running with the arguments: "hello world!"")
@@ -199,6 +198,8 @@ There are a few specific converters that only work with prefixed commands due to
 Prefixed commands can be typehinted with some Discord models, like so:
 
 ```python
+from interactions import Member
+
 @prefixed_command()
 async def poke(ctx: PrefixedContext, target: Member):
     await ctx.reply(f"{target.mention}, you got poked by {ctx.author.mention}!")
@@ -217,8 +218,18 @@ A table of supported objects and their converters can be found [here](../08 Conv
 For example, the below will try to convert an argument to a `GuildText` first, then a `User` if it cannot do so.
 
 ```python
+from typing import Union
+from interactions import GuildText, User
+
 @prefixed_command()
 async def union(ctx: PrefixedContext, param: Union[GuildText, User]):
+    await ctx.reply(str(param))
+```
+
+Using `|` for specifying a union is also supported, if you prefer it:
+```python
+@prefixed_command()
+async def union(ctx: PrefixedContext, param: GuildText | User):
     await ctx.reply(str(param))
 ```
 
@@ -233,6 +244,8 @@ If a parameter is marked as `Optional`, then the command handler will try conver
 For example, you could use the following code:
 
 ```python
+from typing import Optional
+
 @prefixed_command()
 async def ban(ctx: PrefixedContext, member: Member, delete_message_days: Optional[int] = 0, *, reason: str):
     await member.ban(delete_message_days=delete_message_days, reason=reason)
@@ -248,6 +261,8 @@ And if a user omits the `delete_message_days` parameter, it would act as so:
 `typing.Literal` specifies that a parameter *must* be one of the values in the list. `interactions.py` also forces that here (though this only works with values of basic types, like `str` or `int`):
 
 ```python
+from typing import Literal
+
 @prefixed_command()
 async def one_or_two(ctx: PrefixedContext, num: Literal[1, 2]):
     await ctx.reply(str(num))
@@ -260,6 +275,8 @@ async def one_or_two(ctx: PrefixedContext, num: Literal[1, 2]):
 The `Greedy` class, included in this library, specifies `interactions.py` to keep converting as many arguments as it can until it fails to do so. For example:
 
 ```python
+from interactions.ext.prefixed_commands import Greedy
+
 @prefixed_command()
 async def slap(ctx: PrefixedContext, members: Greedy[Member]):
     slapped = ", ".join(x.display_name for x in members)

--- a/docs/src/Guides/90 Example.md
+++ b/docs/src/Guides/90 Example.md
@@ -92,7 +92,7 @@ def setup(bot):
 
 ```python
 
-from interactions import slash_command, slash_option, InteractionContext, context_menu, CommandType, Button, ActionRow,
+from interactions import slash_command, slash_option, SlashContext, context_menu, CommandType, Button, ActionRow,
     ButtonStyle, Extension
 
 
@@ -100,7 +100,7 @@ class CommandsExampleSkin(Extension):
     @slash_command("command", description="This is a test", scopes=701347683591389185)
     @slash_option("another", "str option", 3, required=True)
     @slash_option("option", "int option", 4, required=True)
-    async def command(self, ctx: InteractionContext, **kwargs):
+    async def command(self, ctx: SlashContext, **kwargs):
         await ctx.send(str(ctx.resolved))
         await ctx.send(f"Test: {kwargs}", components=[ActionRow(Button(1, "Test"))])
         print(ctx.resolved)

--- a/docs/src/Guides/98 Migration from 4.X.md
+++ b/docs/src/Guides/98 Migration from 4.X.md
@@ -6,6 +6,11 @@ Version 5.X (and beyond) is a major rewrite of interactions.py compared to 4.X, 
 
 Now, let's get started, shall we?
 
+???+ note
+    In v5's documentation, you will often see imports using the format `from interactions import X`, unlike v4. You can still use `import interactions` and do `interactions.X` though.
+
+    Events, errors, and utilities are under their own sub-namespace when using `import interactions`. For example, events are under `interactions.events.X`.
+
 ## Python Version Change
 
 Starting from version 5, **Python 3.10 or higher is now required**, whereas version 4 only needed 3.8+. This is because 5.x incorporates many new and exciting features introduced in more recent versions of Python.

--- a/docs/src/Guides/98 Migration from 4.X.md
+++ b/docs/src/Guides/98 Migration from 4.X.md
@@ -40,6 +40,26 @@ Autodeferring is also pretty similar, although there's more control, with option
 
 Similarly to Slash Commands, events have also been reworked in v5. Instead of `@bot.event` and `@extension_listener`, the way to listen to events is now `@listen`. There are multiple ways to subscribe to events, whether it is using the function name or the argument of the `@listen` decorator. You can find more information on handling events using v5 [on its own guide page](../10 Events).
 
+An important note: events now dispatch an event object that contains every part about an event, instead of the object that directly corresponds to an event. For example, message creation now looks like this:
+```python
+from interactions import listen
+from interactions.api.events import MessageCreate
+
+@listen()
+async def on_message_create(event: MessageCreate):
+    event.message  # actual message
+```
+
+This is more notable with events that used to have two or more arguments. They *also* now only have one event object:
+```python
+from interactions.api.events import MemberUpdate
+
+@listen()
+async def on_member_update(event: MemberUpdate):
+    event.before  # before update
+    event.after  # after update
+```
+
 ## Other Types of Interactions (Context Menus, Components, Modals)
 
 These should be a lot more familiar to you - many interactions in v5 that aren't slash commands are similar to v4, minus name changes (largely to the decorators and classes you use). They should still *function* similarly though, but it's never a bad idea to consult the various guides that are on the sidebar to gain a better picture of how they work.

--- a/docs/src/Guides/index.md
+++ b/docs/src/Guides/index.md
@@ -1,6 +1,11 @@
 Let's be honest; reading API documentation is a bit of a pain.
 These guides are meant to help you get started with the library and offer a point of reference.
 
+???+ note
+    As with many Python libraries, you may use `import interactions` and do `interactions.X` for your objects. The documentation leads more towards using `from interactions import X`, however.
+
+    Events, errors, and utilities are under their own sub-namespace when using `import interactions`. For example, events are under `interactions.events.X`.
+
 <div class="grid cards" markdown>
 
 -   [__:material-star-shooting: Getting Started__](01 Getting Started.md)


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [ ] Bugfix
- [x] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
This PR goes in and fixes or adjusts many parts of the documentation. The major changes include:
- Many collapsible notes are now uncollapsed by default.
- Imports are now included in code examples as needed. Basically, if a new object/function appears in a code example that wasn't in a prior example, it will have an import so that users can understand how to add it in themselves.
- Many "NAFF-isms" that were changed during the port of NAFF -> ipy have been fixed.
- Notes about the import style have been added, as well as how `import interactions` is okay to do. Technically standard Python stuff, but people have been asking about it.
- Notes about how event dispatches a single object instead of spread out variables has been added to the v4 migration.
- Oh yeah, "class definition" subcommands are finally documented.

## Changes
See diff and above.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [ ] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [ ] I've run the `pre-commit` code linter over all edited files
- [ ] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [x] I've updated / added  documentation, where applicable
