### PR TITLE
feat: add moderated for create_tag methods

### DIFF
--- a/interactions/api/http/http_requests/channels.py
+++ b/interactions/api/http/http_requests/channels.py
@@ -585,6 +585,7 @@ class ChannelRequests(CanRequest):
         name: str,
         emoji_id: Optional["Snowflake_Type"] = None,
         emoji_name: Optional[str] = None,
+        moderated: bool = False,
     ) -> discord_typings.ChannelData:
         """
         Create a new tag.
@@ -594,6 +595,7 @@ class ChannelRequests(CanRequest):
             name: The name of the tag
             emoji_id: The ID of the emoji to use for the tag
             emoji_name: The name of the emoji to use for the tag
+            moderated: whether this tag can only be added to or removed from threads by a member with the MANAGE_THREADS permission
 
         !!! note
             Can either have an `emoji_id` or an `emoji_name`, but not both.
@@ -603,6 +605,7 @@ class ChannelRequests(CanRequest):
             "name": name,
             "emoji_id": int(emoji_id) if emoji_id else None,
             "emoji_name": emoji_name or None,
+            "moderated": moderated,
         }
         payload = dict_filter_none(payload)
 

--- a/interactions/models/discord/channel.py
+++ b/interactions/models/discord/channel.py
@@ -2581,13 +2581,16 @@ class GuildForum(GuildChannel):
 
         return next((tag for tag in self.available_tags if predicate(tag)), None)
 
-    async def create_tag(self, name: str, emoji: Union["models.PartialEmoji", dict, str, None] = None) -> "ThreadTag":
+    async def create_tag(
+        self, name: str, emoji: Union["models.PartialEmoji", dict, str, None] = None, moderated: bool = False
+    ) -> "ThreadTag":
         """
         Create a tag for this forum.
 
         Args:
             name: The name of the tag
             emoji: The emoji to use for the tag
+            moderated: whether this tag can only be added to or removed from threads by a member with the MANAGE_THREADS permission
 
         !!! note
             If the emoji is a custom emoji, it must be from the same guild as the channel.
@@ -2596,7 +2599,7 @@ class GuildForum(GuildChannel):
             The created tag object.
 
         """
-        payload = {"channel_id": self.id, "name": name}
+        payload = {"channel_id": self.id, "name": name, "moderated": moderated}
 
         if emoji:
             if isinstance(emoji, str):


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [x] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
Adds in the `moderated` field for the `create_tag` methods. This was already in `ThreadTag`, but some other places missed this.


## Changes
See description.


## Related Issues
Fixes #1591


## Test Scenarios
```python
await forum.create_tag("tag", "👋", moderated=True)
```


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [x] I've updated / added  documentation, where applicable
