### PR TITLE
fix: prevent udp ka from throwing error on close

### DIFF
--- a/interactions/api/voice/voice_gateway.py
+++ b/interactions/api/voice/voice_gateway.py
@@ -280,6 +280,8 @@ class VoiceGateway(WebsocketClient):
             except socket.error as e:
                 self.logger.warning(f"Ending Keep Alive due to {e}")
                 return
+            except AttributeError:
+                return
             except Exception as e:
                 self.logger.debug("Keep Alive Error: ", exc_info=e)
         self.logger.debug("Ending UDP Keep Alive")


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
<!-- Provide a clear and concise description of the purpose of this PR and why it should be merged -->
<!-- If your code adds or changes features, a usage example would be helpful -->
Prevents `AttributeError` when the voice client closes ungracefully. 

## Changes
<!-- List the changes you have made in a bullet-point format -->
- Catches said error 

## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
