### PR TITLE
feat: add Client.mention_command

### DIFF
--- a/interactions/client/client.py
+++ b/interactions/client/client.py
@@ -2466,8 +2466,8 @@ class Client(
         Returns a string that would mention the interaction specified.
 
         Args:
-            name (str): The name of the interaction.
-            scope (int, optional): The scope of the interaction. Defaults to 0, the global scope.
+            name: The name of the interaction.
+            scope: The scope of the interaction. Defaults to 0, the global scope.
 
         Returns:
             str: The interaction's mention in the specified scope.

--- a/interactions/client/client.py
+++ b/interactions/client/client.py
@@ -2461,6 +2461,19 @@ class Client(
         """
         return self._connection_state.get_voice_state(guild_id)
 
+    def mention_command(self, name: str, scope: int = 0) -> str:
+        """
+        Returns a string that would mention the interaction specified.
+
+        Args:
+            name (str): The name of the interaction.
+            scope (int, optional): The scope of the interaction. Defaults to 0, the global scope.
+
+        Returns:
+            str: The interaction's mention in the specified scope.
+        """
+        return self.interactions_by_scope[scope][name].mention(scope)
+
     async def change_presence(
         self,
         status: Optional[Union[str, Status]] = Status.ONLINE,


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [x] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
Many users have trouble generating the mention string of an interaction command. This PR adds a function that gets just that.

## Changes
- Add `Client.mention_command` to mention an interaction command.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [x] I've updated / added  documentation, where applicable
