### PR TITLE
fix: properly parse converters for hybrid commands

### DIFF
--- a/interactions/ext/hybrid_commands/hybrid_slash.py
+++ b/interactions/ext/hybrid_commands/hybrid_slash.py
@@ -13,7 +13,6 @@ from interactions import (
     BaseChannelConverter,
     ChannelType,
     BaseChannel,
-    BaseCommand,
     MemberConverter,
     UserConverter,
     RoleConverter,
@@ -177,7 +176,7 @@ class ChainConverter(Converter):
     def __init__(
         self,
         first_converter: Converter,
-        second_converter: type[Converter] | Converter,
+        second_converter: Callable,
         name_of_cmd: str,
     ) -> None:
         self.first_converter = first_converter
@@ -186,16 +185,14 @@ class ChainConverter(Converter):
 
     async def convert(self, ctx: BaseContext, arg: str) -> Any:
         first = await self.first_converter.convert(ctx, arg)
-        return await maybe_coroutine(
-            BaseCommand._get_converter_function(self.second_converter, self.name_of_cmd)(ctx, first)
-        )
+        return await maybe_coroutine(self.second_converter, ctx, first)
 
 
 class ChainNoArgConverter(NoArgumentConverter):
     def __init__(
         self,
         first_converter: NoArgumentConverter,
-        second_converter: type[Converter] | Converter,
+        second_converter: Callable,
         name_of_cmd: str,
     ) -> None:
         self.first_converter = first_converter
@@ -204,9 +201,7 @@ class ChainNoArgConverter(NoArgumentConverter):
 
     async def convert(self, ctx: "HybridContext", _: Any) -> Any:
         first = await self.first_converter.convert(ctx, _)
-        return await maybe_coroutine(
-            BaseCommand._get_converter_function(self.second_converter, self.name_of_cmd)(ctx, first)
-        )
+        return await maybe_coroutine(self.second_converter, ctx, first)
 
 
 def type_from_option(option_type: OptionType | int) -> Converter:


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
Who know that the complex prefixafication of slash commands could lead to bugs?

I (somewhat) kid of course. Regardless, this PR fixes one such bug - it turns out that I was assuming `SlashCommandParameter.converter` was, well, a `Converter`, when in reality it's actually the equivalent of the `convert` function *inside* of the converter (which is done so that we don't waste time initing a converter every single time... that can get quite time consuming). The hybrid command parser did not account for this, so I went back to make it do so.


## Changes
- Assume `second_converter` in the chain converters are functions, not actual converters. This has the extra benefit of getting rid of an import and simplifying the code.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
```python
class TestConverter(interactions.Converter):
    async def convert(self, ctx: interactions.SlashContext, arg: str):
        return arg.upper()

@hybrid.hybrid_slash_command(
    name="info"
)
@interactions.slash_option(
    name="arg",
    description="The argument to send",
    opt_type=interactions.OptionType.STRING,
    required=True,
)
async def dummy(ctx: hybrid.HybridContext, arg: TestConverter):
    await ctx.send(str(arg))
```


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
