### PR TITLE
feat: allow .purge to return messages

### DIFF
--- a/interactions/models/discord/channel.py
+++ b/interactions/models/discord/channel.py
@@ -404,11 +404,12 @@ class MessageableMixin(SendMixin):
         search_limit: int = 100,
         predicate: Callable[["models.Message"], bool] = MISSING,
         avoid_loading_msg: bool = True,
+        return_messages: bool = False,
         before: Optional[Snowflake_Type] = MISSING,
         after: Optional[Snowflake_Type] = MISSING,
         around: Optional[Snowflake_Type] = MISSING,
         reason: Absent[Optional[str]] = MISSING,
-    ) -> int:
+    ) -> int | List["models.Message"]:
         """
         Bulk delete messages within a channel. If a `predicate` is provided, it will be used to determine which messages to delete, otherwise all messages will be deleted within the `deletion_limit`.
 
@@ -424,6 +425,7 @@ class MessageableMixin(SendMixin):
             search_limit: How many messages to search through
             predicate: A function that returns True or False, and takes a message as an argument
             avoid_loading_msg: Should the bot attempt to avoid deleting its own loading messages (recommended enabled)
+            return_messages: Should the bot return the messages that were deleted
             before: Search messages before this ID
             after: Search messages after this ID
             around: Search messages around this ID
@@ -461,13 +463,13 @@ class MessageableMixin(SendMixin):
                 # message is too old to be purged
                 continue
 
-            to_delete.append(message.id)
+            to_delete.append(message)
 
-        count = len(to_delete)
+        out = to_delete.copy()
         while len(to_delete):
-            iteration = [to_delete.pop() for i in range(min(100, len(to_delete)))]
+            iteration = [to_delete.pop().id for i in range(min(100, len(to_delete)))]
             await self.delete_messages(iteration, reason=reason)
-        return count
+        return out if return_messages else len(out)
 
     async def trigger_typing(self) -> None:
         """Trigger a typing animation in this channel."""


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [x] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
<!-- Provide a clear and concise description of the purpose of this PR and why it should be merged -->
<!-- If your code adds or changes features, a usage example would be helpful -->
Allows `channel.purge` to optionally return a list of messages instead of a message count


## Changes
<!-- List the changes you have made in a bullet-point format -->
- Add a kwarg to `.purge` which tells it to return the messages deleted, otherwise normal behaviour is preserverd

## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->
#1390 

## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->
```python
channel = bot.get_channel(1085629305129807872)

out = await channel.purge(deletion_limit=10)
assert out == 10
out = await channel.purge(deletion_limit=10, return_messages=False)
assert out == 10
out = await channel.purge(deletion_limit=10, return_messages=True)
assert len(out) == 10
assert isinstance(out, list)
assert all(isinstance(m, interactions.Message) for m in out)
```

## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
