### PR TITLE
feat: pass event object based on listeners signature

### DIFF
--- a/interactions/client/client.py
+++ b/interactions/client/client.py
@@ -1208,6 +1208,8 @@ class Client(
             self.logger.debug(f"Listener {listener} has already been hooked, not re-hooking it again")
             return
 
+        listener.lazy_parse_params()
+
         if listener.event not in self.listeners:
             self.listeners[listener.event] = []
         self.listeners[listener.event].append(listener)

--- a/interactions/client/client.py
+++ b/interactions/client/client.py
@@ -571,8 +571,10 @@ class Client(
                 ):
                     await self.wait_until_ready()
 
-                if len(_event.__attrs_attrs__) == 2 and coro.event != "event":
-                    # override_name & bot & logging
+                # don't pass event object if listener doesn't expect it
+                # check coro signature for event param
+                callback_signature = inspect.signature(_coro.callback)
+                if len(callback_signature.parameters) == 0:
                     await _coro()
                 else:
                     await _coro(_event, *_args, **_kwargs)

--- a/interactions/models/internal/extension.py
+++ b/interactions/models/internal/extension.py
@@ -101,7 +101,7 @@ class Extension:
         for _name, val in callables:
             if isinstance(val, models.BaseCommand):
                 val.extension = instance
-                val = wrap_partial(val, instance)
+                val = val.copy_with_binding(instance)
                 bot.add_command(val)
                 instance._commands.append(val)
 
@@ -110,12 +110,12 @@ class Extension:
 
             elif isinstance(val, models.Listener):
                 val.extension = instance
-                val = wrap_partial(val, instance)
+                val = val.copy_with_binding(instance)
                 bot.add_listener(val)  # type: ignore
                 instance._listeners.append(val)
             elif isinstance(val, models.GlobalAutoComplete):
                 val.extension = instance
-                val = wrap_partial(val, instance)
+                val = val.copy_with_binding(instance)
                 bot.add_global_autocomplete(val)
         bot.dispatch(events.ExtensionCommandParse(extension=instance, callables=callables))
 

--- a/interactions/models/internal/listener.py
+++ b/interactions/models/internal/listener.py
@@ -3,7 +3,7 @@ import inspect
 from typing import Callable
 
 from interactions.api.events.internal import BaseEvent
-from interactions.client.const import MISSING, Absent, AsyncCallable, get_logger
+from interactions.client.const import MISSING, Absent, AsyncCallable
 from interactions.client.utils import get_event_name
 from interactions.models.internal.callback import CallbackObject
 

--- a/interactions/models/internal/listener.py
+++ b/interactions/models/internal/listener.py
@@ -77,7 +77,14 @@ class Listener(CallbackObject):
             if not asyncio.iscoroutinefunction(coro):
                 raise TypeError("Listener must be a coroutine")
 
-            coro_signature = inspect.signature(coro)
+            coro_parametrers = inspect.signature(coro).parameters.copy()
+            if coro_parametrers and list(coro_parametrers.keys())[0] == "self":
+                # remove self; those who name it differently are on their own
+                coro_parametrers.pop("self")
+
+            # If the coroutine has no parameters, we don't need to pass the event object
+            pass_event_object = len(coro_parametrers) != 0
+
             name = event_name
 
             if name is MISSING:
@@ -92,9 +99,6 @@ class Listener(CallbackObject):
 
                 if not name:
                     name = coro.__name__
-
-            # If the coroutine has no parameters, we don't need to pass the event object
-            pass_event_object = len(coro_signature.parameters) != 0
 
             return cls(
                 coro,


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [X] Feature addition
- [X] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description & changes
Event object is now passed (or not) based on whether there are any parameters in listener



## Test Scenarios
Tested on my bot and with test script - both as standalone function listeners and as extension methods

## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [X] I've ensured my code works on Python `3.10.x`
- [ ] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [X] I've run the `pre-commit` code linter over all edited files
- [X] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
