### PR TITLE
feat: `SlashCommandChoice` as  parameter for `AutoCompleteContext.send`

### DIFF
--- a/interactions/models/internal/context.py
+++ b/interactions/models/internal/context.py
@@ -853,7 +853,9 @@ class AutocompleteContext(BaseInteractionContext):
             self.focussed_option = SlashCommandOption.from_dict(option)
         return
 
-    async def send(self, choices: typing.Iterable[str | int | float | dict[str, int | float | str]|SlashCommandChoice]) -> None:
+    async def send(
+        self, choices: typing.Iterable[str | int | float | dict[str, int | float | str] | SlashCommandChoice]
+    ) -> None:
         """
         Send your autocomplete choices to discord. Choices must be either a list of strings, or a dictionary following the following format:
 
@@ -883,7 +885,7 @@ class AutocompleteContext(BaseInteractionContext):
             if isinstance(choice, dict):
                 name = choice["name"]
                 value = choice["value"]
-            if isinstance(choice, SlashCommandChoice):
+            elif isinstance(choice, SlashCommandChoice):
                 name = choice.name
                 value = choice.value
             else:

--- a/interactions/models/internal/context.py
+++ b/interactions/models/internal/context.py
@@ -36,6 +36,7 @@ from interactions.models.discord.embed import Embed
 from interactions.models.internal.application_commands import (
     OptionType,
     CallbackType,
+    SlashCommandChoice,
     SlashCommandOption,
     InteractionCommand,
 )
@@ -852,7 +853,7 @@ class AutocompleteContext(BaseInteractionContext):
             self.focussed_option = SlashCommandOption.from_dict(option)
         return
 
-    async def send(self, choices: typing.Iterable[str | int | float | dict[str, int | float | str]]) -> None:
+    async def send(self, choices: typing.Iterable[str | int | float | dict[str, int | float | str]|SlashCommandChoice]) -> None:
         """
         Send your autocomplete choices to discord. Choices must be either a list of strings, or a dictionary following the following format:
 
@@ -882,6 +883,9 @@ class AutocompleteContext(BaseInteractionContext):
             if isinstance(choice, dict):
                 name = choice["name"]
                 value = choice["value"]
+            if isinstance(choice, SlashCommandChoice):
+                name = choice.name
+                value = choice.value
             else:
                 name = str(choice)
                 value = choice


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [x] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [x] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
Adds `SlashCommandChoice` as a parameter for `AutoCompleteContext.send`


## Changes
<!-- List the changes you have made in a bullet-point format -->


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [ ] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
