### PR TITLE
feat: add default to delete/edit init interaction msg

### DIFF
--- a/interactions/models/internal/context.py
+++ b/interactions/models/internal/context.py
@@ -544,18 +544,20 @@ class InteractionContext(BaseInteractionContext, SendMixin):
 
     respond = send
 
-    async def delete(self, message: "Snowflake_Type") -> None:
+    async def delete(self, message: "Snowflake_Type" = "@original") -> None:
         """
         Delete a message sent in response to this interaction.
 
         Args:
-            message: The message to delete
+            message: The message to delete. Defaults to @original which represents the initial response message.
         """
-        await self.client.http.delete_interaction_message(self.client.app.id, self.token, to_snowflake(message))
+        await self.client.http.delete_interaction_message(
+            self.client.app.id, self.token, to_snowflake(message) if message != "@original" else message
+        )
 
     async def edit(
         self,
-        message: "Snowflake_Type",
+        message: "Snowflake_Type" = "@original",
         *,
         content: typing.Optional[str] = None,
         embeds: typing.Optional[
@@ -591,7 +593,7 @@ class InteractionContext(BaseInteractionContext, SendMixin):
             payload=message_payload,
             application_id=self.client.app.id,
             token=self.token,
-            message_id=to_snowflake(message),
+            message_id=to_snowflake(message) if message != "@original" else message,
             files=files,
         )
         if message_data:


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [x] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
This PR adds a default value for the message in `InteractionContext.edit/delete` that deletes the initial interaction response. Many people were getting confused at those two not doing exactly this, resulting in things that seemed like bugs to them.

## Changes
- Add `@original` as the default `message` for `InteractionContext.edit/delete`, and pass them directly in if the message is that. Discord handles the rest.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
