### PR TITLE
fix/feat: adjust invite obj to respect event variants

### DIFF
--- a/interactions/models/discord/invite.py
+++ b/interactions/models/discord/invite.py
@@ -44,9 +44,9 @@ class Invite(ClientObject):
         default=None, converter=optional_c(InviteTargetType), repr=True
     )
     """The type of target for this voice channel invite"""
-    approximate_presence_count: Optional[int] = attrs.field(repr=False, default=None)
+    approximate_presence_count: Optional[int] = attrs.field(repr=False, default=MISSING)
     """Approximate count of online members, returned when fetching invites with `with_counts` set as `True`"""
-    approximate_member_count: Optional[int] = attrs.field(repr=False, default=None)
+    approximate_member_count: Optional[int] = attrs.field(repr=False, default=MISSING)
     """Approximate count of total members, returned when fetching invites with `with_counts` set as `True`"""
     scheduled_event: Optional["Snowflake_Type"] = attrs.field(
         default=None, converter=optional_c(to_snowflake), repr=True
@@ -58,7 +58,7 @@ class Invite(ClientObject):
     """Stage instance data if there is a public Stage instance in the Stage channel this invite is for (deprecated)"""
     target_application: Optional[dict] = attrs.field(repr=False, default=None)
     """The embedded application to open for this voice channel embedded application invite"""
-    guild_preview: Optional[GuildPreview] = attrs.field(repr=False, default=None)
+    guild_preview: Optional[GuildPreview] = attrs.field(repr=False, default=MISSING)
     """The guild this invite is for - not given in invite events"""
 
     # internal for props

--- a/interactions/models/discord/invite.py
+++ b/interactions/models/discord/invite.py
@@ -70,7 +70,7 @@ class Invite(ClientObject):
     )
 
     @property
-    def channel(self) -> "Optional[TYPE_GUILD_CHANNEL]":
+    def channel(self) -> Optional["TYPE_GUILD_CHANNEL"]:
         """The cached channel the invite is for."""
         return self._client.cache.get_channel(self._channel_id)
 

--- a/interactions/models/discord/invite.py
+++ b/interactions/models/discord/invite.py
@@ -25,37 +25,37 @@ __all__ = ("Invite",)
 @attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class Invite(ClientObject):
     code: str = attrs.field(repr=True)
-    """the invite code (unique ID)"""
+    """The invite code (unique ID)"""
 
     # metadata
     uses: int = attrs.field(default=0, repr=True)
-    """the guild this invite is for"""
+    """How many times this invite has been used"""
     max_uses: int = attrs.field(repr=False, default=0)
-    """max number of times this invite can be used"""
+    """Max number of times this invite can be used"""
     max_age: int = attrs.field(repr=False, default=0)
-    """duration (in seconds) after which the invite expires"""
+    """Duration (in seconds) after which the invite expires"""
     created_at: Timestamp = attrs.field(default=MISSING, converter=optional_c(timestamp_converter), repr=True)
-    """when this invite was created"""
+    """When this invite was created"""
     temporary: bool = attrs.field(default=False, repr=True)
-    """whether this invite only grants temporary membership"""
+    """Whether this invite only grants temporary membership"""
 
     # target data
     target_type: Optional[Union[InviteTargetType, int]] = attrs.field(
         default=None, converter=optional_c(InviteTargetType), repr=True
     )
-    """the type of target for this voice channel invite"""
+    """The type of target for this voice channel invite"""
     approximate_presence_count: Optional[int] = attrs.field(repr=False, default=None)
-    """approximate count of online members, returned from the `GET /invites/<code>` endpoint when `with_counts` is `True`"""
+    """Approximate count of online members, returned when fetching invites with `with_counts` set as `True`"""
     approximate_member_count: Optional[int] = attrs.field(repr=False, default=None)
-    """approximate count of total members, returned from the `GET /invites/<code>` endpoint when `with_counts` is `True`"""
+    """Approximate count of total members, returned when fetching invites with `with_counts` set as `True`"""
     scheduled_event: Optional["Snowflake_Type"] = attrs.field(
         default=None, converter=optional_c(to_snowflake), repr=True
     )
-    """guild scheduled event data, only included if `guild_scheduled_event_id` contains a valid guild scheduled event id"""
+    """Guild scheduled event data, only included if `guild_scheduled_event_id` contains a valid guild scheduled event id"""
     expires_at: Optional[Timestamp] = attrs.field(default=None, converter=optional_c(timestamp_converter), repr=True)
-    """the expiration date of this invite, returned from the `GET /invites/<code>` endpoint when `with_expiration` is `True`"""
+    """The expiration date of this invite, returned when fetching invites with `with_expiration` set as `True`"""
     stage_instance: Optional[StageInstance] = attrs.field(repr=False, default=None)
-    """stage instance data if there is a public Stage instance in the Stage channel this invite is for (deprecated)"""
+    """Stage instance data if there is a public Stage instance in the Stage channel this invite is for (deprecated)"""
     target_application: Optional[dict] = attrs.field(repr=False, default=None)
     """The embedded application to open for this voice channel embedded application invite"""
     guild_preview: Optional[GuildPreview] = attrs.field(repr=False, default=None)


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [x] Feature addition
- [x] Bugfix
- [x] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
This PR adjusts the event object to account for the [event variants](https://discord.com/developers/docs/topics/gateway-events#invite-create) of it, and just for added polish. In the future, these could have event-specific objects, but this'll do for now.


## Changes
- Make the docstrings not all lowercase, and replace HTTP mentions.
- Capture and use `guild_id` if it exists. This introduces a new variable, `guild`, that can be used to attempt to get the cached guild.
- Capture and use `target_user` properly.
- Use channel data if given to us. It's better than nothing.
- Note that the channel and guild are *cached* results - it's common to get an invite outside of the servers the bot can see, so I think it's worth noting.


## Related Issues
Fixes #1498.


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [x] I've updated / added  documentation, where applicable
