### PR TITLE
fix: rely on guild id instead of guild for buckets

### DIFF
--- a/interactions/models/internal/cooldowns.py
+++ b/interactions/models/internal/cooldowns.py
@@ -47,15 +47,15 @@ class Buckets(IntEnum):
         if self is Buckets.USER:
             return context.author.id
         if self is Buckets.GUILD:
-            return context.guild_id if context.guild else context.author.id
+            return context.guild_id or context.author.id
         if self is Buckets.CHANNEL:
             return context.channel.id
         if self is Buckets.MEMBER:
-            return (context.guild_id, context.author.id) if context.guild else context.author.id
+            return (context.guild_id, context.author.id) if context.guild_id else context.author.id
         if self is Buckets.CATEGORY:
             return await context.channel.parent_id if context.channel.parent else context.channel.id
         if self is Buckets.ROLE:
-            return context.author.top_role.id if context.guild else context.channel.id
+            return context.author.top_role.id if context.guild_id else context.channel.id
         return context.author.id
 
     def __call__(self, context: "BaseContext") -> Any:


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
This PR fixes `Buckets` so that it uses `guild_id` instead of `guild` for verifying a guild exists for its various buckets. This allows it to work in scenarios where the `guild` attribute itself may return `None`, IE in scenarios where the guild cache is disabled. This also is likely less expensive than using the guild attribute.


## Changes
- See the above and diff - there isn't a whole lot going on here.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
- Set the guild cache to a null cache.
- Use a cooldown involving a guild.


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
