### PR TITLE
tests: Remove unused pytest plugin

### DIFF
--- a/.github/workflows/pytest-push.yml
+++ b/.github/workflows/pytest-push.yml
@@ -42,7 +42,7 @@ jobs:
           BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
           RUN_TESTBOT: ${{ matrix.RUN_TESTBOT }}
         run: |
-          pytest
+          pytest --cov=./ --cov-report xml:coverage.xml
           coverage xml -i
       - name: Upload Coverage
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ source = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "-l -ra --durations=2 --cov=./ --cov-report xml:coverage.xml --junitxml=TestResults.xml"
+addopts = "-l -ra --durations=2 --junitxml=TestResults.xml"
 doctest_optionflags = "NORMALIZE_WHITESPACE"
 asyncio_mode="auto"
 log_cli = "1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ mkdocs-minify-plugin = { version = "*", optional = true }
 mkdocs-git-committers-plugin-2 = { version = "*", optional = true }
 mkdocs-git-revision-date-localized-plugin = { version = "*", optional = true }
 pytest = { version = "*", optional = true }
-pytest-recording = { version = "*", optional = true }
 pytest-asyncio = { version = "*", optional = true }
 pytest-cov = { version = "*", optional = true }
 python-dotenv = { version = "*", optional = true }
@@ -66,7 +65,6 @@ mkdocs-git-revision-date-localized-plugin = "*"
 
 [tool.poetry.group.tests.dependencies]
 pytest = "*"
-pytest-recording = "*"
 pytest-asyncio = "*"
 pytest-cov = "*"
 python-dotenv = "*"

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ extras_require["docs"] = extras_require["all"] + [
 ]
 extras_require["tests"] = [
     "pytest",
-    "pytest-recording",
     "pytest-asyncio",
     "pytest-cov",
     "python-dotenv",


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [x] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
Tests are currently failing on CI due to https://github.com/kevin1024/vcrpy/issues/688.  As we never actually ended up using it in any of our tests, I'm just going to remove the plugin from the test environment entirely.


## Changes
Remove Unused plugin from [tests] extra dependencies.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [x] I've ensured my code works on Python `3.10.x`
- [ ] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
