### PR TITLE
fix: copy prefixed cmd set when unloading ext

### DIFF
--- a/interactions/ext/prefixed_commands/manager.py
+++ b/interactions/ext/prefixed_commands/manager.py
@@ -239,7 +239,7 @@ class PrefixedManager:
     @listen("extension_unload")
     async def _handle_ext_unload(self, event: ExtensionUnload) -> None:
         """Unregisters all prefixed commands in an extension as it is being unloaded."""
-        for name in self._ext_command_list[event.extension.extension_name]:
+        for name in self._ext_command_list[event.extension.extension_name].copy():
             self.remove_command(name)
 
     @listen("raw_message_create", is_default_listener=True)


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
Quick little bugfix. Nothing really to note, it's a bit urgent but not by that much.


## Changes
- When unloading an extension, copy the set of prefixed commands in that extension for iteration. As this set is edited while removing each command, the iterator will freak out otherwise.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [x] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
