### PR TITLE
fix emoji.edit allowing roleslist

### DIFF
--- a/interactions/models/discord/emoji.py
+++ b/interactions/models/discord/emoji.py
@@ -11,7 +11,7 @@ from interactions.client.utils.attr_converters import list_converter
 from interactions.client.utils.attr_converters import optional
 from interactions.client.utils.serializer import dict_filter_none, no_export_meta
 from interactions.models.discord.base import ClientObject
-from interactions.models.discord.snowflake import SnowflakeObject, to_snowflake
+from interactions.models.discord.snowflake import SnowflakeObject, to_snowflake, to_snowflake_list
 
 if TYPE_CHECKING:
     from interactions.client import Client
@@ -185,7 +185,7 @@ class CustomEmoji(PartialEmoji, ClientObject):
         data_payload = dict_filter_none(
             {
                 "name": name,
-                "roles": roles,
+                "roles": to_snowflake_list(roles) if roles else None,
             }
         )
 


### PR DESCRIPTION


## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
<!-- Provide a clear and concise description of the purpose of this PR and why it should be merged -->
<!-- If your code adds or changes features, a usage example would be helpful -->
Allowing list of Roles in CustomEmoji.edit() by converting it to snowflake_list.


## Changes
<!-- List the changes you have made in a bullet-point format -->
add to_snowflake_list() to convert list of Roles into list of snowflakes, according the roles argument definition.

## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->
#1426

## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->
```py
role1, role2 = interactions.Role(...)
emoji = await guild.fetch_custom_emoji(emoji_id=emoji_id)
await emoji.edit(roles=[role1, role2])
```

## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [x] I've ensured my code works on Python `3.10.x`
- [ ] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [ ] I've run the `pre-commit` code linter over all edited files
- [ ] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
