### PR TITLE
Fix bot voice state connection issues

### DIFF
--- a/interactions/api/events/processors/voice_events.py
+++ b/interactions/api/events/processors/voice_events.py
@@ -13,17 +13,17 @@ __all__ = ("VoiceEvents",)
 class VoiceEvents(EventMixinTemplate):
     @Processor.define()
     async def _on_raw_voice_state_update(self, event: "RawGatewayEvent") -> None:
-        after = await self.cache.place_voice_state_data(event.data)
-
         if str(event.data["user_id"]) == str(self.user.id):
             # User is the bot itself
-            before = self.cache.get_bot_voice_state(event.data["guild_id"])
+            before = copy.copy(self.cache.get_bot_voice_state(event.data["guild_id"])) or None
+            after = await self.cache.place_voice_state_data(event.data, update_cache=False)
             if vc := before:
                 # noinspection PyProtectedMember
                 await vc._voice_state_update(before, after, event.data)
         else:
             # User is not the bot
             before = copy.copy(self.cache.get_voice_state(event.data["user_id"])) or None
+            after = await self.cache.place_voice_state_data(event.data)
 
         self.dispatch(events.VoiceStateUpdate(before, after))
 

--- a/interactions/api/events/processors/voice_events.py
+++ b/interactions/api/events/processors/voice_events.py
@@ -14,7 +14,7 @@ class VoiceEvents(EventMixinTemplate):
     @Processor.define()
     async def _on_raw_voice_state_update(self, event: "RawGatewayEvent") -> None:
         after = await self.cache.place_voice_state_data(event.data)
-        is_bot = event.data['member']['user']['bot']
+        is_bot = event.data["member"]["user"]["bot"]
 
         if is_bot:
             if vc := self.cache.get_bot_voice_state(event.data["guild_id"]):

--- a/interactions/api/events/processors/voice_events.py
+++ b/interactions/api/events/processors/voice_events.py
@@ -17,7 +17,9 @@ class VoiceEvents(EventMixinTemplate):
         is_bot = event.data['member']['user']['bot']
 
         if is_bot:
-            if vc := self.cache.get_bot_voice_state(event.data["guild_id"]):
+            before_bot_guild_voice_state = self.cache.get_bot_voice_state(event.data["guild_id"])
+            self.dispatch(events.VoiceStateUpdate(before_bot_guild_voice_state, after))
+            if vc := before_bot_guild_voice_state:
                 # noinspection PyProtectedMember
                 await vc._voice_state_update(after, event.data)
             return

--- a/interactions/client/smart_cache.py
+++ b/interactions/client/smart_cache.py
@@ -747,7 +747,9 @@ class GlobalCache:
         """
         return self.voice_state_cache.get(to_optional_snowflake(user_id))
 
-    async def place_voice_state_data(self, data: discord_typings.VoiceStateData, update_cache = True) -> Optional[VoiceState]:
+    async def place_voice_state_data(
+        self, data: discord_typings.VoiceStateData, update_cache=True
+    ) -> Optional[VoiceState]:
         """
         Take json data representing a VoiceState, process it, and cache it.
 

--- a/interactions/client/smart_cache.py
+++ b/interactions/client/smart_cache.py
@@ -747,10 +747,7 @@ class GlobalCache:
         """
         return self.voice_state_cache.get(to_optional_snowflake(user_id))
 
-
-    async def place_voice_state_data(
-        self, data: discord_typings.VoiceStateData, update_cache=True
-    ):
+    async def place_voice_state_data(self, data: discord_typings.VoiceStateData, update_cache=True):
         """
         Take json data representing a VoiceState, process it, and cache it.
 

--- a/interactions/client/smart_cache.py
+++ b/interactions/client/smart_cache.py
@@ -747,7 +747,7 @@ class GlobalCache:
         """
         return self.voice_state_cache.get(to_optional_snowflake(user_id))
 
-    async def place_voice_state_data(self, data: discord_typings.VoiceStateData, update_cache=True):
+    async def place_voice_state_data(self, data: discord_typings.VoiceStateData, update_cache=True) -> Optional[VoiceState]:
         """
         Take json data representing a VoiceState, process it, and cache it.
 

--- a/interactions/client/smart_cache.py
+++ b/interactions/client/smart_cache.py
@@ -747,7 +747,9 @@ class GlobalCache:
         """
         return self.voice_state_cache.get(to_optional_snowflake(user_id))
 
-    async def place_voice_state_data(self, data: discord_typings.VoiceStateData, update_cache=True) -> Optional[VoiceState]:
+    async def place_voice_state_data(
+        self, data: discord_typings.VoiceStateData, update_cache=True
+    ) -> Optional[VoiceState]:
         """
         Take json data representing a VoiceState, process it, and cache it.
 

--- a/interactions/client/smart_cache.py
+++ b/interactions/client/smart_cache.py
@@ -747,7 +747,7 @@ class GlobalCache:
         """
         return self.voice_state_cache.get(to_optional_snowflake(user_id))
 
-    async def place_voice_state_data(self, data: discord_typings.VoiceStateData) -> Optional[VoiceState]:
+    async def place_voice_state_data(self, data: discord_typings.VoiceStateData, update_cache = True) -> Optional[VoiceState]:
         """
         Take json data representing a VoiceState, process it, and cache it.
 
@@ -768,7 +768,7 @@ class GlobalCache:
         # check if the channel_id is None
         # if that is the case, the user disconnected, and we can delete them from the cache
         if not data["channel_id"]:
-            if user_id in self.voice_state_cache:
+            if update_cache and user_id in self.voice_state_cache:
                 self.voice_state_cache.pop(user_id)
             voice_state = None
 
@@ -780,7 +780,8 @@ class GlobalCache:
             new_channel._voice_member_ids.append(user_id)
 
             voice_state = VoiceState.from_dict(data, self._client)
-            self.voice_state_cache[user_id] = voice_state
+            if update_cache:
+                self.voice_state_cache[user_id] = voice_state
 
         return voice_state
 

--- a/interactions/client/smart_cache.py
+++ b/interactions/client/smart_cache.py
@@ -747,12 +747,13 @@ class GlobalCache:
         """
         return self.voice_state_cache.get(to_optional_snowflake(user_id))
 
-    async def place_voice_state_data(self, data: discord_typings.VoiceStateData, update_cache = True) -> Optional[VoiceState]:
+    async def place_voice_state_data(self, data: discord_typings.VoiceStateData, update_cache=True) -> Optional[VoiceState]:
         """
         Take json data representing a VoiceState, process it, and cache it.
 
         Args:
             data: json representation of the VoiceState
+            update_cache: Bool for updating cache or not
 
         Returns:
             The processed VoiceState object

--- a/interactions/models/internal/active_voice_state.py
+++ b/interactions/models/internal/active_voice_state.py
@@ -289,7 +289,6 @@ class ActiveVoiceState(VoiceState):
 
     async def _voice_state_update(
         self,
-        before: Optional[VoiceState],
         after: Optional[VoiceState],
         data: Optional[VoiceStateData],
     ) -> None:
@@ -297,7 +296,6 @@ class ActiveVoiceState(VoiceState):
         An internal receiver for voice server state events.
 
         Args:
-            before: The previous voice state
             after: The current voice state
             data: Raw data from gateway
         """

--- a/interactions/models/internal/active_voice_state.py
+++ b/interactions/models/internal/active_voice_state.py
@@ -289,6 +289,7 @@ class ActiveVoiceState(VoiceState):
 
     async def _voice_state_update(
         self,
+        before: Optional[VoiceState],
         after: Optional[VoiceState],
         data: Optional[VoiceStateData],
     ) -> None:

--- a/interactions/models/internal/active_voice_state.py
+++ b/interactions/models/internal/active_voice_state.py
@@ -297,6 +297,7 @@ class ActiveVoiceState(VoiceState):
         An internal receiver for voice server state events.
 
         Args:
+            before: The previous voice state
             after: The current voice state
             data: Raw data from gateway
         """


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
I encountered a bug where connecting and disconnecting the bot itself across different guilds caused weird state issues to happen. Like if you disconnect the bot from a voice channel in one guild, the bot in the other guild wouldn't disconnect properly. See linked-issue for full context.

The issue with this in voice_events.py. The problem is that that it's grabbing cached before data for the user ID, which is fine if you're doing voice updates for actual non-bot users, but if this event is happening on a bot, it's gonna pull the "user" data for that bot, which will be global across guilds. I updated the code so that the bot updates ignore the before data and don't dispatch a voice state update, since this voice state update would be global across all guilds and not useful in any way. This fixed the bug I was encountering.


## Changes
<!-- List the changes you have made in a bullet-point format -->


## Related Issues
[Issue 1531](https://github.com/interactions-py/interactions.py/issues/1531)


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [ ] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [ ] I've run the `pre-commit` code linter over all edited files
- [ ] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
