### PR TITLE
fix: correct listen typehint

### DIFF
--- a/interactions/models/internal/listener.py
+++ b/interactions/models/internal/listener.py
@@ -116,7 +116,7 @@ class Listener(CallbackObject):
 
 
 def listen(
-    event_name: Absent[str | BaseEvent] = MISSING,
+    event_name: Absent[str | type[BaseEvent]] = MISSING,
     *,
     delay_until_ready: bool = False,
     is_default_listener: bool = False,


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
I swear I'm not trying to PR so much, it's just that this came in my head and was so simple--

Anyways, this fixes `listen`'s typehint when using an event object for `event_name` (which is the current recommended way).

## Changes
- Typehint for class of `BaseEvent` instead of just `BaseEvent` for `listen`.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
