### PR TITLE
feat: infer modal/component callback names from coroutine

### DIFF
--- a/interactions/models/internal/application_commands.py
+++ b/interactions/models/internal/application_commands.py
@@ -1170,6 +1170,8 @@ def component_callback(*custom_id: str | re.Pattern) -> Callable[[AsyncCallable]
     """
 
     def wrapper(func: AsyncCallable) -> ComponentCommand:
+        custom_id = custom_id or [func.__name__]  # noqa: F823
+
         if not asyncio.iscoroutinefunction(func):
             raise ValueError("Commands must be coroutines")
 
@@ -1196,6 +1198,8 @@ def modal_callback(*custom_id: str | re.Pattern) -> Callable[[AsyncCallable], Mo
     """
 
     def wrapper(func: AsyncCallable) -> ModalCommand:
+        custom_id = custom_id or [func.__name__]  # noqa: F823
+
         if not asyncio.iscoroutinefunction(func):
             raise ValueError("Commands must be coroutines")
 

--- a/interactions/models/internal/application_commands.py
+++ b/interactions/models/internal/application_commands.py
@@ -1190,7 +1190,9 @@ def modal_callback(*custom_id: str | re.Pattern) -> Callable[[AsyncCallable], Mo
     Your callback will be given a single argument, `ModalContext`
 
     Note:
-        This can optionally take a regex pattern, which will be used to match against the custom ID of the modal
+        This can optionally take a regex pattern, which will be used to match against the custom ID of the modal.
+
+        If you do not supply a `custom_id`, the name of the coroutine will be used instead.
 
 
     Args:

--- a/interactions/models/internal/application_commands.py
+++ b/interactions/models/internal/application_commands.py
@@ -1162,7 +1162,9 @@ def component_callback(*custom_id: str | re.Pattern) -> Callable[[AsyncCallable]
     Your callback will be given a single argument, `ComponentContext`
 
     Note:
-        This can optionally take a regex pattern, which will be used to match against the custom ID of the component
+        This can optionally take a regex pattern, which will be used to match against the custom ID of the component.
+
+        If you do not supply a `custom_id`, the name of the coroutine will be used instead.
 
     Args:
         *custom_id: The custom ID of the component to wait for


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [x] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
<!-- Provide a clear and concise description of the purpose of this PR and why it should be merged -->
<!-- If your code adds or changes features, a usage example would be helpful -->

This infers registration of modal and component callbacks off of the coroutine name if the `custom_id` argument is not supplied.

## Changes
<!-- List the changes you have made in a bullet-point format -->

- Added validation check to overwrite `custom_id` on truthiness - otherwise the coroutine name.

## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->

#1518 

## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [ ] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [ ] I've tested my changes on supported Python versions
- [x] I've added tests for my code, if applicable
- [x] I've updated / added  documentation, where applicable
