### PR TITLE
feat: cache channel data from interactions

### DIFF
--- a/interactions/models/internal/context.py
+++ b/interactions/models/internal/context.py
@@ -284,6 +284,9 @@ class BaseInteractionContext(BaseContext):
         instance.resolved = Resolved.from_dict(client, payload["data"].get("resolved", {}), payload.get("guild_id"))
 
         instance.channel_id = Snowflake(payload["channel_id"])
+        if channel := payload.get("channel"):
+            client.cache.place_channel_data(channel)
+
         if member := payload.get("member"):
             instance.author_id = Snowflake(member["user"]["id"])
             instance.guild_id = Snowflake(payload["guild_id"])


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [x] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
What, did you think I was done with PRs?

This PR caches [channels in interactions](https://discord.com/developers/docs/interactions/receiving-and-responding), a relatively new addition to the interaction payload. As these only have partial data, these shouldn't be trusted as the sole source of information if possible - but for bots that disable/limit the channel cache, this addition is very nice.


## Changes
- Place/update channel in cache if it exists in the interaction payload when parsing interaction contexts.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
- Severely limit channel cache.
- Print out `ctx.channel` in a command.


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
