### PR TITLE
fix: use message channel for PrefixedContext

### DIFF
--- a/interactions/ext/prefixed_commands/context.py
+++ b/interactions/ext/prefixed_commands/context.py
@@ -4,6 +4,7 @@ from typing_extensions import Self
 
 from interactions.client.client import Client
 from interactions.client.mixins.send import SendMixin
+from interactions.models.discord.channel import TYPE_MESSAGEABLE_CHANNEL
 from interactions.models.discord.embed import Embed
 from interactions.models.discord.file import UPLOADABLE_TYPE
 from interactions.models.discord.message import Message
@@ -61,6 +62,11 @@ class PrefixedContext(BaseContext, SendMixin):
     def message(self) -> Message:
         """The message that invoked this context."""
         return self._message
+
+    @property
+    def channel(self) -> TYPE_MESSAGEABLE_CHANNEL:
+        """The channel this context was invoked in."""
+        return self.message.channel
 
     @property
     def invoke_target(self) -> str:


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
This PR fixes `PrefixedContext`'s `channel` in DMs, as using the cache only (as `BaseContext` did) would result in an error. Instead, `channel` now is an alias to `message.channel`.

## Changes
- Make `channel` in `PrefixedContext` an alias to `message.channel`.


## Related Issues
Half of #1490.


## Test Scenarios
Run a prefixed/hybrid command in DMs and use `ctx.channel`.


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
