### PR TITLE
fix: re-set _shard_ready on resume

### DIFF
--- a/interactions/api/gateway/gateway.py
+++ b/interactions/api/gateway/gateway.py
@@ -214,6 +214,7 @@ class GatewayClient(WebsocketClient):
                 return self.state.client.dispatch(events.WebsocketReady(data))
 
             case "RESUMED":
+                self.state._shard_ready.set()
                 self.state.wrapped_logger(
                     logging.INFO, f"Successfully resumed connection! Session_ID: {self.session_id}"
                 )


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
When creating a repeating task that printed each shards' status sometimes a shard would report as not ready even though the console had said the shard was online. This change fixes an issue where a shard's state was not being set to ready after a Reconnect opcode.

## Changes
- Added `self.state._shard_ready.set()` to `dispatch_event`

## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [ ] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
