### PR TITLE
fix: allow delete_after for ephemeral messages

### DIFF
--- a/interactions/client/mixins/send.py
+++ b/interactions/client/mixins/send.py
@@ -111,5 +111,8 @@ class SendMixin:
         if message_data:
             message = self.client.cache.place_message_data(message_data)
             if delete_after:
-                await message.delete(delay=delete_after)
+                if kwargs.get("pass_self_into_delete"):  # hack to pass in interaction/hybrid context
+                    await message.delete(delay=delete_after, context=self)
+                else:
+                    await message.delete(delay=delete_after)
             return message

--- a/interactions/ext/hybrid_commands/context.py
+++ b/interactions/ext/hybrid_commands/context.py
@@ -311,6 +311,7 @@ class HybridContext(BaseContext, SendMixin):
             tts=tts,
             flags=flags,
             delete_after=delete_after,
+            pass_self_into_delete=bool(self._slash_ctx),
             **kwargs,
         )
 

--- a/interactions/models/internal/context.py
+++ b/interactions/models/internal/context.py
@@ -523,6 +523,7 @@ class InteractionContext(BaseInteractionContext, SendMixin):
             tts=tts,
             flags=flags,
             delete_after=delete_after,
+            pass_self_into_delete=True,
             **kwargs,
         )
 


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
This PR allows using `delete_after` for ephemeral messages, which previously produced an error due to not passing the context in for `message.delete(...)`. This uses a purposely hidden kwarg to do so - let me know if that needs to be changed.


## Changes

- Use a hidden kwarg for `SendMixin` to determine if the mixin should pass in itself for `message.delete(...)`. I figured it was better than using an isinstance and potentially maybe causing recursive imports.
- Make `InteractionContext` and `HybridContext` pass this value as appropriate.

## Related Issues
Fixes #1465.


## Test Scenarios
- Send an ephemeral message through a slash command (broken on hybrid commands due to a different bug that will be PRed shortly).
- Use `delete_after` while sending.


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
