### PR TITLE
feat: add id attr to app perms update event

### DIFF
--- a/interactions/api/events/discord.py
+++ b/interactions/api/events/discord.py
@@ -142,6 +142,7 @@ class AutoModDeleted(AutoModCreated):
 
 @attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class ApplicationCommandPermissionsUpdate(BaseEvent):
+    id: "Snowflake_Type" = attrs.field(repr=False, metadata=docs("The ID of the command permissions were updated for"))
     guild_id: "Snowflake_Type" = attrs.field(
         repr=False, metadata=docs("The guild the command permissions were updated in")
     )


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [x] Feature addition
- [ ] Bugfix
- [x] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
<!-- Provide a clear and concise description of the purpose of this PR and why it should be merged -->
<!-- If your code adds or changes features, a usage example would be helpful -->

The `id` field of this gateway event is missing in our library implementation, as I was browsing through the Discord Gateway API's receive events to find any remaining inconsistencies. This PR proposes implementing it into the dataclass so developers may have access to it.

## Changes
<!-- List the changes you have made in a bullet-point format -->

- Added an `id` attribute to the `ApplicationCommandPermissionsUpdate(BaseEvent)` dataclass.

## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->

#1473 

## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->

## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [x] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`

## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [x] I've added tests for my code, if applicable
- [x] I've updated / added  documentation, where applicable