### PR TITLE
fix: consider binding when running autocomplete functions

### DIFF
--- a/interactions/client/client.py
+++ b/interactions/client/client.py
@@ -1808,9 +1808,7 @@ class Client(
                 if auto_opt := getattr(ctx, "focussed_option", None):
                     if autocomplete := ctx.command.autocomplete_callbacks.get(str(auto_opt.name)):
                         if ctx.command.has_binding:
-                            callback = CallbackObject()
-                            callback.callback = autocomplete
-                            callback._binding = ctx.command._binding
+                            callback = functools.partial(ctx.command.call_with_binding, autocomplete)
                         else:
                             callback = autocomplete
                     elif autocomplete := self._global_autocompletes.get(str(auto_opt.name)):

--- a/interactions/client/client.py
+++ b/interactions/client/client.py
@@ -1807,7 +1807,12 @@ class Client(
 
                 if auto_opt := getattr(ctx, "focussed_option", None):
                     if autocomplete := ctx.command.autocomplete_callbacks.get(str(auto_opt.name)):
-                        callback = autocomplete
+                        if ctx.command.has_binding:
+                            callback = CallbackObject()
+                            callback.callback = autocomplete
+                            callback._binding = ctx.command._binding
+                        else:
+                            callback = autocomplete
                     elif autocomplete := self._global_autocompletes.get(str(auto_opt.name)):
                         callback = autocomplete
                     else:


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [ X] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
Autocomplete functions implemented as methods of a Client subclass are not called with binding to the client object. This causes the autocomplete call to raise an exception. This PR fixes the issue.

## Changes
- Call autocomplete methods with object binding.


## Related Issues
#1582

## Test Scenarios
Issue #1582 has a script that demonstrates the failure before this patch, and success after this patch.


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [X ] I've ensured my code works on Python `3.10.x`
- [ ] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [ X] I've run the `pre-commit` code linter over all edited files
- [ X] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable

There were no autocomplete tests prior to this, and I did not add any to the tests/ directory.
No documentation should need to be updated.
