### PR TITLE
Added poll option to jurriged ext

### DIFF
--- a/docs/src/Guides/22 Live Patching.md
+++ b/docs/src/Guides/22 Live Patching.md
@@ -17,3 +17,12 @@ That's it! The extension will handle all of the leg work, and all you'll notice 
 ## How is this useful?
 
 interactions.py takes advantage of jurigged to reload any and all commands that were edited whenever a change is made, allowing you to have more uptime with while still adding/improving features of your bot.
+
+## It's not working inside Docker!
+To make `jurigged` work inside Docker container, you need to mount the directory you're working in as a volume in the container (pointing to the code directory inside the container).
+
+Additionally, you need to initialize the `jurigged` extension with the `poll` keyword argument set to `True`:
+
+```py
+bot.load_extension("interactions.ext.jurigged", poll=True)
+```


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [X] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
Normal jurigged watch doesn't work inside docker container with mounted volume. However, jurigged provides `poll` kwarg, which enables polling and solves the issue. This PR adds an option to pass it along during ext setup.

## Changes
* Made an `__init__` for Jurigged ext
* Added optional (default False) `poll` keyword to `__init__` and `setup`
* Added `poll` attribute to Jurigged ext
* Passed `poll` attribute to `jurigged.watch` function
* Profit

## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->
You can test kwarg inside or outside Docker, really.

## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [X] I've ensured my code works on Python `3.10.x`
- [ ] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [X] I've run the `pre-commit` code linter over all edited files
- [X] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [X] I've updated / added  documentation, where applicable
