### PR TITLE
fix: account for BaseChannel for channel mentions

### DIFF
--- a/interactions/models/discord/message.py
+++ b/interactions/models/discord/message.py
@@ -24,7 +24,7 @@ from interactions.client.utils.attr_converters import optional as optional_c
 from interactions.client.utils.attr_converters import timestamp_converter
 from interactions.client.utils.serializer import dict_filter_none
 from interactions.client.utils.text_utils import mentions
-from interactions.models.discord.channel import BaseChannel
+from interactions.models.discord.channel import BaseChannel, GuildChannel
 from interactions.models.discord.emoji import process_emoji_req_format
 from interactions.models.discord.file import UPLOADABLE_TYPE
 from interactions.models.discord.embed import process_embeds
@@ -109,7 +109,7 @@ class Attachment(DiscordObject):
 
 @attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class ChannelMention(DiscordObject):
-    guild_id: "Snowflake_Type" = attrs.field(
+    guild_id: "Snowflake_Type | None" = attrs.field(
         repr=False,
     )
     """id of the guild containing the channel"""
@@ -466,7 +466,7 @@ class Message(BaseMessage):
                 if channel_id not in found_ids and (channel := client.get_channel(channel_id)):
                     channel_data = {
                         "id": channel.id,
-                        "guild_id": channel._guild_id,
+                        "guild_id": channel._guild_id if isinstance(channel, GuildChannel) else None,
                         "type": channel.type,
                         "name": channel.name,
                     }


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
This PR fixes the assumption that every channel mention a bot gets for a message is a `GuildChannel`. Instead, we now properly handle if it isn't, and properly assign `None` as the guild ID for the resulting `ChannelMention`.

## Changes
- See above.


## Related Issues
Fixes #1466 - well, okay, it fixes an issue mentioned in it, but GitHub parsing is GitHub parsing.


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
