### PR TITLE
fix: account for discord's discrim change

### DIFF
--- a/interactions/models/discord/user.py
+++ b/interactions/models/discord/user.py
@@ -52,7 +52,7 @@ class BaseUser(DiscordObject, _SendDMMixin):
         repr=True, metadata=docs("The user's chosen display name, platform-wide"), default=None
     )
     discriminator: str = attrs.field(
-        repr=True, metadata=docs("The user's 4-digit discord-tag")
+        repr=True, metadata=docs("The user's 4-digit discord-tag"), default="0"
     )  # will likely be removed in future api version
     avatar: "Asset" = attrs.field(repr=False, metadata=docs("The user's default avatar"))
 

--- a/interactions/models/discord/user.py
+++ b/interactions/models/discord/user.py
@@ -51,7 +51,7 @@ class BaseUser(DiscordObject, _SendDMMixin):
     global_name: str | None = attrs.field(
         repr=True, metadata=docs("The user's chosen display name, platform-wide"), default=None
     )
-    discriminator: int = attrs.field(repr=True, metadata=docs("The user's 4-digit discord-tag"))
+    discriminator: str = attrs.field(repr=True, metadata=docs("The user's 4-digit discord-tag"))
     avatar: "Asset" = attrs.field(repr=False, metadata=docs("The user's default avatar"))
 
     def __str__(self) -> str:

--- a/interactions/models/discord/user.py
+++ b/interactions/models/discord/user.py
@@ -51,7 +51,7 @@ class BaseUser(DiscordObject, _SendDMMixin):
     global_name: str | None = attrs.field(
         repr=True, metadata=docs("The user's chosen display name, platform-wide"), default=None
     )
-    discriminator: str = attrs.field(repr=True, metadata=docs("The user's 4-digit discord-tag"))
+    discriminator: str | None = attrs.field(repr=True, metadata=docs("The user's 4-digit discord-tag"), default=None)
     avatar: "Asset" = attrs.field(repr=False, metadata=docs("The user's default avatar"))
 
     def __str__(self) -> str:
@@ -69,6 +69,8 @@ class BaseUser(DiscordObject, _SendDMMixin):
     @property
     def tag(self) -> str:
         """Returns the user's Discord tag."""
+        if not self.discriminator or self.discriminator == "0":
+            return f"@{self.username}"
         return f"{self.username}#{self.discriminator}"
 
     @property

--- a/interactions/models/discord/user.py
+++ b/interactions/models/discord/user.py
@@ -51,7 +51,9 @@ class BaseUser(DiscordObject, _SendDMMixin):
     global_name: str | None = attrs.field(
         repr=True, metadata=docs("The user's chosen display name, platform-wide"), default=None
     )
-    discriminator: str | None = attrs.field(repr=True, metadata=docs("The user's 4-digit discord-tag"), default=None)
+    discriminator: str = attrs.field(
+        repr=True, metadata=docs("The user's 4-digit discord-tag")
+    )  # will likely be removed in future api version
     avatar: "Asset" = attrs.field(repr=False, metadata=docs("The user's default avatar"))
 
     def __str__(self) -> str:
@@ -62,6 +64,8 @@ class BaseUser(DiscordObject, _SendDMMixin):
         if not isinstance(data["avatar"], Asset):
             if data["avatar"]:
                 data["avatar"] = Asset.from_path_hash(client, f"avatars/{data['id']}/{{}}", data["avatar"])
+            elif data["discriminator"] == "0":
+                data["avatar"] = Asset(client, f"{Asset.BASE}/embed/avatars/{(int(data['id']) >> 22) % 5}")
             else:
                 data["avatar"] = Asset(client, f"{Asset.BASE}/embed/avatars/{int(data['discriminator']) % 5}")
         return data
@@ -69,7 +73,7 @@ class BaseUser(DiscordObject, _SendDMMixin):
     @property
     def tag(self) -> str:
         """Returns the user's Discord tag."""
-        if not self.discriminator or self.discriminator == "0":
+        if self.discriminator == "0":
             return f"@{self.username}"
         return f"{self.username}#{self.discriminator}"
 

--- a/interactions/models/discord/user.pyi
+++ b/interactions/models/discord/user.pyi
@@ -39,7 +39,7 @@ class _SendDMMixin(SendMixin):
 class FakeBaseUserMixin(DiscordObject, _SendDMMixin):
     username: str
     global_name: str | None
-    discriminator: int
+    discriminator: str
     avatar: Asset
     def __str__(self) -> str: ...
     @classmethod

--- a/interactions/models/discord/user.pyi
+++ b/interactions/models/discord/user.pyi
@@ -39,7 +39,7 @@ class _SendDMMixin(SendMixin):
 class FakeBaseUserMixin(DiscordObject, _SendDMMixin):
     username: str
     global_name: str | None
-    discriminator: str
+    discriminator: str | None
     avatar: Asset
     def __str__(self) -> str: ...
     @classmethod

--- a/interactions/models/discord/user.pyi
+++ b/interactions/models/discord/user.pyi
@@ -39,7 +39,7 @@ class _SendDMMixin(SendMixin):
 class FakeBaseUserMixin(DiscordObject, _SendDMMixin):
     username: str
     global_name: str | None
-    discriminator: str | None
+    discriminator: str
     avatar: Asset
     def __str__(self) -> str: ...
     @classmethod


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
This future-proofs the `User` class by handling cases where `discriminator` is `0` and handles them appropriately. These placeholder discriminators will be appearing over the next couple of weeks.


## Changes
- Get the correct icon if the discriminator is 0 and the user has no specific icon set (based on https://github.com/discord/discord-api-docs/pull/6130, a draft, but I think this specific behavior is unlikely to change).
- Makes `tag` use the new `@username` format for tags if the discriminator is equal to 0.
- Correctly note that `discriminator` is `str`, not `int`.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [x] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
