### PR TITLE
fix: properly check if name is none for anno names

### DIFF
--- a/interactions/models/internal/application_commands.py
+++ b/interactions/models/internal/application_commands.py
@@ -609,8 +609,8 @@ class SlashCommand(InteractionCommand):
         if not self.options:
             self.options = []
 
-        if option.name is None:
-            option.name = name
+        if option.name.default is None:
+            option.name = LocalisedName.converter(name)
         else:
             option.argument_name = name
 


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
This fixes #1554 by properly checking if `option.name` is None. Previously, it was incorrectly assuming that `name` would be kept as `None` when passing it into the `SlashCommandOption`'s init, when that doesn't seem to be the case (anymore? I swore this didn't happen before). Instead, it was a `LocalisedName`, and now the logic for the names accounts for that (and also properly sets the new name variable too).


## Changes
See description.


## Related Issues
#1554 


## Test Scenarios
```python
@interactions.slash_command()
async def test(ctx: interactions.SlashContext, user: interactions.slash_user_option("e")):
    await ctx.send(user.mention)
```


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
