### PR TITLE
Adding handling for system tz not found exception

### DIFF
--- a/interactions/models/discord/timestamp.py
+++ b/interactions/models/discord/timestamp.py
@@ -60,14 +60,15 @@ class Timestamp(datetime):
             timestamp = super().fromtimestamp(t, tz=tz)
         except Exception:
             # May be in milliseconds instead of seconds
-            timestamp = super().fromtimestamp(t / 1000, tz=tz)
+            t = t / 1000
+            timestamp = super().fromtimestamp(t, tz=tz)
 
         try:
             # Try to fallback to local / system tz
             return timestamp.astimezone() if timestamp.tzinfo is None else timestamp
         except Exception:
-            # Fallback to utc timezone if system tz not found
-            return super().fromtimestamp(t / 1000, tz=timezone.utc)
+            # Fallback to utc tz if no system tz
+            return super().fromtimestamp(t, tz=timezone.utc)
 
     @classmethod
     def fromordinal(cls, n: int) -> "Timestamp":

--- a/interactions/models/discord/timestamp.py
+++ b/interactions/models/discord/timestamp.py
@@ -62,7 +62,12 @@ class Timestamp(datetime):
             # May be in milliseconds instead of seconds
             timestamp = super().fromtimestamp(t / 1000, tz=tz)
 
-        return timestamp.astimezone() if timestamp.tzinfo is None else timestamp
+        try:
+            # Try to fallback to local / system tz
+            return timestamp.astimezone() if timestamp.tzinfo is None else timestamp
+        except Exception:
+            # Fallback to utc timezone if system tz not found
+            return super().fromtimestamp(t / 1000, tz=timezone.utc)
 
     @classmethod
     def fromordinal(cls, n: int) -> "Timestamp":


### PR DESCRIPTION
## Pull Request Type
- [ ] Feature addition
- [✓] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement

## Description
It handles a rare exception that was found while testing locally in a Windows 10 environment.

## Changes
- A `try-except` catch for the `timestamp.astimezone()` function in the return
- Allows fallback handling to UTC, if the system tz isn't found at any time
