### PR TITLE
feat: warn users when they try and send attachments as files

### DIFF
--- a/interactions/client/mixins/send.py
+++ b/interactions/client/mixins/send.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING, Any, Iterable, Optional, Union
 
 import interactions.models as models
+import interactions.models.discord
 from interactions.models.discord.enums import MessageFlags
 
 if TYPE_CHECKING:
@@ -81,6 +82,18 @@ class SendMixin:
             if isinstance(flags, int):
                 flags = MessageFlags(flags)
             flags = flags | MessageFlags.SILENT
+
+        if (
+            files
+            and (
+                isinstance(files, Iterable)
+                and any(isinstance(file, interactions.models.discord.message.Attachment) for file in files)
+            )
+            or isinstance(files, interactions.models.discord.message.Attachment)
+        ):
+            raise ValueError(
+                "Attachments are not files. Attachments only contain metadata about the file, not the file itself - to send an attachment, you need to download it first. Check Attachment.url"
+            )
 
         message_payload = models.discord.message.process_message_payload(
             content=content,


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [x] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
<!-- Provide a clear and concise description of the purpose of this PR and why it should be merged -->
<!-- If your code adds or changes features, a usage example would be helpful -->
Stop users from thinking attachments and files are the same thing. 

I considered transparently handling it, but I thought better of it as I was implementing it as it's wholly unnecessary... and to be candid this is user error through and through 

## Changes
<!-- List the changes you have made in a bullet-point format -->
- Check type of files being passed to SendMixin.send

## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->
- Too many help threads


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->
```python
@slash_command("test", description="Test command")
@slash_option("attachment", "Attachment", OptionType.ATTACHMENT, required=True)
async def test_command(ctx: InteractionContext, attachment: File):
    await ctx.send("Hello world!", files=[attachment])
    # await ctx.send("Hello world!", files=attachment)   # uncomment to check both wrapped and unwrapped files
```
![image](https://github.com/interactions-py/interactions.py/assets/22540825/9fa3cf8d-19a7-42e9-9bda-614551eef31c)


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
