### PR TITLE
feat: allow for editing the bot's banner

### DIFF
--- a/interactions/models/discord/user.py
+++ b/interactions/models/discord/user.py
@@ -239,12 +239,18 @@ class ClientUser(User):
         """The guilds the user is in."""
         return list(filter(None, (self._client.cache.get_guild(guild_id) for guild_id in self._guild_ids)))
 
-    async def edit(self, *, username: Absent[str] = MISSING, avatar: Absent[UPLOADABLE_TYPE] = MISSING) -> None:
+    async def edit(
+        self,
+        *,
+        username: Absent[str] = MISSING,
+        avatar: Absent[UPLOADABLE_TYPE] = MISSING,
+        banner: Absent[UPLOADABLE_TYPE] = MISSING,
+    ) -> None:
         """
         Edit the client's user.
 
-        You can either change the username, or avatar, or both at once.
-        `avatar` may be set to `None` to remove your bot's avatar
+        You can change the username, avatar, and banner, or any combination of the three.
+        `avatar` and `banner` may be set to `None` to remove your bot's avatar/banner
 
         ??? Hint "Example Usage:"
             ```python
@@ -258,6 +264,7 @@ class ClientUser(User):
         Args:
             username: The username you want to use
             avatar: The avatar to use. Can be a image file, path, or `bytes` (see example)
+            banner: The banner to use. Can be a image file, path, or `bytes`
 
         Raises:
             TooManyChanges: If you change the profile too many times
@@ -270,6 +277,10 @@ class ClientUser(User):
             payload["avatar"] = to_image_data(avatar)
         elif avatar is None:
             payload["avatar"] = None
+        if banner:
+            payload["banner"] = to_image_data(banner)
+        elif banner is None:
+            payload["banner"] = None
 
         try:
             resp = await self._client.http.modify_client_user(payload)

--- a/interactions/models/discord/user.pyi
+++ b/interactions/models/discord/user.pyi
@@ -95,7 +95,13 @@ class ClientUser(User):
     def _add_guilds(self, guild_ids: Set["Snowflake_Type"]) -> None: ...
     @property
     def guilds(self) -> List["Guild"]: ...
-    async def edit(self, *, username: Absent[str] = ..., avatar: Absent[UPLOADABLE_TYPE] = ...) -> None: ...
+    async def edit(
+        self,
+        *,
+        username: Absent[str] = ...,
+        avatar: Absent[UPLOADABLE_TYPE] = ...,
+        banner: Absent[UPLOADABLE_TYPE] = ...,
+    ) -> None: ...
 
 @attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class Member(FakeUserMixin):


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [x] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
This PR allows you to edit the bot's banner, like how you can for the icon right now.

## Changes
- Add `banner` attribute to `ClientUser.edit`. This is pretty much a copy and paste of `avatar`.
  - The docstrings have been updated to note this.
- Update `user.pyi`.


## Related Issues
Fixes #1635.


## Test Scenarios
```python
@slash_command()
async def test(ctx: SlashContext):
    await ctx.send("Hello!")
    await ctx.bot.user.edit(banner=...)
```


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [x] I've updated / added  documentation, where applicable
