### PR TITLE
fix: pass default_member_permissions in SlashCommand.group()

### DIFF
--- a/interactions/models/internal/application_commands.py
+++ b/interactions/models/internal/application_commands.py
@@ -720,6 +720,7 @@ class SlashCommand(InteractionCommand):
             group_name=name,
             group_description=description,
             scopes=self.scopes,
+            default_member_permissions=self.default_member_permissions,
             dm_permission=self.dm_permission,
             checks=self.checks.copy() if inherit_checks else [],
         )


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [X] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
`SlashCommand.group()` now pases parent default_member_permissions (like `.subcommand()` does) to prevent conflicts and errors during synchonisation (couldn't use `SlashCommand.group()` when the parent command had default_member_permissions because of that).

## Test Scenarios
```py
test_cmd = interactions.SlashCommand(
    name="test",
    description="test",
    default_member_permissions=interactions.Permissions.ADMINISTRATOR,
)

test_grp = test_cmd.group("group", "test group")
```

## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [X] I've ensured my code works on Python `3.10.x`
- [ ] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [X] I've run the `pre-commit` code linter over all edited files
- [X] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
