### PR TITLE
fix: change SENTRY_TOKEN to SENTRY_DSN

### DIFF
--- a/docs/src/Guides/25 Error Tracking.md
+++ b/docs/src/Guides/25 Error Tracking.md
@@ -36,7 +36,7 @@ And this is great when debugging.  But it consumes your rate limit, can run into
 
 interactions.py contains built-in support for Sentry.io, a cloud error tracking platform.
 
-To enable it, call `bot.load_extension('interactions.ext.sentry', token=SENTRY_TOKEN)` as early as possible in your startup. (Load it before your own extensions, so it can catch intitialization errors in those extensions)
+To enable it, call `bot.load_extension('interactions.ext.sentry', dsn=SENTRY_DSN)` as early as possible in your startup. Load this extension before your own extensions, so it can catch intitialization errors in those extensions. `SENTRY_DSN` is provided by your Sentry.io project and should look something like `https://...@o9253.sentry.io/1048576`.
 
 # What does this do that vanilla Sentry doesn't?
 

--- a/interactions/ext/sentry.py
+++ b/interactions/ext/sentry.py
@@ -1,7 +1,7 @@
 """
 Sets up a Sentry Logger
 
-And then call `bot.load_extension('interactions.ext.sentry', token=SENTRY_TOKEN)`
+And then call `bot.load_extension('interactions.ext.sentry', dsn=SENTRY_DSN)`
 Optionally takes a filter function that will be called before sending the event to Sentry.
 """
 
@@ -90,15 +90,17 @@ class HookedTask(Task):
 
 def setup(
     bot: Client,
-    token: str | None = None,
+    dsn: str | None = None,
     filter: Optional[Callable[[dict[str, Any], dict[str, Any]], Optional[dict[str, Any]]]] = None,
+    token: str | None = None,
     **kwargs,
 ) -> None:
-    if not token:
-        bot.logger.error("Cannot enable sentry integration, no token provided")
+    dsn = dsn or token
+    if not dsn:
+        bot.logger.error("Cannot enable sentry integration, no Sentry DSN provided")
         return
     if filter is None:
         filter = default_sentry_filter
-    sentry_sdk.init(token, before_send=filter, **kwargs)
+    sentry_sdk.init(dsn, before_send=filter, **kwargs)
     Task.on_error_sentry_hook = HookedTask.on_error_sentry_hook  # type: ignore
     SentryExtension(bot)


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [x] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
<!-- Provide a clear and concise description of the purpose of this PR and why it should be merged -->
<!-- If your code adds or changes features, a usage example would be helpful -->
Change references to SENTRY_TOKEN with SENTRY_DSN in docs (Error Tracking guide) and messages (`interactions.ext.sentry:setup` on error), in accordance with Sentry.io docs. This should avoid confusion by users possibly adding a Sentry.io auth token on setup.

Added as `fix` as this PR also includes a fix on an error when specifying `dsn="dsn"` but not `token="dsn"` on extension setup.

## Changes
<!-- List the changes you have made in a bullet-point format -->
* `interactions.ext.sentry:setup:` Add argument `dsn` in place of `token`
  * `token` is moved back and is accessible as a kwarg, avoiding breaking changes. However, `dsn` will take precedence when available.
  * This avoids an error when using `dsn="dsn"` without specifying `token="dsn"`.
* Replace references to `token=SENTRY_TOKEN` with `dsn=SENTRY_DSN`. Instead, an error would be emitted if both are unspecified or `None`.
* Edited the Error Tracking guide accordingly
  * Added small information on what DSN looks like (a url).

## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->
A `ZeroDivisionError` event should appear on the Sentry.io project corresponding to the DSN. The DSN below is an example.
```python
from interactions import Client, slash_command, SlashContext

@slash_command(name="test", description="Test command")
async def test_cmd(ctx: SlashContext):
  plant = 1 / 0
  await ctx.send("This message is never reached")

bot = Client()
bot.load_extension("interactions.ext.sentry", dsn="https://...@o1.ingest.sentry.io/1048576")
bot.start("token")
```

The `load_extension` should still work with `token` kwarg:
```python
bot.load_extension("interactions.ext.sentry", token="https://...@o1.ingest.us.sentry.io/1048576")
```

Keyword `dsn` overrides `token` when available:
```python
bot.load_extension("interactions.ext.sentry", token="bad link", dsn="https://...@o1.ingest.us.sentry.io/1048576")
```

The error message should show, this time for "no Sentry DSN".
```python
bot.load_extension("interactions.ext.sentry")
```

## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [x] I've updated / added  documentation, where applicable
