### PR TITLE
fix: properly pass guild_id to http's get_guild

### DIFF
--- a/interactions/api/http/http_requests/guild.py
+++ b/interactions/api/http/http_requests/guild.py
@@ -54,8 +54,8 @@ class GuildRequests(CanRequest):
             a guild object
 
         """
-        params = {"guild_id": guild_id, "with_counts": int(with_counts)}
-        result = await self.request(Route("GET", "/guilds/{guild_id}"), params=params)
+        params = {"with_counts": int(with_counts)}
+        result = await self.request(Route("GET", "/guilds/{guild_id}", guild_id=guild_id), params=params)
         return cast(discord_typings.GuildData, result)
 
     async def get_guild_preview(self, guild_id: "Snowflake_Type") -> discord_typings.GuildPreviewData:


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
Fixes #1393, which prevented properly fetching a guild.


## Changes
- Properly pass in `guild_id` to the `Route` for `get_guild`, not to the parameters.


## Related Issues
#1393


## Test Scenarios
```python
await bot.fetch_guild(1234)  # invalid id, so will bypass cache anyhow
```


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [x] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [x] I've added tests for my code, if applicable
- [x] I've updated / added  documentation, where applicable
