### PR TITLE
fix:  Add missing attributes to user.pyi stub file

### DIFF
--- a/interactions/models/discord/user.pyi
+++ b/interactions/models/discord/user.pyi
@@ -68,9 +68,11 @@ class FakeUserMixin(FakeBaseUserMixin):
     public_flags: UserFlags
     premium_type: PremiumType
     banner: Optional["Asset"]
+    avatar_decoration: Optional["Asset"]
     accent_color: Optional["Color"]
     activities: list[Activity]
     status: Absent[Status]
+    _fetched: bool
     @classmethod
     def _process_dict(cls, data: Dict[str, Any], client: Client) -> Dict[str, Any]: ...
     @property
@@ -148,6 +150,7 @@ class Member(FakeUserMixin):
         reason: Absent[str] = ...,
     ) -> dict: ...
     async def move(self, channel_id: Snowflake_Type) -> None: ...
+    async def disconnect(self) -> None: ...
     async def edit(
         self,
         *,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,6 @@ skip = ["__init__.py"]
 
 [tool.mypy]
 ignore_missing_imports = true
-plugins = "naff.ext.mypy"
 
 [tool.pyright]
 useLibraryCodeForTypes = true


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
It was raised that `avatar_decoration` wasn't in the stub file.  This PR adds it, and a few other attributes that weren't stubbed.


## Changes
- Adds missing attribute stubs
- Remove config line that prevents mypy from running in the repo


## Related Issues
https://canary.discord.com/channels/789032594456576001/1117602196813533365


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [x] I've ensured my code works on Python `3.10.x`
- [ ] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [ ] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
