### PR TITLE
fix!: pass a Member as author of MessageReactionRemove

### DIFF
--- a/interactions/api/events/processors/reaction_events.py
+++ b/interactions/api/events/processors/reaction_events.py
@@ -15,7 +15,10 @@ class ReactionEvents(EventMixinTemplate):
         if member := event.data.get("member"):
             author = self.cache.place_member_data(event.data.get("guild_id"), member)
         else:
-            author = await self.cache.fetch_user(event.data.get("user_id"))
+            if guild_id := event.data.get("guild_id"):
+                author = await self.cache.fetch_member(guild_id, event.data.get("user_id"))
+            else:
+                author = await self.cache.fetch_user(event.data.get("user_id"))
 
         emoji = PartialEmoji.from_dict(event.data.get("emoji"))  # type: ignore
         message = self.cache.get_message(event.data.get("channel_id"), event.data.get("message_id"))

--- a/interactions/api/events/processors/reaction_events.py
+++ b/interactions/api/events/processors/reaction_events.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING
 
 import interactions.api.events as events
 from interactions.models import PartialEmoji, Reaction
+
 from ._template import EventMixinTemplate, Processor
 
 if TYPE_CHECKING:
@@ -14,11 +15,10 @@ class ReactionEvents(EventMixinTemplate):
     async def _handle_message_reaction_change(self, event: "RawGatewayEvent", add: bool) -> None:
         if member := event.data.get("member"):
             author = self.cache.place_member_data(event.data.get("guild_id"), member)
+        elif guild_id := event.data.get("guild_id"):
+            author = await self.cache.fetch_member(guild_id, event.data.get("user_id"))
         else:
-            if guild_id := event.data.get("guild_id"):
-                author = await self.cache.fetch_member(guild_id, event.data.get("user_id"))
-            else:
-                author = await self.cache.fetch_user(event.data.get("user_id"))
+            author = await self.cache.fetch_user(event.data.get("user_id"))
 
         emoji = PartialEmoji.from_dict(event.data.get("emoji"))  # type: ignore
         message = self.cache.get_message(event.data.get("channel_id"), event.data.get("message_id"))


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
Reported on the Support server, MessageReactionRemove does not pass the author as a Member even if the event is fired from a guild


## Changes
<!-- List the changes you have made in a bullet-point format -->


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
```py
@interactions.listen(interactions.events.MessageReactionRemove)
async def on_reaction_remove(event: interactions.events.MessageReactionRemove):
    print(type(event.author))
```


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [x] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
