### PR TITLE
feat: add `user` & `member` props to auto mod action

### DIFF
--- a/interactions/models/discord/auto_mod.py
+++ b/interactions/models/discord/auto_mod.py
@@ -16,15 +16,7 @@ from interactions.models.discord.enums import (
 from interactions.models.discord.snowflake import to_snowflake_list, to_snowflake
 
 if TYPE_CHECKING:
-    from interactions import (
-        Snowflake_Type,
-        Guild,
-        GuildText,
-        Message,
-        Client,
-        Member,
-        User
-    )
+    from interactions import Snowflake_Type, Guild, GuildText, Message, Client, Member, User
 
 __all__ = ("AutoModerationAction", "AutoModRule")
 

--- a/interactions/models/discord/auto_mod.py
+++ b/interactions/models/discord/auto_mod.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
         Message,
         Client,
         Member,
+        User
     )
 
 __all__ = ("AutoModerationAction", "AutoModRule")
@@ -319,6 +320,7 @@ class AutoModerationAction(ClientObject):
     _guild_id: "Snowflake_Type" = attrs.field(
         repr=False,
     )
+    _user_id: "Snowflake_Type" = attrs.field(repr=False)
 
     @classmethod
     def _process_dict(cls, data: dict, client: "Client") -> dict:
@@ -337,6 +339,14 @@ class AutoModerationAction(ClientObject):
     @property
     def message(self) -> "Optional[Message]":
         return self._client.cache.get_message(self._channel_id, self._message_id)
+
+    @property
+    def user(self) -> "User":
+        return self._client.cache.get_user(self._user_id)
+
+    @property
+    def member(self) -> "Optional[Member]":
+        return self._client.cache.get_member(self._guild_id, self._user_id)
 
 
 ACTION_MAPPING = {


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [x] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
Discord provides `user_id` field in the auto moderation action execution event, but current object doesn't have it
https://discord.com/developers/docs/topics/gateway-events#auto-moderation-action-execution-auto-moderation-action-execution-event-fields
<!-- Provide a clear and concise description of the purpose of this PR and why it should be merged -->
<!-- If your code adds or changes features, a usage example would be helpful -->


## Changes
- Adds `_user_id` field to `AutoModerationAction`
- Adds `user` and `member` properties to `AutoModerationAction`
<!-- List the changes you have made in a bullet-point format -->


## Related Issues
#1357 
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [ ] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
