### PR TITLE
feat: ability to define which shards connect

### DIFF
--- a/interactions/client/auto_shard_client.py
+++ b/interactions/client/auto_shard_client.py
@@ -35,7 +35,7 @@ class AutoShardedClient(Client):
         self.auto_sharding = "total_shards" not in kwargs
         super().__init__(*args, **kwargs)
 
-        self.only_shards: Optional[List[int]] = kwargs.get("only_shards", None)
+        self.shard_ids: Optional[List[int]] = kwargs.get("shard_ids", None)
 
         self._connection_state = None
 
@@ -247,8 +247,8 @@ class AutoShardedClient(Client):
 
         self.logger.debug(f"Starting bot with {self.total_shards} shard{'s' if self.total_shards != 1 else ''}")
 
-        if self.only_shards:
-            self._connection_states = [ConnectionState(self, self.intents, shard_id) for shard_id in self.only_shards]
+        if self.shard_ids:
+            self._connection_states = [ConnectionState(self, self.intents, shard_id) for shard_id in self.shard_ids]
         else:
             self._connection_states = [
                 ConnectionState(self, self.intents, shard_id) for shard_id in range(self.total_shards)

--- a/interactions/client/auto_shard_client.py
+++ b/interactions/client/auto_shard_client.py
@@ -2,7 +2,7 @@ import asyncio
 import time
 from datetime import datetime
 from collections import defaultdict
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, List
 
 import interactions.api.events as events
 from interactions.api.events import ShardConnect
@@ -34,6 +34,8 @@ class AutoShardedClient(Client):
     def __init__(self, *args, **kwargs) -> None:
         self.auto_sharding = "total_shards" not in kwargs
         super().__init__(*args, **kwargs)
+
+        self.only_shards: Optional[List[int]] = kwargs.get("only_shards", None)
 
         self._connection_state = None
 
@@ -244,9 +246,13 @@ class AutoShardedClient(Client):
             )
 
         self.logger.debug(f"Starting bot with {self.total_shards} shard{'s' if self.total_shards != 1 else ''}")
-        self._connection_states: list[ConnectionState] = [
-            ConnectionState(self, self.intents, shard_id) for shard_id in range(self.total_shards)
-        ]
+
+        if self.only_shards:
+            self._connection_states = [ConnectionState(self, self.intents, shard_id) for shard_id in self.only_shards]
+        else:
+            self._connection_states = [
+                ConnectionState(self, self.intents, shard_id) for shard_id in range(self.total_shards)
+            ]
 
     async def change_presence(
         self,


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [x] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
Having one AutoShardedClient can be risky in the case of a fatal error in a users code. Leading for the entire bot to crash. With this feature, a user can call a microservice or other to determine what shards the AutoShardedClient should be running. 


## Changes
- added `shard_ids` to AutoShardedClient classs


## Test Scenarios
```py
bot = AutoShardedClient(
    fetch_members=False,
    delete_unused_application_cmds=False,
    sync_interactions=False,
    total_shards=112,
    shard_ids=[12, 13, 14, 15, 16],
    basic_logging=True,
    log_level=logging.DEBUG,
)


@listen(Startup, delay_until_ready=True)
async def on_startup(event: Startup):
    print("Bot is ready")
    print(f"Logged in as {bot.user}")
    print(f"Bot ID: {bot.user.id}")
    print(f"Guilds: {len(bot.guilds)}")

```


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [ ] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
