### PR TITLE
fix: properly parse image from dict for embeds

### DIFF
--- a/interactions/models/discord/embed.py
+++ b/interactions/models/discord/embed.py
@@ -229,6 +229,12 @@ class Embed(DictSerializationMixin):
         metadata=no_export_meta,
     )
 
+    @classmethod
+    def _process_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
+        if image_data := data.pop("image", None):
+            data["images"] = [image_data]
+        return data
+
     @property
     def image(self) -> Optional[EmbedAttachment]:
         """


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
Ever since the change to make `Embed` have `images` instead of `image`, it seems like there was a bug where embeds from messages (or from a passed-in dictionary in general) were not processed properly by `Embed` and so were missing from the resulting object. This PR fixes that.


## Changes
- Convert "image" field in a dict to "images" if detected when processing the dict for `Embed`.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
- Send message on Discord with an embed with an image.
- Fetch that message, look at the embed, and observe the lack of an image in the resulting object.


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
