### PR TITLE
fix: correctly work with Permissions.NONE when passed into Guild.create_role

### DIFF
--- a/interactions/models/discord/guild.py
+++ b/interactions/models/discord/guild.py
@@ -1457,7 +1457,7 @@ class Guild(BaseGuild):
         if name:
             payload["name"] = name
 
-        if permissions or permissions == Permissions.NONE:
+        if permissions is not MISSING and permissions is not None:
             payload["permissions"] = str(int(permissions))
 
         if colour := colour or color:

--- a/interactions/models/discord/guild.py
+++ b/interactions/models/discord/guild.py
@@ -1457,7 +1457,7 @@ class Guild(BaseGuild):
         if name:
             payload["name"] = name
 
-        if permissions:
+        if permissions or permissions == Permissions.NONE:
             payload["permissions"] = str(int(permissions))
 
         if colour := colour or color:


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
<!-- Provide a clear and concise description of the purpose of this PR and why it should be merged -->
<!-- If your code adds or changes features, a usage example would be helpful -->
The `interactions.Guild.create_role` method does not work correctly if you pass in `interactions.Permissions.NONE`. Rather than creating the role in Discord with every permission disabled, it instead creates the role with discord's default permissions enabled.


## Changes
<!-- List the changes you have made in a bullet-point format -->
- Update `interactions.Guild.create_role` method
  - Updated the arg check for adding `permissions` to the payload to check equality to`interactions.Permissions.NONE` in addition to truthy values


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->
fixes #1420


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->
- Setup a bot like below:
  ```python
  import interactions as ipy
  
  bot = ipy.Client(intents=ipy.Intents.DEFAULT, debug_scope=<your_guild_id>)
  
  @ipy.slash_command()
  async def create_role(ctx: ipy.SlashContext):
      role = await ctx.guild.create_role(name="test role", permissions=ipy.Permissions.NONE)
      await ctx.send(f"role's new permissions: {role.permissions}")
  
  if __name__ == "__main__":
      bot.start("<token>")
  ```
- Prior to this change, you will see the bot respond with the permission set value being `137408993025601` (discord's default)
- After this change, you should instead see the bot respond with the permission set value being `0`

I didn't add any unit tests because it seemed like overkill for such a small edge case. But I can add one in if folks disagree.


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [x] I've ensured my code works on Python `3.10.x`
- [ ] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [ ] I've tested my changes on supported Python versions
- [x] I've added tests for my code, if applicable
- [x] I've updated / added  documentation, where applicable
