### PR TITLE
feat: add fail_if_not_exists for PrefixedContext.reply

### DIFF
--- a/interactions/ext/prefixed_commands/context.py
+++ b/interactions/ext/prefixed_commands/context.py
@@ -7,7 +7,7 @@ from interactions.client.mixins.send import SendMixin
 from interactions.models.discord.channel import TYPE_MESSAGEABLE_CHANNEL
 from interactions.models.discord.embed import Embed
 from interactions.models.discord.file import UPLOADABLE_TYPE
-from interactions.models.discord.message import Message
+from interactions.models.discord.message import Message, MessageReference
 from interactions.models.internal.context import BaseContext
 from interactions.models.misc.context_manager import Typing
 
@@ -86,6 +86,7 @@ class PrefixedContext(BaseContext, SendMixin):
         content: Optional[str] = None,
         embeds: Optional[Union[Iterable[Union[Embed, dict]], Union[Embed, dict]]] = None,
         embed: Optional[Union[Embed, dict]] = None,
+        fail_if_not_exists: bool = True,
         **kwargs: Any,
     ) -> Message:
         """
@@ -95,10 +96,12 @@ class PrefixedContext(BaseContext, SendMixin):
             content: Message text content.
             embeds: Embedded rich content (up to 6000 characters).
             embed: Embedded rich content (up to 6000 characters).
+            fail_if_not_exists: Whether to error if the command invocation doesn't exist.
             **kwargs: Additional options to pass to `send`.
 
         Returns:
             New message object.
 
         """
-        return await self.send(content=content, reply_to=self.message, embeds=embeds or embed, **kwargs)
+        ref = MessageReference.for_message(self.message, fail_if_not_exists=fail_if_not_exists)
+        return await self.send(content=content, reply_to=ref, embeds=embeds or embed, **kwargs)

--- a/interactions/ext/prefixed_commands/context.py
+++ b/interactions/ext/prefixed_commands/context.py
@@ -96,7 +96,7 @@ class PrefixedContext(BaseContext, SendMixin):
             content: Message text content.
             embeds: Embedded rich content (up to 6000 characters).
             embed: Embedded rich content (up to 6000 characters).
-            fail_if_not_exists: Whether to error if the command invocation doesn't exist.
+            fail_if_not_exists: Whether to error if the command invocation doesn't exist instead of sending as a normal (non-reply) message.
             **kwargs: Additional options to pass to `send`.
 
         Returns:


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [x] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
This is a simple PR to add `fail_if_not_exists` to `PrefixedContext.reply`. Really, I have to question why `fail_if_not_exists` doesn't default to `False` - regardless, people at least have the option now.


## Changes
- Add `fail_if_not_exists` to `PrefixedContext.reply`.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
```python
@prefixed_command()
async def some_cmd(ctx: PrefixedContext):
    await ctx.message.delete()
    await ctx.reply("Hello!")  # will fail
    # meanwhile, await ctx.reply("Hello!", fail_if_not_exists=False) will work with this PR
```

## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
