### PR TITLE
fix: correct expire property for interaction ctx

### DIFF
--- a/interactions/models/internal/context.py
+++ b/interactions/models/internal/context.py
@@ -35,6 +35,7 @@ from interactions.models.discord.message import (
 )
 from interactions.models.discord.snowflake import Snowflake, Snowflake_Type, to_snowflake, to_optional_snowflake
 from interactions.models.discord.embed import Embed
+from interactions.models.discord.timestamp import Timestamp
 from interactions.models.internal.application_commands import (
     OptionType,
     CallbackType,
@@ -329,16 +330,16 @@ class BaseInteractionContext(BaseContext):
         return self.client._interaction_lookup[self._command_name]
 
     @property
-    def expires_at(self) -> typing.Optional[datetime.datetime]:
+    def expires_at(self) -> Timestamp:
         """The time at which the interaction expires."""
-        if self.responded:
+        if self.responded or self.deferred:
             return self.id.created_at + datetime.timedelta(minutes=15)
         return self.id.created_at + datetime.timedelta(seconds=3)
 
     @property
     def expired(self) -> bool:
         """Whether the interaction has expired."""
-        return datetime.datetime.utcnow() > self.expires_at
+        return Timestamp.utcnow() > self.expires_at
 
     @property
     def invoke_target(self) -> str:


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
Turns out `BaseInteractionContext` does not handle either `expires_at` or `expired` correctly. This PR fixes that.


## Changes
- Correct typehint of `expires_at`.
- Make `expires_at` consider deferrals.
- Make `expired` use `Timestamp` instead of naive `datetime`.


## Related Issues
Fixes #1623.


## Test Scenarios
```python
import asyncio

@interactions.slash_command()
async def test(ctx: interactions.SlashContext):
    await ctx.defer()
    await asyncio.sleep(10)
    print(ctx.expired)  # should return false, but just errors out
    await ctx.send("Hello!")
```


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
