### PR TITLE
feat: add regex support for modal callback

### DIFF
--- a/interactions/client/client.py
+++ b/interactions/client/client.py
@@ -1793,7 +1793,9 @@ class Client(
                         break
 
             if modal_callback:
-                await self.__dispatch_interaction(ctx=ctx, callback=modal_callback(ctx), error_callback=events.ModalError)
+                await self.__dispatch_interaction(
+                    ctx=ctx, callback=modal_callback(ctx), error_callback=events.ModalError
+                )
 
         else:
             raise NotImplementedError(f"Unknown Interaction Received: {interaction_data['type']}")

--- a/interactions/models/internal/application_commands.py
+++ b/interactions/models/internal/application_commands.py
@@ -96,6 +96,11 @@ def desc_validator(_: Any, attr: Attribute, value: str) -> None:
         raise ValueError(f"Description must be between 1 and {SLASH_CMD_MAX_DESC_LENGTH} characters long")
 
 
+def custom_ids_validator(*custom_id: str | re.Pattern) -> None:
+    if not (all(isinstance(i, re.Pattern) for i in custom_id) or all(isinstance(i, str) for i in custom_id)):
+        raise ValueError("All custom IDs be either a string or a regex pattern, not a mix of both.")
+
+
 @attrs.define(
     eq=False,
     order=False,
@@ -1144,17 +1149,20 @@ def component_callback(*custom_id: str | re.Pattern) -> Callable[[AsyncCallable]
         return ComponentCommand(name=f"ComponentCallback::{custom_id}", callback=func, listeners=custom_id)
 
     custom_id = _unpack_helper(custom_id)
-    if not (all(isinstance(i, re.Pattern) for i in custom_id) or all(isinstance(i, str) for i in custom_id)):
-        raise ValueError("All custom IDs be either a string or a regex pattern, not a mix of both.")
+    custom_ids_validator(*custom_id)
     return wrapper
 
 
-def modal_callback(*custom_id: str) -> Callable[[AsyncCallable], ModalCommand]:
+def modal_callback(*custom_id: str | re.Pattern) -> Callable[[AsyncCallable], ModalCommand]:
     """
     Register a coroutine as a modal callback.
 
     Modal callbacks work the same way as commands, just using modals as a way of invoking, instead of messages.
     Your callback will be given a single argument, `ModalContext`
+
+    Note:
+        This can optionally take a regex pattern, which will be used to match against the custom ID of the modal
+
 
     Args:
         *custom_id: The custom ID of the modal to wait for
@@ -1167,6 +1175,7 @@ def modal_callback(*custom_id: str) -> Callable[[AsyncCallable], ModalCommand]:
         return ModalCommand(name=f"ModalCallback::{custom_id}", callback=func, listeners=custom_id)
 
     custom_id = _unpack_helper(custom_id)
+    custom_ids_validator(*custom_id)
     return wrapper
 
 


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [x] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [x] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
This pr implements regex support for modal callbacks on [this request](https://discord.com/channels/789032594456576001/1101972075465408632)
<!-- Provide a clear and concise description of the purpose of this PR and why it should be merged -->
<!-- If your code adds or changes features, a usage example would be helpful -->


## Changes
- Adds support for regex patterns in `modal_callback` decorator
- Adds new field `_regex_modal_callbacks` for `Client`.
- Adds registering and dispatching modal callbacks with regex
- Moves custom id validating to own method
<!-- List the changes you have made in a bullet-point format -->


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
Put a string or regex pattern object from `re.compile` to `@modal_callback` decorator

```py
@modal_callback("btn")
async def callback(ctx, **kwargs):
    await ctx.send("Test"):

import re
@modal_callback(re.compile("test"))
async def callback(ctx, **kwargs):
    await ctx.send("Test"):
```
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [ ] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [x] I've updated / added  documentation, where applicable
