### PR TITLE
feat: add ability to use different arg name than option name

### DIFF
--- a/interactions/ext/hybrid_commands/hybrid_slash.py
+++ b/interactions/ext/hybrid_commands/hybrid_slash.py
@@ -351,7 +351,7 @@ def slash_to_prefixed(cmd: HybridSlashCommand) -> _HybridToPrefixedCommand:  # n
             # there isn't much we can do here
             raise ValueError("Autocomplete is unsupported in hybrid commands.")
 
-        name = str(option.name)
+        name = option.argument_name or str(option.name)
         annotation = inspect.Parameter.empty
         default = inspect.Parameter.empty
         kind = inspect.Parameter.POSITIONAL_ONLY if cmd._uses_arg else inspect.Parameter.POSITIONAL_OR_KEYWORD

--- a/interactions/models/internal/annotations/slash.py
+++ b/interactions/models/internal/annotations/slash.py
@@ -35,6 +35,7 @@ def slash_str_option(
     choices: List[Union["SlashCommandChoice", dict]] | None = None,
     min_length: Optional[int] = None,
     max_length: Optional[int] = None,
+    name: Optional[str] = None,
 ) -> Type[str]:
     """
     Annotates an argument as a string type slash command option.
@@ -46,10 +47,11 @@ def slash_str_option(
         choices: The choices allowed by this command
         min_length: The minimum length of text a user can input.
         max_length: The maximum length of text a user can input.
+        name: The name of the option. Defaults to the name of the argument
 
     """
     return SlashCommandOption(
-        name="placeholder",
+        name=name,
         description=description,
         required=required,
         autocomplete=autocomplete,
@@ -67,6 +69,7 @@ def slash_float_option(
     choices: List[Union["SlashCommandChoice", dict]] | None = None,
     min_value: Optional[float] = None,
     max_value: Optional[float] = None,
+    name: Optional[str] = None,
 ) -> Type[float]:
     """
     Annotates an argument as a float type slash command option.
@@ -78,10 +81,11 @@ def slash_float_option(
         choices: The choices allowed by this command
         min_value: The minimum number allowed
         max_value: The maximum number allowed
+        name: The name of the option. Defaults to the name of the argument
 
     """
     return SlashCommandOption(
-        name="placeholder",
+        name=name,
         description=description,
         required=required,
         autocomplete=autocomplete,
@@ -99,6 +103,7 @@ def slash_int_option(
     choices: List[Union["SlashCommandChoice", dict]] | None = None,
     min_value: Optional[float] = None,
     max_value: Optional[float] = None,
+    name: Optional[str] = None,
 ) -> Type[int]:
     """
     Annotates an argument as a integer type slash command option.
@@ -110,10 +115,11 @@ def slash_int_option(
         choices: The choices allowed by this command
         min_value: The minimum number allowed
         max_value: The maximum number allowed
+        name: The name of the option. Defaults to the name of the argument
 
     """
     return SlashCommandOption(
-        name="placeholder",
+        name=name,
         description=description,
         required=required,
         autocomplete=autocomplete,
@@ -127,6 +133,7 @@ def slash_int_option(
 def slash_bool_option(
     description: str,
     required: bool = False,
+    name: Optional[str] = None,
 ) -> Type[bool]:
     """
     Annotates an argument as a boolean type slash command option.
@@ -134,10 +141,11 @@ def slash_bool_option(
     Args:
         description: The description of your option
         required: Is this option required?
+        name: The name of the option. Defaults to the name of the argument
 
     """
     return SlashCommandOption(
-        name="placeholder",
+        name=name,
         description=description,
         required=required,
         type=models.OptionType.BOOLEAN,
@@ -148,6 +156,7 @@ def slash_user_option(
     description: str,
     required: bool = False,
     autocomplete: bool = False,
+    name: Optional[str] = None,
 ) -> Type[Union["User", "Member"]]:
     """
     Annotates an argument as a user type slash command option.
@@ -156,10 +165,11 @@ def slash_user_option(
         description: The description of your option
         required: Is this option required?
         autocomplete: Use autocomplete for this option
+        name: The name of the option. Defaults to the name of the argument
 
     """
     return SlashCommandOption(
-        name="placeholder",
+        name=name,
         description=description,
         required=required,
         autocomplete=autocomplete,
@@ -173,6 +183,7 @@ def slash_channel_option(
     autocomplete: bool = False,
     choices: List[Union["SlashCommandChoice", dict]] | None = None,
     channel_types: Optional[list[Union["ChannelType", int]]] = None,
+    name: Optional[str] = None,
 ) -> Type["BaseChannel"]:
     """
     Annotates an argument as a channel type slash command option.
@@ -183,10 +194,11 @@ def slash_channel_option(
         autocomplete: Use autocomplete for this option
         choices: The choices allowed by this command
         channel_types: The types of channel allowed by this option
+        name: The name of the option. Defaults to the name of the argument
 
     """
     return SlashCommandOption(
-        name="placeholder",
+        name=name,
         description=description,
         required=required,
         autocomplete=autocomplete,
@@ -201,6 +213,7 @@ def slash_role_option(
     required: bool = False,
     autocomplete: bool = False,
     choices: List[Union["SlashCommandChoice", dict]] | None = None,
+    name: Optional[str] = None,
 ) -> Type["Role"]:
     """
     Annotates an argument as a role type slash command option.
@@ -210,10 +223,11 @@ def slash_role_option(
         required: Is this option required?
         autocomplete: Use autocomplete for this option
         choices: The choices allowed by this command
+        name: The name of the option. Defaults to the name of the argument
 
     """
     return SlashCommandOption(
-        name="placeholder",
+        name=name,
         description=description,
         required=required,
         autocomplete=autocomplete,
@@ -227,6 +241,7 @@ def slash_mentionable_option(
     required: bool = False,
     autocomplete: bool = False,
     choices: List[Union["SlashCommandChoice", dict]] | None = None,
+    name: Optional[str] = None,
 ) -> Type[Union["Role", "BaseChannel", "User", "Member"]]:
     """
     Annotates an argument as a mentionable type slash command option.
@@ -236,10 +251,11 @@ def slash_mentionable_option(
         required: Is this option required?
         autocomplete: Use autocomplete for this option
         choices: The choices allowed by this command
+        name: The name of the option. Defaults to the name of the argument
 
     """
     return SlashCommandOption(
-        name="placeholder",
+        name=name,
         description=description,
         required=required,
         autocomplete=autocomplete,
@@ -251,6 +267,7 @@ def slash_mentionable_option(
 def slash_attachment_option(
     description: str,
     required: bool = False,
+    name: Optional[str] = None,
 ) -> Type["Attachment"]:
     """
     Annotates an argument as an attachment type slash command option.
@@ -258,10 +275,11 @@ def slash_attachment_option(
     Args:
         description: The description of your option
         required: Is this option required?
+        name: The name of the option. Defaults to the name of the argument
 
     """
     return SlashCommandOption(
-        name="placeholder",
+        name=name,
         description=description,
         required=required,
         type=models.OptionType.ATTACHMENT,

--- a/interactions/models/internal/application_commands.py
+++ b/interactions/models/internal/application_commands.py
@@ -684,7 +684,12 @@ class SlashCommand(InteractionCommand):
                 )
                 if maybe_argument_name:
                     name = option.name if isinstance(option, SlashCommandOption) else option["name"]
-                    self.parameters[maybe_argument_name]._option_name = str(name)
+                    try:
+                        self.parameters[maybe_argument_name]._option_name = str(name)
+                    except KeyError:
+                        raise TypeError(
+                            f'Argument name "{maybe_argument_name}" for "{name}" does not match any parameter in {self.resolved_name}\'s function.'
+                        ) from None
 
     def to_dict(self) -> dict:
         data = super().to_dict()

--- a/interactions/models/internal/application_commands.py
+++ b/interactions/models/internal/application_commands.py
@@ -400,6 +400,7 @@ class SlashCommandOption(DictSerializationMixin):
         max_value: The maximum value permitted. The option needs to be an integer or float
         min_length: The minimum length of text a user can input. The option needs to be a string
         max_length: The maximum length of text a user can input. The option needs to be a string
+        argument_name: The name of the argument to be used in the function. If not given, assumed to be the same as the name of the option
 
     """
 
@@ -418,6 +419,7 @@ class SlashCommandOption(DictSerializationMixin):
     max_value: Optional[float] = attrs.field(repr=False, default=None)
     min_length: Optional[int] = attrs.field(repr=False, default=None)
     max_length: Optional[int] = attrs.field(repr=False, default=None)
+    argument_name: Optional[str] = attrs.field(repr=False, default=None)
 
     @type.validator
     def _type_validator(self, attribute: str, value: int) -> None:
@@ -488,6 +490,7 @@ class SlashCommandOption(DictSerializationMixin):
 
     def as_dict(self) -> dict:
         data = attrs.asdict(self)
+        data.pop("argument_name", None)
         data["name"] = str(self.name)
         data["description"] = str(self.description)
         data["choices"] = [
@@ -506,6 +509,11 @@ class SlashCommandParameter:
     kind: inspect._ParameterKind = attrs.field()
     default: typing.Any = attrs.field(default=MISSING)
     converter: typing.Optional[typing.Callable] = attrs.field(default=None)
+    _option_name: typing.Optional[str] = attrs.field(default=None)
+
+    @property
+    def option_name(self) -> str:
+        return self._option_name or self.name
 
 
 def _get_option_from_annotated(annotated: Annotated) -> SlashCommandOption | None:
@@ -601,10 +609,14 @@ class SlashCommand(InteractionCommand):
         if not self.options:
             self.options = []
 
-        option.name = name
+        if option.name is None:
+            option.name = name
+        else:
+            option.argument_name = name
+
         self.options.append(option)
 
-    def _parse_parameters(self) -> None:
+    def _parse_parameters(self) -> None:  # noqa: C901
         """
         Parses the parameters that this command has into a form i.py can use.
 
@@ -664,6 +676,15 @@ class SlashCommand(InteractionCommand):
                     our_param.converter = self._get_converter_function(converter, our_param.name)
 
             self.parameters[param.name] = our_param
+
+        if self.options:
+            for option in self.options:
+                maybe_argument_name = (
+                    option.argument_name if isinstance(option, SlashCommandOption) else option.get("argument_name")
+                )
+                if maybe_argument_name:
+                    name = option.name if isinstance(option, SlashCommandOption) else option["name"]
+                    self.parameters[maybe_argument_name]._option_name = str(name)
 
     def to_dict(self) -> dict:
         data = super().to_dict()
@@ -780,8 +801,8 @@ class SlashCommand(InteractionCommand):
         new_args = []
         new_kwargs = {}
 
-        for name, param in self.parameters.items():
-            value = kwargs_copy.pop(name, MISSING)
+        for param in self.parameters.values():
+            value = kwargs_copy.pop(param.option_name, MISSING)
             if value is MISSING:
                 continue
 
@@ -791,7 +812,7 @@ class SlashCommand(InteractionCommand):
             if param.kind == inspect.Parameter.POSITIONAL_ONLY:
                 new_args.append(value)
             else:
-                new_kwargs[name] = value
+                new_kwargs[param.name] = value
 
         # i do want to address one thing: what happens if you have both *args and **kwargs
         # in your argument?
@@ -1196,6 +1217,7 @@ def slash_option(
     max_value: Optional[float] = None,
     min_length: Optional[int] = None,
     max_length: Optional[int] = None,
+    argument_name: Optional[str] = None,
 ) -> Callable[[SlashCommandT], SlashCommandT]:
     r"""
     A decorator to add an option to a slash command.
@@ -1212,6 +1234,7 @@ def slash_option(
         max_value: The maximum value permitted. The option needs to be an integer or float
         min_length: The minimum length of text a user can input. The option needs to be a string
         max_length: The maximum length of text a user can input. The option needs to be a string
+        argument_name: The name of the argument to be used in the function. If not given, assumed to be the same as the name of the option
     """
 
     def wrapper(func: SlashCommandT) -> SlashCommandT:
@@ -1230,6 +1253,7 @@ def slash_option(
             max_value=max_value,
             min_length=min_length,
             max_length=max_length,
+            argument_name=argument_name,
         )
         if not hasattr(func, "options"):
             func.options = []

--- a/interactions/models/internal/application_commands.py
+++ b/interactions/models/internal/application_commands.py
@@ -687,7 +687,7 @@ class SlashCommand(InteractionCommand):
                     try:
                         self.parameters[maybe_argument_name]._option_name = str(name)
                     except KeyError:
-                        raise TypeError(
+                        raise ValueError(
                             f'Argument name "{maybe_argument_name}" for "{name}" does not match any parameter in {self.resolved_name}\'s function.'
                         ) from None
 


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [x] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
This PR adds the ability for the argument name of an option for slash commands to be different from the option name itself. For example, this example works, despite the difference between `test` and `_test`.
```python
@interactions.slash_command(name="test", description="A test command.")
@interactions.slash_option(
    "test",
    "A thing.",
    interactions.OptionType.STRING,
    required=True,
    argument_name="_test",
)
async def test(ctx: interactions.SlashContext, _test: str):
    await ctx.send(_test)
```

To keep this non-breaking, `argument_name`/`name` had to be inserted into the current methods at... awkward positions, but it should work.

## Changes
- Introduce a new parameter to `SlashCommandOption`, `argument_name`.
  - On its own, it does basically nothing but exist. It's even removed when transformed into a dict, just to not break serialization (and since it isn't a Discord concept).
- Add options to the various ways of declaring slash command options to specify either the argument name or the name of the option as appropriate.
  - If they're not given, they default to their old behavior.
- Add an extra final step to parsing parameters for slash commands to find options with `argument_name` specified and essentially link `SlashCommandParameter` and the actual option name through it. Of course, this required a new parameter to `SlashCommandParameter`.
- Slightly adjust the callback logic to handle the translation between the two names smoothly.
- Make hybrid commands respect this logic (or, well, be able to handle it at least).


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
