### PR TITLE
fix: fail loudly if extension classes are named the same

### DIFF
--- a/interactions/models/internal/extension.py
+++ b/interactions/models/internal/extension.py
@@ -79,6 +79,10 @@ class Extension:
         instance.client = bot
 
         instance.name = cls.__name__
+
+        if instance.name in bot.ext:
+            raise ValueError(f"An extension with the name {instance.name} is already loaded!")
+
         instance.extension_checks = []
         instance.extension_prerun = []
         instance.extension_postrun = []


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
Currently, loading two extensions that have the same class name causes subtle bugs to occur, which eventually culminates in `reload_extension` and other parts of code to error out in a confusing way (it literally took a whole year of discussion in the help forums to find this, as a refernece). While `interactions.py` *should* be able to handle extensions like this, making that work would require breaking changes, so failing loudly is a preferable solution here.

This PR does just that.


## Changes
- Error out when initializing an extension if another extension has the same class name.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
```python
# main.py
bot.load_extension("extension_1")
bot.load_extension("extension_2")
bot.reload_extension("extension_1")
```

```python
# extension_1.py

from interactions import Extension, slash_command, SlashContext

class MyExtension(Extension):
    @slash_command()
    async def test(ctx: SlashContext):
        await ctx.send("Hello!")
```

```python
# extension_2.py

from interactions import Extension, slash_command, SlashContext

class MyExtension(Extension):
    @slash_command()
    async def test2(ctx: SlashContext):
        await ctx.send("Hello!")
```

## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
