### PR TITLE
fix: Correctly handle race condition if voice keepalive procs while reconnecting

### DIFF
--- a/interactions/api/voice/voice_gateway.py
+++ b/interactions/api/voice/voice_gateway.py
@@ -268,7 +268,7 @@ class VoiceGateway(WebsocketClient):
         keep_alive = b"\xc9\x00\x00\x00\x00\x00\x00\x00\x00"
 
         self.logger.debug("Starting UDP Keep Alive")
-        while not self.socket._closed and not self.ws.closed:
+        while not self.socket._closed and self.ws and not self.ws.closed:
             try:
                 _, writable, _ = select.select([], [self.socket], [], 0)
                 while not writable:


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
During Voice reconnect, we briefly set the websocket to None: https://github.com/interactions-py/interactions.py/blob/stable/interactions/api/voice/voice_gateway.py#L222-L236

If the keepalive triggers during that await, self.ws is None, and we get a lovely error.


## Changes
Do a null check before checking self.ws.connected


## Related Issues
https://canary.discord.com/channels/789032594456576001/1095994644929708083/1118804300357967872
https://github.com/interactions-py/interactions.py/actions/runs/5285126118/jobs/9563299904


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [ ] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [ ] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
