### PR TITLE
fix💥: don't pass kwargs to modal callbacks

### DIFF
--- a/interactions/models/internal/application_commands.py
+++ b/interactions/models/internal/application_commands.py
@@ -844,7 +844,9 @@ class ComponentCommand(InteractionCommand):
 
 @attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class ModalCommand(ComponentCommand):
-    ...
+    async def call_callback(self, callback: Callable, context: "BaseContext") -> None:
+        # default call_callback passes kwargs, we dont want to do that here
+        await self.call_with_binding(callback, context)  # type: ignore
 
 
 def _unpack_helper(iterable: typing.Iterable[str]) -> list[str]:


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
This PR fixes #1517 by making sure `ctx.kwargs` is not passed into modal callbacks. While this behavior was unintended, this change is breaking, hence the draft status.


## Changes
- Override `call_callback` in `ModalCommand` so that the actual callback does not receive `**ctx.kwargs`.


## Related Issues
Fixes #1517.

## Test Scenarios
See bug report.


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
