### PR TITLE
feat: Add **kwargs passthrough to `client.load_extensions`

### DIFF
--- a/interactions/client/client.py
+++ b/interactions/client/client.py
@@ -2012,6 +2012,7 @@ class Client(
         self,
         *packages: str,
         recursive: bool = False,
+        **load_kwargs: Any,
     ) -> None:
         """
         Load multiple extensions at once.
@@ -2035,7 +2036,7 @@ class Client(
             extensions = [f.replace(os.path.sep, ".").replace(".py", "") for f in glob.glob(pattern, recursive=True)]
 
             for ext in extensions:
-                self.load_extension(ext)
+                self.load_extension(ext, **load_kwargs)
 
     def unload_extension(
         self, name: str, package: str | None = None, force: bool = False, **unload_kwargs: Any


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [x] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
Adds the ability to pass **kwargs into `Client.load_extensions` 

## Related Issues

#1552


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
