### PR TITLE
fix: properly pass in proxy to http client

### DIFF
--- a/interactions/api/http/http_client.py
+++ b/interactions/api/http/http_client.py
@@ -218,7 +218,7 @@ class HTTPClient(
         connector: BaseConnector | None = None,
         logger: Logger = MISSING,
         show_ratelimit_tracebacks: bool = False,
-        proxy: tuple[str, BasicAuth] | None = None,
+        proxy: tuple[str | None, BasicAuth | None] | None = None,
     ) -> None:
         self.connector: BaseConnector | None = connector
         self.__session: ClientSession | None = None
@@ -233,7 +233,7 @@ class HTTPClient(
         self.user_agent: str = (
             f"DiscordBot ({__repo_url__} {__version__} Python/{__py_version__}) aiohttp/{aiohttp.__version__}"
         )
-        self.proxy: tuple[str, BasicAuth] | None = proxy
+        self.proxy: tuple[str | None, BasicAuth | None] | None = proxy
         self.__proxy_validated: bool = False
 
         if logger is MISSING:

--- a/interactions/client/client.py
+++ b/interactions/client/client.py
@@ -348,8 +348,9 @@ class Client(
         if isinstance(proxy_auth, tuple):
             proxy_auth = BasicAuth(*proxy_auth)
 
+        proxy = (proxy_url, proxy_auth) if proxy_url or proxy_auth else None
         self.http: HTTPClient = HTTPClient(
-            logger=self.logger, show_ratelimit_tracebacks=show_ratelimit_tracebacks, proxy=(proxy_url, proxy_auth)
+            logger=self.logger, show_ratelimit_tracebacks=show_ratelimit_tracebacks, proxy=proxy
         )
         """The HTTP client to use when interacting with discord endpoints"""
 


### PR DESCRIPTION
This also fixes the typehint for the http client

## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
This PR makes it so that if no proxy URL and no proxy authentication was passed, the passed proxy to `HTTPClient` will be `None` instead of a tuple of `(None, None)`. Having it be `(None, None)` meant that `bool(proxy)` was always true, and so triggered a proxy check *every time a bot started.* My bots sometimes got hung up on this step when starting up (something about the WiFi where I live doesn't like it), so this bypass is nice.

Also, the typehint for `HTTPClient`'s `proxy` was adjusted to note how either the proxy URL or the proxy auth could be invalid, because why not.


## Changes
- Pass in `None` instead of a tuple if `proxy_url` and `proxy_auth` are `None` into `HTTPClient`.
- Make typehint for `HTTPClient` more accurate.
  - This could probably be made more accurate through a tuple union type, but I'm lazy and I think this solution is good enough.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
Start up a bot. Literally. Look at the log and find if it tries to validate the proxy or not - it shouldn't attempt to.


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
