### PR TITLE
feat: Handle async checks in wait_for_component

### DIFF
--- a/interactions/client/client.py
+++ b/interactions/client/client.py
@@ -1105,7 +1105,7 @@ class Client(
                 dict,
             ]
         ] = None,
-        check: Optional[Callable] = None,
+        check: Absent[Optional[Union[Callable[..., bool], Callable[..., Awaitable[bool]]]]] = None,
         timeout: Optional[float] = None,
     ) -> "events.Component":
         """

--- a/interactions/client/client.py
+++ b/interactions/client/client.py
@@ -1136,7 +1136,7 @@ class Client(
         if custom_ids and not all(isinstance(x, str) for x in custom_ids):
             custom_ids = [str(i) for i in custom_ids]
 
-        def _check(event: events.Component) -> bool:
+        async def _check(event: events.Component) -> bool:
             ctx: ComponentContext = event.ctx
             # if custom_ids is empty or there is a match
             wanted_message = not message_ids or ctx.message.id in (
@@ -1144,6 +1144,8 @@ class Client(
             )
             wanted_component = not custom_ids or ctx.custom_id in custom_ids
             if wanted_message and wanted_component:
+                if asyncio.iscoroutinefunction(check):
+                    return bool(check is None or await check(event))
                 return bool(check is None or check(event))
             return False
 


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [x] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
Following a help thread on discord I found that `client.wait_for_component()` did not support async checks, despite the fact that the underlying `client.wait_for()` and `Wait` class both do. 
This PR copies that functionality to apply to the check passed to `wait_for_component()`


## Changes
- use `asyncio.iscoroutinefunction()` to determine if we need to await on a check or call it normally


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
I am unsure how to go about unit testing this due to my limited experience with asyncio and pytest. However I have validated this fixes the issues with the following code

```python
@slash_command(name="test", scopes=[1094385160536993884])
    async def test(self, ctx: SlashContext):
        components = Button(
            custom_id="my_button_id",
            style=ButtonStyle.GREEN,
            label="Click Me",
        )

        message = await ctx.channel.send("Look a Button!", components=components)

        # define the check
        async def check(res: events.Component) -> bool:
            await res.ctx.send("You clicked the button!", ephemeral=True)
            return res.ctx.author.display_name.startswith("A")

        try:

            used_component = await self.bot.wait_for_component(components=components, check=check, timeout=30)

        except TimeoutError:
            print("Timed Out!")

            components.disabled = True
            await message.edit(components=components)

        else:
            await used_component.ctx.send("Your name starts with 'a'")
```

I forgot to install pre-commit before making my commits, but `pre-commit run --all-files` passes

```
poetry run pre-commit run --all-files
[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Initializing environment for https://github.com/charliermarsh/ruff-pre-commit.
[INFO] Initializing environment for https://github.com/psf/black.
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/charliermarsh/ruff-pre-commit.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/psf/black.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
Requirements.............................................................Passed
Debugging................................................................Passed
Trailing Whitespace......................................................Passed
EOF Newlines.............................................................Passed
YAML Structure...........................................................Passed
TOML Structure...........................................................Passed
Merge Conflicts..........................................................Passed
ruff.....................................................................Passed
Black Formatting.........................................................Passed
```

## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [X] I've ensured my code works on Python `3.10.x`
- [X] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [X] I've run the `pre-commit` code linter over all edited files
- [X] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
