### PR TITLE
feat: add permissions attr to channels

### DIFF
--- a/interactions/models/discord/channel.py
+++ b/interactions/models/discord/channel.py
@@ -775,6 +775,8 @@ class BaseChannel(DiscordObject):
     """The name of the channel (1-100 characters)"""
     type: Union[ChannelType, int] = attrs.field(repr=True, converter=ChannelType)
     """The channel topic (0-1024 characters)"""
+    permissions: Optional[Permissions] = attrs.field(repr=False, default=None, converter=optional_c(Permissions))
+    """Calculated permissions for the bot in this channel, only given when using channels as an option with slash commands"""
 
     @classmethod
     def from_dict_factory(cls, data: dict, client: "Client") -> "TYPE_ALL_CHANNEL":


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [x] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
In [the Discord API docs for channels](https://discord.com/developers/docs/resources/channel#channel-object), I noticed an attribute called `permissions`, which gives the calculated permissions for the current bot user if the channel was gotten as an option from a slash command. This PR adds that attribute into interactions.py itself.

*Note: technically, Discord doesn't specify that it'll not exist in DMs, but... yeah, it doesn't exist in DMs. I've decided to keep it in `BaseChannel` regardless to be consistent with Discord though.*

## Changes
- Add `permissions` to `BaseChannel`.

## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
```python
@interactions.slash_command(name="cmd", description="My command")
@interactions.slash_option(
    name="chan",
    description="My channel option",
    opt_type=interactions.OptionType.CHANNEL,
    required=True,
)
async def cmd(ctx: interactions.SlashContext, chan: interactions.BaseChannel):
    await ctx.send(str(chan.permissions))
```


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [x] I've updated / added  documentation, where applicable
