### PR TITLE
fix: ensure next_fire in TimeTrigger returns proper next time

### DIFF
--- a/interactions/models/internal/tasks/triggers.py
+++ b/interactions/models/internal/tasks/triggers.py
@@ -105,6 +105,10 @@ class TimeTrigger(BaseTrigger):
         )
         if target.tzinfo == timezone.utc:
             target = target.astimezone(now.tzinfo)
+            # target can fall behind or go forward a day, but all we need is the time itself
+            # to be converted
+            # to ensure it's on the same day as "now" and not break the next if statement,
+            # we can just replace the date with now's date
             target = target.replace(year=now.year, month=now.month, day=now.day, tzinfo=None)
 
         if target <= self.last_call_time:

--- a/interactions/models/internal/tasks/triggers.py
+++ b/interactions/models/internal/tasks/triggers.py
@@ -105,9 +105,9 @@ class TimeTrigger(BaseTrigger):
         )
         if target.tzinfo == timezone.utc:
             target = target.astimezone(now.tzinfo)
-            target = target.replace(tzinfo=None)
+            target = target.replace(year=now.year, month=now.month, day=now.day, tzinfo=None)
 
-        while target <= self.last_call_time:
+        if target <= self.last_call_time:
             target += timedelta(days=1)
         return target
 

--- a/interactions/models/internal/tasks/triggers.py
+++ b/interactions/models/internal/tasks/triggers.py
@@ -107,7 +107,7 @@ class TimeTrigger(BaseTrigger):
             target = target.astimezone(now.tzinfo)
             target = target.replace(tzinfo=None)
 
-        if target <= self.last_call_time:
+        while target <= self.last_call_time:
             target += timedelta(days=1)
         return target
 


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
This one's a bit weird, so I'll explain it through an example.

Let's say, on a bot's device, the time is currently 11:00 PM (23:00) EST on 2023-11-27 (YYYY-MM-DD). EST has a time difference of -5 hours from UTC, making this 4:00 AM UTC *on the next day*, 2023-11-28. Now, say, we create a task that looks like so:
```python
@interactions.Task.create(interactions.TimeTrigger(3, 59, 00, utc=True))
async def test():
    print("test")
```

Naturally, this *should* result in the task, if started, to not trigger until 10:59 PM (22:59) EST, or 3:59 AM UTC, the *next* day (2023-11-28). However, this will not happen - what *will* happen is that the console will have an endless spam of `test` until midnight EST. But why is this the case?

The offender of this issue is in `TimeTrigger`'s `next_fire`, so let's break it down.
```python
def next_fire(self) -> datetime | None:
    now = datetime.now()
    target = datetime(
        now.year,
        now.month,
        now.day,
        self.target_time[0],
        self.target_time[1],
        self.target_time[2],
        tzinfo=self.tz,
    )
    if target.tzinfo == timezone.utc:
        target = target.astimezone(now.tzinfo)
        target = target.replace(tzinfo=None)

    if target <= self.last_call_time:
        target += timedelta(days=1)
    return target
```

On the first run of this program, `now` is 11:00 PM (23:00) EST on 2023-11-27. Thus, `target` is 3:59 AM UTC on 2023-11-27. Because the `target`'s timezone *is* UTC, `target` gets converted into the equivalent time in (well, in this case) EST - 10:59 PM (22:59) EST on 2023-11-*26*.

When first starting the bot, we can assume `self.last_call_time` is essentially `now` - it'll maybe be a couple of seconds behind, but that doesn't matter. Now, our `target` is indeed less than the time it is right now - as an attempt to fix this, the code adds a day to `target`, making it 10:59 PM (22:59) EST on 2023-11-*27*.

Note, though, that the current time is *11:00 PM (23:00)* EST on 2023-11-27, meaning the `target` is *still* behind `now` when that should never happen, breaking the rest of the task's code's assumptions and causing that loop.

Now, this all happens because `target`, when being converted from UTC to local/native time, goes back a day, when the code incorrectly assumes that it'll stay on the same day. This PR fixes that by ensuring that the new `target`, after the time conversions, is set back to the current date as specified by `now`.

## Changes
- Ensure `target` has the same date (though not time) as `now` in `TimeTrigger`'s `next_fire()`.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
See the description.


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
