### PR TITLE
fix: address issues with tag usage for guild forums

### DIFF
--- a/interactions/models/discord/channel.py
+++ b/interactions/models/discord/channel.py
@@ -2420,7 +2420,7 @@ class GuildForum(GuildChannel):
         self,
         name: str,
         content: str | None,
-        applied_tags: Optional[List[Union["Snowflake_Type", "ThreadTag", str]]] = MISSING,
+        applied_tags: Optional[List[Union["Snowflake_Type", "ThreadTag", str]]] = None,
         *,
         auto_archive_duration: AutoArchiveDuration = AutoArchiveDuration.ONE_DAY,
         rate_limit_per_user: Absent[int] = MISSING,
@@ -2463,7 +2463,7 @@ class GuildForum(GuildChannel):
         Returns:
             A GuildForumPost object representing the created post.
         """
-        if applied_tags != MISSING:
+        if applied_tags is not None:
             processed = []
             for tag in applied_tags:
                 if isinstance(tag, ThreadTag):
@@ -2568,12 +2568,13 @@ class GuildForum(GuildChannel):
         Returns:
             A ThreadTag object representing the tag.
         """
+        value = str(value)
 
         def maybe_insensitive(string: str) -> str:
             return string.lower() if case_insensitive else string
 
         def predicate(tag: ThreadTag) -> Optional["ThreadTag"]:
-            if str(tag.id) == str(value):
+            if str(tag.id) == value:
                 return tag
             if maybe_insensitive(tag.name) == maybe_insensitive(value):
                 return tag

--- a/interactions/models/discord/channel.py
+++ b/interactions/models/discord/channel.py
@@ -2420,7 +2420,7 @@ class GuildForum(GuildChannel):
         self,
         name: str,
         content: str | None,
-        applied_tags: Optional[List[Union["Snowflake_Type", "ThreadTag", str]]] = None,
+        applied_tags: Absent[List[Union["Snowflake_Type", "ThreadTag", str]]] = MISSING,
         *,
         auto_archive_duration: AutoArchiveDuration = AutoArchiveDuration.ONE_DAY,
         rate_limit_per_user: Absent[int] = MISSING,
@@ -2463,7 +2463,7 @@ class GuildForum(GuildChannel):
         Returns:
             A GuildForumPost object representing the created post.
         """
-        if applied_tags is not None:
+        if applied_tags is not MISSING:
             processed = []
             for tag in applied_tags:
                 if isinstance(tag, ThreadTag):


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
This PR has a couple (two) fixes to `GuildForum`. These fixes make using `create_post` significantly less confusing to use.


## Changes

- Allow non-strings into `get_tag`.
  - Previously, this would bug out due to the `maybe_insensitive` check.
- Note `applied_tags` as being `Absent`, not `Optional`. It probably *should* be `Optional`, but changing the default value's probably breaking, right?


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
