### PR TITLE
feat: Provide Guild ID in GuildLeft event

### DIFF
--- a/interactions/api/events/discord.py
+++ b/interactions/api/events/discord.py
@@ -29,6 +29,7 @@ import interactions.models
 from interactions.api.events.base import GuildEvent, BaseEvent
 from interactions.client.const import Absent
 from interactions.client.utils.attr_utils import docs
+from interactions.models.discord.snowflake import to_snowflake
 
 __all__ = (
     "ApplicationCommandPermissionsUpdate",
@@ -291,6 +292,9 @@ class GuildUpdate(BaseEvent):
 @attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class GuildLeft(BaseEvent):
     """Dispatched when a guild is left."""
+
+    guild_id: "Snowflake_Type" = attrs.field(repr=True, converter=to_snowflake)
+    """The ID of the guild"""
 
     guild: "Guild" = attrs.field(repr=True)
     """The guild this event is dispatched from"""

--- a/interactions/api/events/processors/guild_events.py
+++ b/interactions/api/events/processors/guild_events.py
@@ -69,7 +69,7 @@ class GuildEvents(EventMixinTemplate):
             guild = self.cache.get_guild(guild_id)
             self.cache.delete_guild(guild_id)
 
-            self.dispatch(events.GuildLeft(guild))
+            self.dispatch(events.GuildLeft(guild_id, guild))
 
     @Processor.define()
     async def _on_raw_guild_ban_add(self, event: "RawGatewayEvent") -> None:


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [x] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
Occasionally, a bot can recieve a GuildLeave event from an uncached guild.  If a user needs to do cleanup, we should provide an ID for them.


## Changes
- Add guild_id field, and pass it in to the event dispatch.


## Related Issues
https://discord.com/channels/789032594456576001/1113659088061083699


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [ ] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [ ] I've run the `pre-commit` code linter over all edited files
- [ ] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
