### PR TITLE
feat: add InvitableMixin to GuildForum

### DIFF
--- a/interactions/models/discord/channel.py
+++ b/interactions/models/discord/channel.py
@@ -2389,7 +2389,7 @@ class GuildStageVoice(GuildVoice):
 
 
 @attrs.define(eq=False, order=False, hash=False, kw_only=True)
-class GuildForum(GuildChannel):
+class GuildForum(GuildChannel, InvitableMixin):
     available_tags: List[ThreadTag] = attrs.field(repr=False, factory=list)
     """A list of tags available to assign to threads"""
     default_reaction_emoji: Optional[DefaultReaction] = attrs.field(repr=False, default=None)


### PR DESCRIPTION
You can invite people to a forum, after all.

## Pull Request Type
<!-- Check the appropriate option -->

- [x] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
Simply adds in `InvitableMixin` to `GuildForum` since you can indeed invite people to it.


## Changes
See description and diff.


## Related Issues
Fixes #1592.


## Test Scenarios
```python
await forum.create_invite()
```


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
