### PR TITLE
fix: assume ratelimit is not in effect if reset after is small amount

### DIFF
--- a/interactions/api/http/http_client.py
+++ b/interactions/api/http/http_client.py
@@ -139,7 +139,7 @@ class BucketLock:
         self.remaining = int(header.get("x-ratelimit-remaining", self.DEFAULT_REMAINING))
         self.delta = float(header.get("x-ratelimit-reset-after", self.DEFAULT_DELTA))
 
-        if self.delta < 0.005:  # the value is so small that we can assume it's 0
+        if self.delta < 0.005 and self.remaining == 0:  # the delta value is so small that we can assume it's 0
             self.delta = self.DEFAULT_DELTA
             self.remaining = self.DEFAULT_REMAINING  # we can assume that we can make another request right away
 

--- a/interactions/api/http/http_client.py
+++ b/interactions/api/http/http_client.py
@@ -141,6 +141,7 @@ class BucketLock:
 
         if self.delta < 0.005:  # the value is so small that we can assume it's 0
             self.delta = self.DEFAULT_DELTA
+            self.remaining = self.DEFAULT_REMAINING  # we can assume that we can make another request right away
 
         if self._semaphore is None or self._semaphore._value != self.limit:
             self._semaphore = asyncio.Semaphore(self.limit)

--- a/interactions/api/http/http_client.py
+++ b/interactions/api/http/http_client.py
@@ -139,6 +139,9 @@ class BucketLock:
         self.remaining = int(header.get("x-ratelimit-remaining", self.DEFAULT_REMAINING))
         self.delta = float(header.get("x-ratelimit-reset-after", self.DEFAULT_DELTA))
 
+        if self.delta < 0.005:  # the value is so small that we can assume it's 0
+            self.delta = self.DEFAULT_DELTA
+
         if self._semaphore is None or self._semaphore._value != self.limit:
             self._semaphore = asyncio.Semaphore(self.limit)
 


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
Some endpoints give a "reset-after" ratelimit header that is so small as to not matter (Python overhead will be much slower anyways), but can cause issues with how interactions.py handles ratelimits. This PR checks for a very small "reset-after" and makes it 0 if that is the case.

## Changes
- If `self.delta` for a `BucketLock` is less than `0.005`, make `self.delta` 0 and `self.remaining` 1.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
Examples of a very small retry after can be found using a simple Curl request to `/users/@me`:
```sh
curl -i -X GET -H "Authorization: Bot YOUR_TOKEN" -H "Content-Type: application/json" https://discord.com/api/v10/users/@me
```

```sh
x-ratelimit-bucket: 78bb8553d9352a5a2f89f9def401287a
x-ratelimit-limit: 1000
x-ratelimit-remaining: 0
x-ratelimit-reset: 1701541977.957
x-ratelimit-reset-after: 0.001
```

Many other `@me` endpoints give a similar result.

## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
