### PR TITLE
feat: add start_time(s) for AutoShardedClient

### DIFF
--- a/interactions/client/auto_shard_client.py
+++ b/interactions/client/auto_shard_client.py
@@ -75,9 +75,9 @@ class AutoShardedClient(Client):
         return next((state.start_time for state in self._connection_states), MISSING)  # type: ignore
 
     @property
-    def start_times(self) -> list[datetime]:
+    def start_times(self) -> dict[int, datetime]:
         """The start times of all shards of the bot."""
-        return [state.start_time for state in self._connection_states]  # type: ignore
+        return {state.shard_id: state.start_time for state in self._connection_states}  # type: ignore
 
     async def stop(self) -> None:
         """Shutdown the bot."""

--- a/interactions/client/auto_shard_client.py
+++ b/interactions/client/auto_shard_client.py
@@ -1,5 +1,6 @@
 import asyncio
 import time
+from datetime import datetime
 from collections import defaultdict
 from typing import TYPE_CHECKING, Optional
 
@@ -67,6 +68,16 @@ class AutoShardedClient(Client):
             {shard_id: latency}
         """
         return {state.shard_id: state.latency for state in self._connection_states}
+
+    @property
+    def start_time(self) -> datetime:
+        """The start time of the first shard of the bot."""
+        return next((state.start_time for state in self._connection_states), MISSING)  # type: ignore
+
+    @property
+    def start_times(self) -> list[datetime]:
+        """The start times of all shards of the bot."""
+        return [state.start_time for state in self._connection_states]  # type: ignore
 
     async def stop(self) -> None:
         """Shutdown the bot."""

--- a/interactions/client/auto_shard_client.py
+++ b/interactions/client/auto_shard_client.py
@@ -76,7 +76,7 @@ class AutoShardedClient(Client):
 
     @property
     def start_times(self) -> dict[int, datetime]:
-        """The start times of all shards of the bot."""
+        """The start times of all shards of the bot, keyed by each shard ID."""
         return {state.shard_id: state.start_time for state in self._connection_states}  # type: ignore
 
     async def stop(self) -> None:


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [x] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
Simply adds `start_time` and `start_times` to `AutoShardedClient`. This fixes a couple of compatibility issues when using it.

Also a bugfix, since `start_time` was erroring out beforehand.


## Changes
See above.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
