### PR TITLE
feat: add kwargs to paginator send & reply methods

### DIFF
--- a/interactions/ext/paginators.py
+++ b/interactions/ext/paginators.py
@@ -13,7 +13,6 @@ from interactions import (
     ButtonStyle,
     spread_to_rows,
     ComponentCommand,
-    InteractionContext,
     Message,
     MISSING,
     Snowflake_Type,

--- a/interactions/ext/paginators.py
+++ b/interactions/ext/paginators.py
@@ -380,6 +380,7 @@ class Paginator:
         Args:
             ctx: The context to reply this paginator with
             **kwargs: Additional options to pass to `reply`.
+
         Returns:
             The resulting message
         """

--- a/interactions/ext/paginators.py
+++ b/interactions/ext/paginators.py
@@ -13,6 +13,7 @@ from interactions import (
     ButtonStyle,
     spread_to_rows,
     ComponentCommand,
+    BaseContext,
     Message,
     MISSING,
     Snowflake_Type,

--- a/interactions/ext/paginators.py
+++ b/interactions/ext/paginators.py
@@ -13,7 +13,7 @@ from interactions import (
     ButtonStyle,
     spread_to_rows,
     ComponentCommand,
-    BaseContext,
+    InteractionContext,
     Message,
     MISSING,
     Snowflake_Type,
@@ -352,18 +352,19 @@ class Paginator:
             "components": [c.to_dict() for c in self.create_components()],
         }
 
-    async def send(self, ctx: BaseContext) -> Message:
+    async def send(self, ctx: InteractionContext, **kwargs) -> Message:
         """
         Send this paginator.
 
         Args:
             ctx: The context to send this paginator with
+            **kwargs: Additional options to pass to `send`.
 
         Returns:
             The resulting message
 
         """
-        self._message = await ctx.send(**self.to_dict())
+        self._message = await ctx.send(**self.to_dict(), **kwargs)
         self._author_id = ctx.author.id
 
         if self.timeout_interval > 1:
@@ -372,16 +373,17 @@ class Paginator:
 
         return self._message
 
-    async def reply(self, ctx: "PrefixedContext") -> Message:
+    async def reply(self, ctx: "PrefixedContext", **kwargs) -> Message:
         """
         Reply this paginator to ctx.
 
         Args:
             ctx: The context to reply this paginator with
+            **kwargs: Additional options to pass to `reply`.
         Returns:
             The resulting message
         """
-        self._message = await ctx.reply(**self.to_dict())
+        self._message = await ctx.reply(**self.to_dict(), **kwargs)
         self._author_id = ctx.author.id
 
         if self.timeout_interval > 1:

--- a/interactions/ext/paginators.py
+++ b/interactions/ext/paginators.py
@@ -352,7 +352,7 @@ class Paginator:
             "components": [c.to_dict() for c in self.create_components()],
         }
 
-    async def send(self, ctx: InteractionContext, **kwargs) -> Message:
+    async def send(self, ctx: BaseContext, **kwargs) -> Message:
         """
         Send this paginator.
 


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [x] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
Adds keyword arguments to paginator send and reply methods. 
These are then passed to the respective methods to pass-through their functionality

Example of usage - sending an ephemeral paginator: 
```
paginator = Paginator.create_from_string(bot, your_content, page_size=1000)
await paginator.send(ctx, ephemeral=True)  # <-- Added ephermal=True (other code taken from docs)
```

## Changes

- Added kwargs to paginator send & reply methods
- Updated BaseContext to InteractionContext as BaseContext does not include a send method


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [X] I've run the `pre-commit` code linter over all edited files
- [ ] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [X] I've updated / added  documentation, where applicable
