### PR TITLE
feat: add nonce and enforce_nonce to SendMixin

### DIFF
--- a/interactions/client/mixins/send.py
+++ b/interactions/client/mixins/send.py
@@ -47,6 +47,8 @@ class SendMixin:
         silent: bool = False,
         flags: Optional[Union[int, "MessageFlags"]] = None,
         delete_after: Optional[float] = None,
+        nonce: Optional[str | int] = None,
+        enforce_nonce: bool = False,
         **kwargs: Any,
     ) -> "Message":
         """
@@ -67,6 +69,10 @@ class SendMixin:
             silent: Should this message be sent without triggering a notification.
             flags: Message flags to apply.
             delete_after: Delete message after this many seconds.
+            nonce: Used to verify a message was sent. Can be up to 25 characters.
+            enforce_nonce: If enabled and nonce is present, it will be checked for uniqueness in the past few minutes. \
+                If another message was created by the same author with the same nonce, that message will be returned \
+                and no new message will be created.
 
         Returns:
             New message object that was sent.
@@ -95,6 +101,9 @@ class SendMixin:
                 "Attachments are not files. Attachments only contain metadata about the file, not the file itself - to send an attachment, you need to download it first. Check Attachment.url"
             )
 
+        if enforce_nonce and not nonce:
+            raise ValueError("You must provide a nonce to use enforce_nonce.")
+
         message_payload = models.discord.message.process_message_payload(
             content=content,
             embeds=embeds or embed,
@@ -104,6 +113,8 @@ class SendMixin:
             reply_to=reply_to,
             tts=tts,
             flags=flags,
+            nonce=nonce,
+            enforce_nonce=enforce_nonce,
             **kwargs,
         )
 

--- a/interactions/models/discord/message.py
+++ b/interactions/models/discord/message.py
@@ -925,7 +925,7 @@ def process_message_payload(
     reply_to: Optional[Union[MessageReference, Message, dict, "Snowflake_Type"]] = None,
     attachments: Optional[List[Union[Attachment, dict]]] = None,
     tts: bool = False,
-    flags: Optional[Union[int, MessageFlags]] = None,\
+    flags: Optional[Union[int, MessageFlags]] = None,
     nonce: Optional[str | int] = None,
     enforce_nonce: bool = False,
     **kwargs,

--- a/interactions/models/discord/message.py
+++ b/interactions/models/discord/message.py
@@ -925,7 +925,9 @@ def process_message_payload(
     reply_to: Optional[Union[MessageReference, Message, dict, "Snowflake_Type"]] = None,
     attachments: Optional[List[Union[Attachment, dict]]] = None,
     tts: bool = False,
-    flags: Optional[Union[int, MessageFlags]] = None,
+    flags: Optional[Union[int, MessageFlags]] = None,\
+    nonce: Optional[str | int] = None,
+    enforce_nonce: bool = False,
     **kwargs,
 ) -> dict:
     """
@@ -941,6 +943,10 @@ def process_message_payload(
         attachments: The attachments to keep, only used when editing message.
         tts: Should this message use Text To Speech.
         flags: Message flags to apply.
+        nonce: Used to verify a message was sent.
+        enforce_nonce: If enabled and nonce is present, it will be checked for uniqueness in the past few minutes. \
+            If another message was created by the same author with the same nonce, that message will be returned \
+            and no new message will be created.
 
     Returns:
         Dictionary
@@ -969,6 +975,8 @@ def process_message_payload(
             "attachments": attachments,
             "tts": tts,
             "flags": flags,
+            "nonce": nonce,
+            "enforce_nonce": enforce_nonce,
             **kwargs,
         }
     )


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [x] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
Exactly what the title of the PR says. Technically, `SendMixin` would have handled these arguments just fine due to the `kwarg` passthrough here, but having them be more official and documented is nice.

## Changes
- Add `nonce` and `enforce_nonce` to `SendMixin`.]
  - There's also a basic check to make sure `nonce` has a value when `enable_nonce` is enabled.
- Add those two properties to `process_message_payload` to cover all bases.


## Related Issues
Resolves #1614.


## Test Scenarios
```python
await channel.send("hello!", nonce="test", enforce_nonce=True)
await channel.send("hello!", nonce="test", enforce_nonce=True)
```

## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [x] I've updated / added  documentation, where applicable
