### PR TITLE
fix: bind app_permissions for HybridContext

### DIFF
--- a/interactions/ext/hybrid_commands/context.py
+++ b/interactions/ext/hybrid_commands/context.py
@@ -118,6 +118,8 @@ class HybridContext(BaseContext, SendMixin):
             app_permissions = ctx.channel.permissions_for(ctx.guild.me)  # type: ignore
         elif ctx.channel.type in {10, 11, 12}:  # it's a thread
             app_permissions = ctx.channel.parent_channel.permissions_for(ctx.guild.me)  # type: ignore
+        else:
+            app_permissions = Permissions(0)
 
         self = cls(ctx.client)
         self.guild_id = ctx.guild_id


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
This PR binds (un-unbounds? bounds?) `app_permissions` in `HybridContext.from_prefixed_command`.

## Changes
See the above. It has the above benefit, when combined with #1491, of making hybrid commands work in DMs.


## Related Issues
Half of #1490.


## Test Scenarios
Use a hybrid command in DMs (ideally with #1491 active).


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
