### PR TITLE
fix: correct link for wait_for_component

### DIFF
--- a/docs/src/Guides/05 Components.md
+++ b/docs/src/Guides/05 Components.md
@@ -193,7 +193,7 @@ When responding to a component you need to satisfy Discord either by responding 
 
     You can also use this to check for a normal message instead of a component interaction.
 
-    For more information, please visit the API reference [here](/interactions.py/API Reference/API Reference/client/#interactions.client.client.Client.wait_for_component).
+    For more information, please visit the API reference [here](/interactions.py/API Reference/API Reference/Client/#interactions.client.Client.wait_for_component).
 
 
 === ":two: Persistent Callback: `@listen()`"


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [x] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
A simple fix for a broken link. 


## Changes
- Correct link for `wait_for_component` in the Components guide.


## Related Issues
Fixes #1595.


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [x] I've updated / added  documentation, where applicable
