### PR TITLE
fix: check for guild for role processors

### DIFF
--- a/interactions/api/events/processors/role_events.py
+++ b/interactions/api/events/processors/role_events.py
@@ -17,8 +17,8 @@ class RoleEvents(EventMixinTemplate):
         g_id = int(event.data.get("guild_id"))
         r_id = int(event.data["role"]["id"])
 
-        guild = self.cache.get_guild(g_id)
-        guild._role_ids.add(r_id)
+        if guild := self.cache.get_guild(g_id):
+            guild._role_ids.add(r_id)
 
         role = self.cache.place_role_data(g_id, [event.data.get("role")])[r_id]
         self.dispatch(events.RoleCreate(g_id, role))
@@ -39,13 +39,13 @@ class RoleEvents(EventMixinTemplate):
         g_id = int(event.data.get("guild_id"))
         r_id = int(event.data.get("role_id"))
 
-        guild = self.cache.get_guild(g_id)
         role = self.cache.get_role(r_id)
 
         self.cache.delete_role(r_id)
 
-        role_members = (member for member in guild.members if member.has_role(r_id))
-        for member in role_members:
-            member._role_ids.remove(r_id)
+        if guild := self.cache.get_guild(g_id):
+            role_members = (member for member in guild.members if member.has_role(r_id))
+            for member in role_members:
+                member._role_ids.remove(r_id)
 
         self.dispatch(events.RoleDelete(g_id, r_id, role))


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
This PR fixes role processors from erroring out when the guild cache is limited or made `NullCache`. Previously, the processors assumed the guild would always exist, when this isn't always the case.

Worth noting: many more processors use a `fetch_guild` to work around this. That... isn't a good idea here, as if the guild isn't in the cache, we likely don't care about it at all.
(Honestly, many processors could benefit from switching from `fetch_guild` to `get_guild`, but that would be breaking.)


## Changes
See the diff.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
- Disable guild cache.
- Create or delete a role.


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
