### PR TITLE
fix: allow int for colo(u)r for Guild.create_role

### DIFF
--- a/interactions/models/discord/guild.py
+++ b/interactions/models/discord/guild.py
@@ -1476,7 +1476,7 @@ class Guild(BaseGuild):
             payload["permissions"] = str(int(permissions))
 
         if colour := colour or color:
-            payload["color"] = colour.value
+            payload["color"] = colour if isinstance(colour, int) else colour.value
 
         if hoist:
             payload["hoist"] = True


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
A quick little fix for `Guild.create_role` to properly parse in `int`s for `colo(u)r`.


## Changes
- Use an isinstance check to properly pass in value of color for the payload's color for `Guild.create_role`.


## Related Issues
Fixes #1464.


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
