### PR TITLE
fix: correctly handle message references

### DIFF
--- a/interactions/models/discord/message.py
+++ b/interactions/models/discord/message.py
@@ -400,6 +400,8 @@ class Message(BaseMessage):
         """
         if self._referenced_message_id is None:
             return None
+
+
         return await self._client.cache.fetch_message(self._channel_id, self._referenced_message_id, force=force)
 
     def get_referenced_message(self) -> Optional["Message"]:
@@ -492,6 +494,8 @@ class Message(BaseMessage):
                 ref_message_data["guild_id"] = data.get("guild_id")
             _m = client.cache.place_message_data(ref_message_data)
             data["referenced_message_id"] = _m.id
+        elif msg_reference := data.get("message_reference"):
+            data["referenced_message_id"] = msg_reference["message_id"]
 
         if "interaction" in data:
             data["interaction"] = MessageInteraction.from_dict(data["interaction"], client)

--- a/interactions/models/discord/message.py
+++ b/interactions/models/discord/message.py
@@ -18,7 +18,7 @@ import attrs
 
 import interactions.models as models
 from interactions.client.const import GUILD_WELCOME_MESSAGES, MISSING, Absent
-from interactions.client.errors import ThreadOutsideOfGuild
+from interactions.client.errors import ThreadOutsideOfGuild, NotFound
 from interactions.client.mixins.serialization import DictSerializationMixin
 from interactions.client.utils.attr_converters import optional as optional_c
 from interactions.client.utils.attr_converters import timestamp_converter
@@ -401,8 +401,10 @@ class Message(BaseMessage):
         if self._referenced_message_id is None:
             return None
 
-
-        return await self._client.cache.fetch_message(self._channel_id, self._referenced_message_id, force=force)
+        try:
+            return await self._client.cache.fetch_message(self._channel_id, self._referenced_message_id, force=force)
+        except NotFound:
+            return None
 
     def get_referenced_message(self) -> Optional["Message"]:
         """


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
Just two bugfixes relating to message references that could cause strange behavior otherwise.


## Changes

- Since Discord annoyingly doesn't always give `referenced_message` even if it is a valid referenced message and a message reference object exists, add a workaround to set `_referenced_message_id` as the message reference object's message ID.
- Correctly catch and return none for `Message.fetch_referenced_message` to match the other fetches.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
It's a bit weird to trigger this, but I've found that creating a large amount of replies will make at least one message not `referenced_message` and so trigger this.


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [x] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
