### PR TITLE
fix: don't assume msg reference always has msg id

### DIFF
--- a/interactions/models/discord/message.py
+++ b/interactions/models/discord/message.py
@@ -497,7 +497,7 @@ class Message(BaseMessage):
             _m = client.cache.place_message_data(ref_message_data)
             data["referenced_message_id"] = _m.id
         elif msg_reference := data.get("message_reference"):
-            data["referenced_message_id"] = msg_reference["message_id"]
+            data["referenced_message_id"] = msg_reference.get("message_id")
 
         if "interaction" in data:
             data["interaction"] = MessageInteraction.from_dict(data["interaction"], client)


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
This is a bit silly - sometimes Discord doesn't provide the message ID for message references... which *does* sound absurd, granted, but is correctly documented as not doing that in Discord's docs, so this is my fault. At least all the bug does is fill up my logs every once in a while.

## Changes
- Use `.get` to get the message ID for the referenced message, instead of blindly assuming it'll be there.

## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
