### PR TITLE
fix: pass in level to wrapped logger when disconnecting

### DIFF
--- a/interactions/api/gateway/state.py
+++ b/interactions/api/gateway/state.py
@@ -128,7 +128,7 @@ class ConnectionState:
 
         except Exception as e:
             self.client.dispatch(events.Disconnect())
-            self.wrapped_logger("".join(traceback.format_exception(type(e), e, e.__traceback__)))
+            self.wrapped_logger(logging.ERROR, "".join(traceback.format_exception(type(e), e, e.__traceback__)))
 
     def wrapped_logger(self, level: int, message: str, **kwargs) -> None:
         """


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
This PR fixes a bug related to the wrapped logger when getting disconnected. The `level` wasn't being passed in into the function, causing errors like #1570.


## Changes
- Pass in `logging.ERROR` as the logging level for `wrapped_logger` during a disconnect. [As you can be seen in the diff that added this wrapped logger](https://github.com/interactions-py/interactions.py/commit/68757cabbb4a092071b070c8d488fba1bdc3fc11#diff-f8291f6a9a0d243c767461eae44cf2576afa698532bf0ebf6b5c178a7553832d), this matches how the logging level was before the bug was introduced.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
