### PR TITLE
fix: filter out Nones from guild.role before sorting

### DIFF
--- a/interactions/models/discord/guild.py
+++ b/interactions/models/discord/guild.py
@@ -369,8 +369,7 @@ class Guild(BaseGuild):
     @property
     def roles(self) -> List["models.Role"]:
         """Returns a list of roles associated with this guild."""
-        roles = sorted((self._client.cache.get_role(r_id) for r_id in self._role_ids), reverse=True)
-        return [r for r in roles if r]
+        return sorted((r for r_id in self._role_ids if (r := self._client.cache.get_role(r_id))), reverse=True)
 
     @property
     def me(self) -> "models.Member":


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
Yes, this is a bug fix to a bug fix. More specifically #1454.
Basically, if the cache returned `None` for a role, `sorted` would still try to sort those `None`s as they haven't been filtered out yet... so you can end up in scenarios where it tries to compare a `NoneType` to a `NoneType`.

## Changes
- Use a funny list comprehension to filter out `None`s in the generator passed to `sorted` for `guild.roles`.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
