### PR TITLE
feat: option to hide paginator buttons on stop/timeout

### DIFF
--- a/interactions/ext/paginators.py
+++ b/interactions/ext/paginators.py
@@ -106,6 +106,8 @@ class Paginator:
     """Show a button which will call the `callback`"""
     show_select_menu: bool = attrs.field(repr=False, default=False)
     """Should a select menu be shown for navigation"""
+    hide_buttons_on_stop: bool = attrs.field(repr=False, default=False)
+    """Should the paginator buttons be hidden instead of disabled after stop or timeout"""
 
     first_button_emoji: Optional[Union["PartialEmoji", dict, str]] = attrs.field(
         repr=False, default="⏮️", metadata=export_converter(process_emoji)
@@ -270,6 +272,9 @@ class Paginator:
             A list of ActionRows
 
         """
+        if disable and self.hide_buttons_on_stop:
+            return []
+
         output = []
 
         if self.show_select_menu:


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [x] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
<!-- Provide a clear and concise description of the purpose of this PR and why it should be merged -->
<!-- If your code adds or changes features, a usage example would be helpful -->
Adds a bool attribute `hide_buttons_on_stop` to `Paginator` in `interactions.ext.paginators`. If set to `True`, the paginator will hide/clear all of its components on (1) a timeout or (2) a call to `Paginator.stop()`. Otherwise, the components are disabled, which is the current (and with this PR, default) behavior of the paginator.

## Changes
<!-- List the changes you have made in a bullet-point format -->
* Add bool attribute `hide_buttons_on_stop` to `Paginator`
* Edited `Paginator.create_components()`
  * The method short-circuits to return `[]` when both the method arg `disable` and the new attribute are `True`.

## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->
### Default (disable)
The buttons are disabled (greyed out) after a timeout of 20 seconds.
```python
@slash_command(name="test-x", description="Test command, base case")
async def test_cmd_x(ctx: SlashContext):
  pages = [Embed(f"This is page {i}") for i in range(5)]
  paginator = Paginator.create_from_embeds(bot, *pages, timeout=20)
  await paginator.send(ctx)
```

### Timeout
The buttons are cleared after a timeout of 20 seconds.
```python
@slash_command(name="test-a", description="Test command, scenario A")
async def test_cmd_a(ctx: SlashContext):
  pages = [Embed(f"This is page {i}") for i in range(5)]
  paginator = Paginator.create_from_embeds(bot, *pages, timeout=20)
  paginator.hide_buttons_on_stop = True
  await paginator.send(ctx)
```

### Stop
The buttons are cleared after 8 seconds (due to `asyncio.sleep()`) since sending.
```python
@slash_command(name="test-b", description="Test command, scenario B")
async def test_cmd_b(ctx: SlashContext):
  pages = [Embed(f"This is page {i}") for i in range(5)]
  paginator = Paginator.create_from_embeds(bot, *pages)
  paginator.hide_buttons_on_stop = True
  await paginator.send(ctx)
  await asyncio.sleep(8)
  await paginator.stop()
```

## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [x] I've added tests for my code, if applicable
- [x] I've updated / added  documentation, where applicable
