### PR TITLE
docs: make autocomplete usage clearer

### DIFF
--- a/docs/src/Guides/03 Creating Commands.md
+++ b/docs/src/Guides/03 Creating Commands.md
@@ -260,20 +260,23 @@ from interactions import AutocompleteContext
 
 @my_command.autocomplete("string_option")
 async def autocomplete(self, ctx: AutocompleteContext):
-    # make sure this is done within three seconds
+    string_option_input = ctx.input_text  # can be empty
+    # you can use ctx.kwargs.get("name") for other options - note they can be empty too
+
+    # make sure you respond within three seconds
     await ctx.send(
         choices=[
             {
-                "name": f"{ctx.input_text}a",
-                "value": f"{ctx.input_text}a",
+                "name": f"{string_option_input}a",
+                "value": f"{string_option_input}a",
             },
             {
-                "name": f"{ctx.input_text}b",
-                "value": f"{ctx.input_text}b",
+                "name": f"{string_option_input}b",
+                "value": f"{string_option_input}b",
             },
             {
-                "name": f"{ctx.input_text}c",
-                "value": f"{ctx.input_text}c",
+                "name": f"{string_option_input}c",
+                "value": f"{string_option_input}c",
             },
         ]
     )


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [ ] Bugfix
- [x] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
This PR makes the autocomplete part of the slash command guide clearer. This basically resolves #1349's original complaint, though this doesn't change anything about `AutocompleteContext`'s API reference.

## Changes

- Make it clearer what `ctx.input_text` is through a variable.
- Note how to get other options in the command (through `ctx.kwargs`).
- Adjust responding comment wording.
- 

## Related Issues
#1349 


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [ ] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [ ] I've run the `pre-commit` code linter over all edited files
- [ ] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [x] I've updated / added  documentation, where applicable
