### PR TITLE
fix: make sure exported auto_defer is deco, not module

### DIFF
--- a/interactions/models/internal/__init__.py
+++ b/interactions/models/internal/__init__.py
@@ -11,6 +11,7 @@ from .annotations import (
 )
 from .callback import CallbackObject
 from .active_voice_state import ActiveVoiceState
+from .auto_defer import AutoDefer  # purposely out of order to make sure auto_defer comes out as the deco
 from .application_commands import (
     application_commands_to_dict,
     auto_defer,
@@ -41,7 +42,6 @@ from .application_commands import (
     subcommand,
     sync_needed,
 )
-from .auto_defer import AutoDefer
 from .checks import dm_only, guild_only, has_any_role, has_id, has_role, is_owner
 from .command import BaseCommand, check, cooldown, max_concurrency
 from .context import (


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
I can't help myself.

This PR fixes the very long lasting issue of `interactions.auto_defer` and `from interactions import auto_defer` being the module instead of the decorator. This bug made using auto deferring *much* more frustrating than it needed to be.

## Changes
- Mess around with the `__init__` imports for internal models so that the last `auto_defer` imported is the decorator instead of the class.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
`from interactions import auto_defer`


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
