### PR TITLE
feat: bypass discord's broken image proxy

### DIFF
--- a/interactions/client/client.py
+++ b/interactions/client/client.py
@@ -544,6 +544,7 @@ class Client(
     def _sanity_check(self) -> None:
         """Checks for possible and common errors in the bot's configuration."""
         self.logger.debug("Running client sanity checks...")
+
         contexts = {
             self.interaction_context: InteractionContext,
             self.component_context: ComponentContext,
@@ -910,6 +911,11 @@ class Client(
         # login will always run after initialisation
         # so im gathering commands here
         self._gather_callbacks()
+
+        if any(v for v in constants.CLIENT_FEATURE_FLAGS.values()):
+            # list all enabled flags
+            enabled_flags = [k for k, v in constants.CLIENT_FEATURE_FLAGS.items() if v]
+            self.logger.info(f"Enabled feature flags: {', '.join(enabled_flags)}")
 
         self.logger.debug("Attempting to login")
         me = await self.http.login(self.token)

--- a/interactions/client/const.py
+++ b/interactions/client/const.py
@@ -208,7 +208,8 @@ CLIENT_FEATURE_FLAGS = {
 def has_client_feature(feature: str) -> bool:
     """Checks if a feature is enabled for the client."""
     if feature.upper() not in CLIENT_FEATURE_FLAGS:
-        raise ValueError(f"Unknown feature {feature!r} - Known features: {list(CLIENT_FEATURE_FLAGS)}")
+        get_logger().warning(f"Unknown feature {feature!r} - Known features: {list(CLIENT_FEATURE_FLAGS)}")
+        return False
     return CLIENT_FEATURE_FLAGS[feature.upper()]
 
 

--- a/interactions/client/const.py
+++ b/interactions/client/const.py
@@ -195,6 +195,17 @@ PREMIUM_GUILD_LIMITS = defaultdict(
     },
 )
 
+CLIENT_FEATURE_FLAGS = {
+    "FOLLOWUP_INTERACTIONS_FOR_IMAGES": False,  # Experimental fix to bypass Discord's broken image proxy
+}
+
+
+def has_client_feature(feature: str) -> bool:
+    """Checks if a feature is enabled for the client."""
+    if feature.upper() not in CLIENT_FEATURE_FLAGS:
+        raise ValueError(f"Unknown feature {feature!r} - Known features: {list(CLIENT_FEATURE_FLAGS)}")
+    return CLIENT_FEATURE_FLAGS[feature.upper()]
+
 
 GUILD_WELCOME_MESSAGES = (
     "{0} joined the party.",

--- a/interactions/client/const.py
+++ b/interactions/client/const.py
@@ -32,6 +32,9 @@ Attributes:
     T TypeVar: A type variable used for generic typing.
     Absent Union[T, Missing]: A type hint for a value that may be MISSING.
 
+    CLIENT_FEATURE_FLAGS dict: A dict of feature flags that can be enabled or disabled for the client.
+    has_feature_flag Callable[[str], bool]: A function that returns whether a feature flag is enabled.
+
 """
 import inspect
 import logging
@@ -78,6 +81,8 @@ __all__ = (
     "LIB_PATH",
     "RECOVERABLE_WEBSOCKET_CLOSE_CODES",
     "NON_RESUMABLE_WEBSOCKET_CLOSE_CODES",
+    "CLIENT_FEATURE_FLAGS",
+    "has_client_feature",
 )
 
 _ver_info = sys.version_info


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [x] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
<!-- Provide a clear and concise description of the purpose of this PR and why it should be merged -->
<!-- If your code adds or changes features, a usage example would be helpful -->
This PR modifies sending behavior to bypass discord's broken image proxy. Allowing normal bot behaviour to continue 

The purpose of the feature flag framework is to allow us to remove the relevant code without breaking changes when the code is no longer required 

Usage:
```
bot = Client(...)
const.CLIENT_FEATURE_FLAGS["FOLLOWUP_INTERACTIONS_FOR_IMAGES"] = True

bot.start(...)
```


## Changes
<!-- List the changes you have made in a bullet-point format -->
- Add new feature flag framework for this sort of issue
- Modify interaction context behaviour to force a deferral when the bot is sending an embedded image
- Modify send behaviour to use the working endpoint `post_followup`

## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [x] I've ensured my code works on Python `3.10.x`
- [ ] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
