### PR TITLE
fix: add ActivityType.CUSTOM to list of valid activities for bots

### DIFF
--- a/interactions/api/gateway/state.py
+++ b/interactions/api/gateway/state.py
@@ -178,6 +178,7 @@ class ConnectionState:
                 ActivityType.LISTENING,
                 ActivityType.WATCHING,
                 ActivityType.COMPETING,
+                ActivityType.CUSTOM,
             ]:
                 self.wrapped_logger(
                     logging.WARNING, f"Activity type `{ActivityType(activity.type).name}` may not be enabled for bots"


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
`ActivityType.CUSTOM` was missing from the "valid activity check" done when changing presences. This didn't stop the bot from changing the presence, but it did produce an annoying warning. This PR adds it to the check, fixing that warning.


## Changes
See description and/or diff.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
```python
bot = Client(
    ...,
    activity=Activity.create("test", type=ActivityType.CUSTOM, state="Woo, a custom status!"),
)
```


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
