### PR TITLE
fix: recorder memory usage when a user rejoins

### DIFF
--- a/interactions/api/voice/recorder.py
+++ b/interactions/api/voice/recorder.py
@@ -217,10 +217,10 @@ class Recorder(threading.Thread):
 
         if raw_audio.ssrc not in self.user_timestamps:
             if last_timestamp := self.audio.last_timestamps.get(raw_audio.user_id, None):
-                diff = raw_audio.timestamp - last_timestamp
-                silence = int(diff * decoder.sample_rate)
+                silence = raw_audio.timestamp - last_timestamp
+                frames = int(silence * decoder.sample_rate)
                 log.debug(
-                    f"{self.state.channel.id}::{raw_audio.user_id} - User rejoined, adding {silence} silence frames ({diff} seconds)"
+                    f"{self.state.channel.id}::{raw_audio.user_id} - User rejoined, adding {frames} silence frames ({silence} seconds)"
                 )
             else:
                 silence = 0


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
This fixes some erroneous code that cause enormous memory usage when rejoining a voice channel with a bot recording.


## Changes
- Fix calculation of how long of silence to add when a user rejoins a recorded voice channel.


## Related Issues
Fixes #1642.


## Test Scenarios
Use whatever you prefer and start monitoring your system memory usage. Join a voice channel and have a bot join it to record. Talk and then disconnect from the voice channel. Wait 3-5 seconds and rejoin the voice channel. Memory usage should stay relatively the same. Stop the recording and confirm the recorded audio is correct.


## Python Compatibility
- [x] I've ensured my code works on Python `3.10.x`
- [ ] I've ensured my code works on Python `3.11.x`


## Checklist
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [x] I've added tests for my code, if applicable
- [x] I've updated / added  documentation, where applicable
