### PR TITLE
fix: pass binding for prefixed variant of hybrid cmd

### DIFF
--- a/interactions/ext/hybrid_commands/hybrid_slash.py
+++ b/interactions/ext/hybrid_commands/hybrid_slash.py
@@ -327,6 +327,10 @@ def slash_to_prefixed(cmd: HybridSlashCommand) -> _HybridToPrefixedCommand:  # n
     if cmd.aliases:
         prefixed_cmd.aliases.extend(cmd.aliases)
 
+    # copy over binding from slash command, if any
+    # can't be done in init due to how _binding works
+    prefixed_cmd._binding = cmd._binding
+
     if not cmd.dm_permission:
         prefixed_cmd.add_check(guild_only())
 


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
When declaring a hybrid command in a subclass of `Client` (see the test scenario a bit below), an error would occur when using the prefixed command variant of it, saying that not enough arguments were passed. This was due to the generated prefixed command not inheriting the binding of the main hybrid/slash command - while the slash command would continue to work fine, the prefixed command would not have the "binded" `self`, causing the issue.

This PR fixes that by setting the generated prefixed command's binding to the main hybrid/slash command's binding.


## Changes
- Set the generated prefixed command's binding to the main hybrid/slash command's binding when generating a prefixed command based off said hybrid/slash command.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
```python
class MyBot(Client):
    @hybrid_slash_command()
    async def test(self, ctx: HybridContext):
        await ctx.reply("e")
```


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
