### PR TITLE
fix: properly fix component/modal callback

### DIFF
--- a/interactions/models/internal/application_commands.py
+++ b/interactions/models/internal/application_commands.py
@@ -1170,7 +1170,6 @@ def component_callback(*custom_id: str | re.Pattern) -> Callable[[AsyncCallable]
         *custom_id: The custom ID of the component to wait for
 
     """
-    resolved_custom_id: tuple[str | re.Pattern, ...] | list[str] = []
 
     def wrapper(func: AsyncCallable) -> ComponentCommand:
         resolved_custom_id = custom_id or [func.__name__]
@@ -1182,8 +1181,8 @@ def component_callback(*custom_id: str | re.Pattern) -> Callable[[AsyncCallable]
             name=f"ComponentCallback::{resolved_custom_id}", callback=func, listeners=resolved_custom_id
         )
 
-    custom_id = _unpack_helper(resolved_custom_id)
-    custom_ids_validator(*resolved_custom_id)
+    custom_id = _unpack_helper(custom_id)
+    custom_ids_validator(*custom_id)
     return wrapper
 
 
@@ -1203,7 +1202,6 @@ def modal_callback(*custom_id: str | re.Pattern) -> Callable[[AsyncCallable], Mo
     Args:
         *custom_id: The custom ID of the modal to wait for
     """
-    resolved_custom_id: tuple[str | re.Pattern, ...] | list[str] = []
 
     def wrapper(func: AsyncCallable) -> ModalCommand:
         resolved_custom_id = custom_id or [func.__name__]
@@ -1213,8 +1211,8 @@ def modal_callback(*custom_id: str | re.Pattern) -> Callable[[AsyncCallable], Mo
 
         return ModalCommand(name=f"ModalCallback::{resolved_custom_id}", callback=func, listeners=resolved_custom_id)
 
-    custom_id = _unpack_helper(resolved_custom_id)
-    custom_ids_validator(*resolved_custom_id)
+    custom_id = _unpack_helper(custom_id)
+    custom_ids_validator(*custom_id)
     return wrapper
 
 


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
`component_callback` and `modal_callback` was *always* using the function name after the last patch due to some weirdness. This PR fixes that by simplifying the patch and... fixing parts of the patch itself, funny enough.

Frankly, I'm disappointed in myself how easy this fix was 😅. 

## Changes
- Pass in `custom_id` to the unpack helper/validator, not the empty `resolved_custom_id`.
- Removed the unused (other than for the mistake above) `resolved_custom_id` initial declaration - I think we all forgot that `resolved_custom_id` does not get passed into there without a `nonlocal`. No idea how `custom_id` does in this specific case, but it does.
  - Yes, this patch makes the code very similar to the code before the first patch. However, since the variable name inside the wrapper function is different from just `custom_id`, everything works now (for some reason).


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
```python
@interactions.slash_command(name="test", description="My command")
async def test(ctx: interactions.SlashContext):
    await ctx.send(
        components=interactions.Button(
            style=interactions.ButtonStyle.PRIMARY, label="Test", custom_id="test"
        )
    )


@interactions.component_callback("test")
async def test_callback(ctx: interactions.ComponentContext):
    await ctx.edit_origin(content="Test")
```


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
