### PR TITLE
feat: add SUPPRESS_NOTIFICATIONS alias for SILENT

### DIFF
--- a/interactions/models/discord/enums.py
+++ b/interactions/models/discord/enums.py
@@ -468,6 +468,9 @@ class MessageFlags(DiscordIntFlag):  # type: ignore
     VOICE_MESSAGE = 1 << 13
     """This message is a voice message"""
 
+    SUPPRESS_NOTIFICATIONS = SILENT
+    """Alias for :attr:`SILENT`"""
+
     # Special members
     NONE = 0
     ALL = AntiFlag()


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [x] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
Simply adds `SUPPRESS_NOTIFICATIONS` as an alias for `SILENT`, since [`SUPPRESS_NOTIFICATIONS` is what the flag is currently called](https://discord.com/developers/docs/resources/channel#message-object-message-flags) in the Discord docs.


## Changes
See description.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [x] I've updated / added  documentation, where applicable
