### PR TITLE
feat:  Warn if people try to run d.py alongside interactions

### DIFF
--- a/interactions/__init__.py
+++ b/interactions/__init__.py
@@ -1,3 +1,4 @@
+import sys
 from .client import (
     __api_version__,
     __py_version__,
@@ -680,6 +681,10 @@ __all__ = (
     "WebSocketOPCode",
 )
 
+if "discord" in sys.modules:
+    get_logger().error(
+        "`import discord` import detected.  Interactions.py is a completely separate library, and is not compatible with d.py models.  Please see https://interactions-py.github.io/interactions.py/Guides/100%20Migration%20From%20D.py/ for how to fix your code."
+    )
 
 ########################################################################################################################
 # Noteworthy Credits

--- a/interactions/client/const.py
+++ b/interactions/client/const.py
@@ -283,8 +283,3 @@ except AssertionError as e:
     raise RuntimeError(
         f"NON_RESUMABLE_WEBSOCKET_CLOSE_CODES contains codes that are not in RECOVERABLE_WEBSOCKET_CLOSE_CODES: {diff}"
     ) from e
-
-if "discord" in sys.modules:
-    get_logger().error(
-        "`import discord` import detected.  Interactions.py is a completely separate library, and is not compatible with d.py models.  Please see https://interactions-py.github.io/interactions.py/Guides/100%20Migration%20From%20D.py/ for how to fix your code."
-    )

--- a/interactions/client/const.py
+++ b/interactions/client/const.py
@@ -283,3 +283,8 @@ except AssertionError as e:
     raise RuntimeError(
         f"NON_RESUMABLE_WEBSOCKET_CLOSE_CODES contains codes that are not in RECOVERABLE_WEBSOCKET_CLOSE_CODES: {diff}"
     ) from e
+
+if "discord" in sys.modules:
+    get_logger().error(
+        "`import discord` import detected.  Interactions.py is a completely separate library, and is not compatible with d.py models.  Please see https://interactions-py.github.io/interactions.py/Guides/100%20Migration%20From%20D.py/ for how to fix your code."
+    )


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [x] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
We frequently recieve support requests where provided code snippits start with the line "import discord" and inevitably don't work. 
Due to the nature of humans generally importing stuff alphabetically, we can do runtime check for this import, and yell at them.


## Changes
<!-- List the changes you have made in a bullet-point format -->


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [ ] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
