### PR TITLE
fix: filter out cache misses from guild properties

### DIFF
--- a/interactions/models/discord/guild.py
+++ b/interactions/models/discord/guild.py
@@ -348,7 +348,8 @@ class Guild(BaseGuild):
     @property
     def members(self) -> List["models.Member"]:
         """Returns a list of all members within this guild."""
-        return [self._client.cache.get_member(self.id, m_id) for m_id in self._member_ids]
+        members = (self._client.cache.get_member(self.id, m_id) for m_id in self._member_ids)
+        return [m for m in members if m]
 
     @property
     def premium_subscribers(self) -> List["models.Member"]:

--- a/interactions/models/discord/guild.py
+++ b/interactions/models/discord/guild.py
@@ -369,7 +369,8 @@ class Guild(BaseGuild):
     @property
     def roles(self) -> List["models.Role"]:
         """Returns a list of roles associated with this guild."""
-        return sorted([self._client.cache.get_role(r_id) for r_id in self._role_ids], reverse=True)
+        roles = sorted((self._client.cache.get_role(r_id) for r_id in self._role_ids), reverse=True)
+        return [r for r in roles if r]
 
     @property
     def me(self) -> "models.Member":


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
Just a quick PR to filter out `None`s and the like from `guild.members` and `guild.roles`. This fixes a lot of events from erroring out.


## Changes
- Filter out `None` from `Guild.member/roles` through a secondary comprehension.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
- Disable member and role cache.
- Start up bot, send messages so that members are cached.
- Leave guild, observe errors.


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
