### PR TITLE
fix: wrap timestamp converter

### DIFF
--- a/interactions/client/utils/attr_converters.py
+++ b/interactions/client/utils/attr_converters.py
@@ -1,5 +1,6 @@
 import inspect
 import typing
+import interactions
 from datetime import datetime
 from typing import Callable, Union, Any
 
@@ -20,13 +21,18 @@ def timestamp_converter(value: Union[datetime, int, float, str]) -> Timestamp:
         A Timestamp object
 
     """
-    if isinstance(value, str):
-        return Timestamp.fromisoformat(value)
-    if isinstance(value, (float, int)):
-        return Timestamp.fromtimestamp(float(value))
-    if isinstance(value, datetime):
-        return Timestamp.fromdatetime(value)
-    raise TypeError("Timestamp must be one of: datetime, int, float, ISO8601 str")
+    try:
+        if isinstance(value, str):
+            return Timestamp.fromisoformat(value)
+        if isinstance(value, (float, int)):
+            return Timestamp.fromtimestamp(float(value))
+        if isinstance(value, datetime):
+            return Timestamp.fromdatetime(value)
+        raise TypeError("Timestamp must be one of: datetime, int, float, ISO8601 str")
+    except ValueError as e:
+        interactions.const.get_logger().warning("Failed to convert timestamp", exc_info=e)
+        # Should only happen if the timestamp is something stupid like 269533-01-01T00:00 - in which case we just return MISSING
+        return MISSING
 
 
 def list_converter(converter) -> Callable[[list], list]:


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
<!-- Provide a clear and concise description of the purpose of this PR and why it should be merged -->
<!-- If your code adds or changes features, a usage example would be helpful -->
Wraps timestamp's converter to handle stupid values like `269533-01-01T00:00`


## Changes
<!-- List the changes you have made in a bullet-point format -->
- Return `MISSING` if timestamp converter hits a ValueError 


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->

![image](https://github.com/interactions-py/interactions.py/assets/22540825/f142f8d0-9a2a-4553-859a-3800ad0e9756)

https://discord.com/channels/789032594456576001/1126845035133030441/1126845035133030441

## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [x] I've ensured my code works on Python `3.10.x`
- [ ] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [x] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
