### PR TITLE
feat: Add support for return-style command callbacks

### DIFF
--- a/docs/src/Guides/03 Creating Commands.md
+++ b/docs/src/Guides/03 Creating Commands.md
@@ -9,6 +9,7 @@ To create an interaction, simply define an asynchronous function and use the `@s
 
 Interactions need to be responded to within 3 seconds. To do this, use `await ctx.send()`.
 If your code needs more time, don't worry. You can use `await ctx.defer()` to increase the time until you need to respond to the command to 15 minutes.
+For very simple commands, you can instead simply return a string
 ```python
 from interactions import slash_command, SlashContext
 
@@ -25,6 +26,11 @@ async def my_long_command_function(ctx: SlashContext):
     await asyncio.sleep(600)
 
     await ctx.send("Hello World")
+
+@slash_command(name="my_simple_command", description="My third command :)")
+async def my_command_function(ctx: SlashContext):
+    return "Hello World"
+
 ```
 ???+ note
     Command names must be lowercase and can only contain `-` and `_` as special symbols and must not contain spaces.


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [x] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
This was in the original v5 plans, but fell to the side in the push for actually releasing in a reasonable time.

Allows commands to return a string or Embed rather than calling `await ctx.send()`.  Useful for lambda-style one-line commands.


## Changes
- Add typecheck to command return-value, and pass it to Context.send if applicable.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [x] I've updated / added  documentation, where applicable
