### PR TITLE
fix: properly pass in ephemeral for hybrid ctx

### DIFF
--- a/interactions/ext/hybrid_commands/context.py
+++ b/interactions/ext/hybrid_commands/context.py
@@ -290,7 +290,7 @@ class HybridContext(BaseContext, SendMixin):
             New message object that was sent.
         """
         flags = MessageFlags(flags or 0)
-        if ephemeral and not self._slash_ctx:
+        if ephemeral and self._slash_ctx:
             flags |= MessageFlags.EPHEMERAL
             self.ephemeral = True
         if suppress_embeds:


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
Seems like people forgot `ephemeral` exists for hybrid commands while testing... though it is a weird decision to use one there. Regardless, this PR fixes a bug that prevented it from working for slash command usages.


## Changes
- Properly check if `_slash_ctx` exist when doing `ephemeral` checks.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
- Make hybrid command with an ephemeral message.
- Use the slash command version.


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
