### PR TITLE
fix: cannot get user of message interaction

### DIFF
--- a/interactions/models/discord/message.py
+++ b/interactions/models/discord/message.py
@@ -187,9 +187,10 @@ class MessageInteraction(DiscordObject):
         data["user_id"] = client.cache.place_user_data(user_data).id
         return data
 
-    async def user(self) -> "models.User":
+    @property
+    def user(self) -> "models.User":
         """Get the user associated with this interaction."""
-        return await self.get_user(self._user_id)
+        return self.client.get_user(self._user_id)
 
 
 @attrs.define(eq=False, order=False, hash=False, kw_only=False)


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
<!-- Provide a clear and concise description of the purpose of this PR and why it should be merged -->
<!-- If your code adds or changes features, a usage example would be helpful -->
When tries to get user of message interaction via `await ctx.message.interaction.user()` it raises an exception

```py
Ignoring exception in Component Callback for message_delete:
Traceback (most recent call last):
  File "bot/venv/Lib/site-packages/interactions/client/client.py", line 1890, in __dispatch_interaction
    response = await callback
               ^^^^^^^^^^^^^^
  File "bot/venv/Lib/site-packages/interactions/models/internal/command.py", line 132, in __call__
    await self.call_callback(self.callback, context)
  File "bot/venv/Lib/site-packages/interactions/models/internal/command.py", line 198, in call_callback
    await self.call_with_binding(callback, context, **context.kwargs)  # type: ignore
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "bot/venv/Lib/site-packages/interactions/models/internal/callback.py", line 43, in call_with_binding
    return await callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "bot/extensions/events.py", line 46, in message_delete
    reference = await ctx.message.interaction.user()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "bot/venv/Lib/site-packages/interactions/models/discord/message.py", line 192, in user  
    return await self.get_user(self._user_id)
                 ^^^^^^^^^^^^^
AttributeError: 'MessageInteraction' object has no attribute 'get_user'
```


## Changes
<!-- List the changes you have made in a bullet-point format -->
- Make `MessageInteraction.user` as property, not as async function.
- Use `self.client.get_user` instead of nonexistent `self.get_user`


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [ ] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
