### PR TITLE
feat: update docs and support state for custom statuses

### DIFF
--- a/interactions/models/discord/activity.py
+++ b/interactions/models/discord/activity.py
@@ -78,7 +78,7 @@ class Activity(DictSerializationMixin):
     details: Optional[str] = attrs.field(repr=False, default=None)
     """What the player is currently doing"""
     state: Optional[str] = attrs.field(repr=False, default=None)
-    """User's current party status, or text used for a custom status is type is set as custom"""
+    """The user's current party status, or text used for a custom status if type is set as CUSTOM"""
     emoji: Optional[PartialEmoji] = attrs.field(repr=False, default=None, converter=optional(PartialEmoji.from_dict))
     """The emoji used for a custom status"""
     party: Optional[ActivityParty] = attrs.field(repr=False, default=None, converter=optional(ActivityParty.from_dict))
@@ -109,7 +109,7 @@ class Activity(DictSerializationMixin):
             name: The new activity's name
             type: Type of activity to create
             url: Stream link for the activity
-            state: Current party status, or text used for a custom status is type is set as custom
+            state: Current party status, or text used for a custom status if type is set as CUSTOM
 
         Returns:
             The new activity object

--- a/interactions/models/discord/activity.py
+++ b/interactions/models/discord/activity.py
@@ -78,7 +78,7 @@ class Activity(DictSerializationMixin):
     details: Optional[str] = attrs.field(repr=False, default=None)
     """What the player is currently doing"""
     state: Optional[str] = attrs.field(repr=False, default=None)
-    """The user's current party status"""
+    """User's current party status, or text used for a custom status is type is set as custom"""
     emoji: Optional[PartialEmoji] = attrs.field(repr=False, default=None, converter=optional(PartialEmoji.from_dict))
     """The emoji used for a custom status"""
     party: Optional[ActivityParty] = attrs.field(repr=False, default=None, converter=optional(ActivityParty.from_dict))
@@ -99,7 +99,9 @@ class Activity(DictSerializationMixin):
     """The custom buttons shown in the Rich Presence (max 2)"""
 
     @classmethod
-    def create(cls, name: str, type: ActivityType = ActivityType.GAME, url: Optional[str] = None) -> "Activity":
+    def create(
+        cls, name: str, type: ActivityType = ActivityType.GAME, url: Optional[str] = None, state: Optional[str] = None
+    ) -> "Activity":
         """
         Creates an activity object for the bot.
 
@@ -107,12 +109,13 @@ class Activity(DictSerializationMixin):
             name: The new activity's name
             type: Type of activity to create
             url: Stream link for the activity
+            state: Current party status, or text used for a custom status is type is set as custom
 
         Returns:
             The new activity object
 
         """
-        return cls(name=name, type=type, url=url)
+        return cls(name=name, type=type, url=url, state=state)
 
     def to_dict(self) -> dict:
-        return dict_filter_none({"name": self.name, "type": self.type, "url": self.url})
+        return dict_filter_none({"name": self.name, "type": self.type, "state": self.state, "url": self.url})


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [x] Feature addition
- [ ] Bugfix
- [x] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
Setting `state` for presences for bots is now supported, [as seen by this changelog,](https://discord.com/developers/docs/change-log#activity-state-for-bot-users) allowing for custom statuses (among other things). Technically, existing interactions.py versions can already use this through a raw dictionary and using the gateway's `change_presence`, but this PR makes it possible to use more normal means, and also updates the docs to note about it.


## Changes
- Update the docs about `Activity.state`.
- Allow setting `state` through `Activity.create`.
- Pass in `state` in the `to_dict` method.


## Related Issues
#1526 


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [ ] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
