### PR TITLE
docs: improve mkdocs config

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,11 +121,12 @@ plugins:
             show_if_no_docstring: True
   - minify:
       minify_html: true
-  # keep this at the bottom of the plugins list - if you are building without insiders, comment it out
-  - privacy:
-      # Downloads all external resources and stores them locally
-      externals: bundle
+
+  - group:
       enabled: !ENV [ DEPLOY, False ]
+      plugins:
+        - privacy:
+            externals: bundle
 
 
 markdown_extensions:
@@ -141,8 +142,8 @@ markdown_extensions:
   - pymdownx.inlinehilite
   - pymdownx.superfences
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.keys
   - pymdownx.saneheaders
   - pymdownx.smartsymbols


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [ ] Bugfix
- [x] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
This PR improves the mkdocs config by switching over to modern standards, largely:
- Adjusting the emoji index and generator to use the new, built-in paths instead of `materialx`. This gets rid of a lot of console spam noting how it's deprecated.
- [Use groups](https://squidfunk.github.io/mkdocs-material/insiders/getting-started/#built-in-plugins) instead of relying on contributors to manually comment out Insiders features so that contributing is much easier. This means any person can now clone the repo, use `mkdocs serve` after installing the dependencies, and it'll work without a complaint. The CI run should still function with Insider plugins working.

## Changes
See description.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [x] I've updated / added  documentation, where applicable
