### PR TITLE
feat: add `rate_limit_per_user` param for create thread methods

### DIFF
--- a/interactions/api/http/http_requests/threads.py
+++ b/interactions/api/http/http_requests/threads.py
@@ -180,6 +180,7 @@ class ThreadRequests:
         auto_archive_duration: int,
         thread_type: Absent[int] = MISSING,
         invitable: Absent[bool] = MISSING,
+        rate_limit_per_user: Absent[int] = MISSING,
         message_id: Absent["Snowflake_Type"] = MISSING,
         reason: Absent[str] = MISSING,
     ) -> discord_typings.ThreadChannelData:
@@ -191,7 +192,8 @@ class ThreadRequests:
             name: The name of the thread
             auto_archive_duration: duration in minutes to automatically archive the thread after recent activity, can be set to: 60, 1440, 4320, 10080
             thread_type: The type of thread, defaults to public. ignored if creating thread from a message
-            invitable:
+            invitable: Whether non-moderators can add other non-moderators to a thread; only available when creating a private thread
+            rate_limit_per_user: The time users must wait between sending messages (0-21600)
             message_id: An optional message to create a thread from.
             reason: An optional reason for the audit log
 
@@ -199,7 +201,11 @@ class ThreadRequests:
             The created thread
 
         """
-        payload = {"name": name, "auto_archive_duration": auto_archive_duration}
+        payload = {
+            "name": name,
+            "auto_archive_duration": auto_archive_duration,
+            "rate_limit_per_user": rate_limit_per_user,
+        }
         if message_id:
             return await self.request(
                 Route(

--- a/interactions/models/discord/channel.py
+++ b/interactions/models/discord/channel.py
@@ -556,6 +556,7 @@ class ThreadableMixin:
         message: Absent[Snowflake_Type] = MISSING,
         thread_type: Absent[ChannelType] = MISSING,
         invitable: Absent[bool] = MISSING,
+        rate_limit_per_user: Absent[int] = MISSING,
         auto_archive_duration: AutoArchiveDuration = AutoArchiveDuration.ONE_DAY,
         reason: Absent[str] = None,
     ) -> "TYPE_THREAD_CHANNEL":
@@ -567,6 +568,7 @@ class ThreadableMixin:
             message: The message to connect this thread to. Required for news channel.
             thread_type: Is the thread private or public. Not applicable to news channel, it will always be GUILD_NEWS_THREAD.
             invitable: whether non-moderators can add other non-moderators to a thread. Only applicable when creating a private thread.
+            rate_limit_per_user: The time users must wait between sending messages (0-21600).
             auto_archive_duration: Time before the thread will be automatically archived. Note 3 day and 7 day archive durations require the server to be boosted.
             reason: The reason for creating this thread.
 
@@ -588,6 +590,7 @@ class ThreadableMixin:
             name=name,
             thread_type=thread_type,
             invitable=invitable,
+            rate_limit_per_user=rate_limit_per_user,
             auto_archive_duration=auto_archive_duration,
             message_id=to_optional_snowflake(message),
             reason=reason,
@@ -1740,6 +1743,7 @@ class GuildText(GuildChannel, MessageableMixin, InvitableMixin, ThreadableMixin,
         self,
         name: str,
         auto_archive_duration: AutoArchiveDuration = AutoArchiveDuration.ONE_DAY,
+        rate_limit_per_user: Absent[int] = MISSING,
         reason: Absent[str] = None,
     ) -> "GuildPublicThread":
         """
@@ -1748,6 +1752,7 @@ class GuildText(GuildChannel, MessageableMixin, InvitableMixin, ThreadableMixin,
         Args:
             name: 1-100 character thread name.
             auto_archive_duration: Time before the thread will be automatically archived. Note 3 day and 7 day archive durations require the server to be boosted.
+            rate_limit_per_user: The time users must wait between sending messages (0-21600).
             reason: The reason for creating this thread.
 
         Returns:
@@ -1758,6 +1763,7 @@ class GuildText(GuildChannel, MessageableMixin, InvitableMixin, ThreadableMixin,
             name=name,
             thread_type=ChannelType.GUILD_PUBLIC_THREAD,
             auto_archive_duration=auto_archive_duration,
+            rate_limit_per_user=rate_limit_per_user,
             reason=reason,
         )
 
@@ -1766,6 +1772,7 @@ class GuildText(GuildChannel, MessageableMixin, InvitableMixin, ThreadableMixin,
         name: str,
         invitable: Absent[bool] = MISSING,
         auto_archive_duration: AutoArchiveDuration = AutoArchiveDuration.ONE_DAY,
+        rate_limit_per_user: Absent[int] = MISSING,
         reason: Absent[str] = None,
     ) -> "GuildPrivateThread":
         """
@@ -1773,7 +1780,8 @@ class GuildText(GuildChannel, MessageableMixin, InvitableMixin, ThreadableMixin,
 
         Args:
             name: 1-100 character thread name.
-            invitable: whether non-moderators can add other non-moderators to a thread.
+            invitable: Whether non-moderators can add other non-moderators to a thread.
+            rate_limit_per_user: The time users must wait between sending messages (0-21600).
             auto_archive_duration: Time before the thread will be automatically archived. Note 3 day and 7 day archive durations require the server to be boosted.
             reason: The reason for creating this thread.
 
@@ -1785,6 +1793,7 @@ class GuildText(GuildChannel, MessageableMixin, InvitableMixin, ThreadableMixin,
             name=name,
             thread_type=ChannelType.GUILD_PRIVATE_THREAD,
             invitable=invitable,
+            rate_limit_per_user=rate_limit_per_user,
             auto_archive_duration=auto_archive_duration,
             reason=reason,
         )


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [x] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
create_thread http methods missed `rate_limit_per_user` parameter
docs: https://discord.com/developers/docs/resources/channel#start-thread-from-message
<!-- Provide a clear and concise description of the purpose of this PR and why it should be merged -->
<!-- If your code adds or changes features, a usage example would be helpful -->


## Changes
Adds missing `rate_limit_per_user` parameter
<!-- List the changes you have made in a bullet-point format -->


## Related Issues
#1356 
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [x] I've updated / added  documentation, where applicable
