### PR TITLE
fix: Don't apply guild_id to messages fetched from DM history

### DIFF
--- a/interactions/models/discord/channel.py
+++ b/interactions/models/discord/channel.py
@@ -348,8 +348,9 @@ class MessageableMixin(SendMixin):
         messages_data = await self._client.http.get_channel_messages(
             self.id, limit, around=around, before=before, after=after
         )
-        for m in messages_data:
-            m["guild_id"] = self._guild_id
+        if isinstance(self, GuildChannel):
+            for m in messages_data:
+                m["guild_id"] = self._guild_id
 
         return [self._client.cache.place_message_data(m) for m in messages_data]
 


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
DM channels don't have a guild ID.


## Changes
- Added type check before copying guild_id.
- Added test case


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [ ] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [x] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
