### PR TITLE
feat: option to defer without raising errors

### DIFF
--- a/interactions/ext/hybrid_commands/context.py
+++ b/interactions/ext/hybrid_commands/context.py
@@ -188,6 +188,7 @@ class HybridContext(BaseContext, SendMixin):
 
         Args:
             ephemeral: Should the response be ephemeral? Only applies to responses for interactions.
+            suppress_error: Should errors on deferring be suppressed than raised.
 
         """
         if self._slash_ctx:

--- a/interactions/ext/hybrid_commands/context.py
+++ b/interactions/ext/hybrid_commands/context.py
@@ -183,9 +183,6 @@ class HybridContext(BaseContext, SendMixin):
             If using this method, whether the interaction response is ephemeral or not will be determined by this
             method regardless of ephemeral settings in send().
 
-            If used alongside auto defer, you may want to use `suppress_error` as auto defer may defer first before
-            this method is called manually.
-
         Args:
             ephemeral: Should the response be ephemeral? Only applies to responses for interactions.
             suppress_error: Should errors on deferring be suppressed than raised.

--- a/interactions/ext/hybrid_commands/context.py
+++ b/interactions/ext/hybrid_commands/context.py
@@ -180,8 +180,10 @@ class HybridContext(BaseContext, SendMixin):
         Either defers the response (if used in an interaction) or triggers a typing indicator for 10 seconds (if used for messages).
 
         ???+ note "Interaction Note"
-            If using this method, whether the interaction response is ephemeral or not will be determined by this
-            method regardless of ephemeral settings in send().
+            This method's ephemeral settings override the ephemeral settings of `send()`.
+
+            For example, deferring with `ephemeral=True` will make the interaction response ephemeral even with
+            `send(ephemeral=False)`.
 
         Args:
             ephemeral: Should the response be ephemeral? Only applies to responses for interactions.

--- a/interactions/ext/hybrid_commands/context.py
+++ b/interactions/ext/hybrid_commands/context.py
@@ -24,7 +24,9 @@ from interactions import (
     process_message_payload,
 )
 from interactions.client.mixins.send import SendMixin
+from interactions.client.errors import HTTPException
 from interactions.ext import prefixed_commands as prefixed
+import contextlib
 
 if TYPE_CHECKING:
     from .hybrid_slash import HybridSlashCommand
@@ -192,6 +194,9 @@ class HybridContext(BaseContext, SendMixin):
         """
         if self._slash_ctx:
             await self._slash_ctx.defer(ephemeral=ephemeral, suppress_error=suppress_error)
+        elif suppress_error:
+            with contextlib.suppress(HTTPException):
+                await self.channel.trigger_typing()
         else:
             await self.channel.trigger_typing()
 

--- a/interactions/ext/hybrid_commands/context.py
+++ b/interactions/ext/hybrid_commands/context.py
@@ -175,16 +175,23 @@ class HybridContext(BaseContext, SendMixin):
             return DeferTyping(self._slash_ctx, self.ephemeral)
         return self.channel.typing
 
-    async def defer(self, ephemeral: bool = False) -> None:
+    async def defer(self, ephemeral: bool = False, suppress_error: bool = False) -> None:
         """
         Either defers the response (if used in an interaction) or triggers a typing indicator for 10 seconds (if used for messages).
+
+        ???+ note "Interaction Note"
+            If using this method, whether the interaction response is ephemeral or not will be determined by this
+            method regardless of ephemeral settings in send().
+
+            If used alongside auto defer, you may want to use `suppress_error` as auto defer may defer first before
+            this method is called manually.
 
         Args:
             ephemeral: Should the response be ephemeral? Only applies to responses for interactions.
 
         """
         if self._slash_ctx:
-            await self._slash_ctx.defer(ephemeral=ephemeral)
+            await self._slash_ctx.defer(ephemeral=ephemeral, suppress_error=suppress_error)
         else:
             await self.channel.trigger_typing()
 

--- a/interactions/models/internal/context.py
+++ b/interactions/models/internal/context.py
@@ -414,9 +414,6 @@ class InteractionContext(BaseInteractionContext, SendMixin):
             If using this method, whether the response is ephemeral or not will be determined by this method regardless
             of ephemeral settings in send().
 
-            If used alongside auto defer, you may want to use `suppress_error` as auto defer may defer first before
-            this method is called manually.
-
         Args:
             ephemeral: Whether the interaction response should be ephemeral.
             suppress_error: Should errors on deferring be suppressed than raised.
@@ -675,9 +672,6 @@ class ContextMenuContext(InteractionContext, ModalMixin):
             If using this method, whether the response is ephemeral or not will be determined by this method regardless
             of ephemeral settings in send().
 
-            If used alongside auto defer, you may want to use `suppress_error` as auto defer may defer first before
-            this method is called manually.
-
         Args:
             ephemeral: Whether the interaction response should be ephemeral.
             edit_origin: Whether to edit the original message instead of sending a new one.
@@ -783,9 +777,6 @@ class ComponentContext(InteractionContext, ModalMixin):
         Note:
             If using this method, whether the response is ephemeral or not will be determined by this method regardless
             of ephemeral settings in send().
-
-            If used alongside auto defer, you may want to use `suppress_error` as auto defer may defer first before
-            this method is called manually.
 
         Args:
             ephemeral: Whether the interaction response should be ephemeral.
@@ -936,9 +927,6 @@ class ModalContext(InteractionContext):
         Note:
             If using this method, whether the response is ephemeral or not will be determined by this method regardless
             of ephemeral settings in send().
-
-            If used alongside auto defer, you may want to use `suppress_error` as auto defer may defer first before
-            this method is called manually.
 
         Args:
             ephemeral: Whether the interaction response should be ephemeral.

--- a/interactions/models/internal/context.py
+++ b/interactions/models/internal/context.py
@@ -419,7 +419,7 @@ class InteractionContext(BaseInteractionContext, SendMixin):
 
         Args:
             ephemeral: Whether the interaction response should be ephemeral.
-            suppress_errors: Should errors on deferring be suppressed than raised
+            suppress_error: Should errors on deferring be suppressed than raised.
 
         """
         if suppress_error:
@@ -681,7 +681,7 @@ class ContextMenuContext(InteractionContext, ModalMixin):
         Args:
             ephemeral: Whether the interaction response should be ephemeral.
             edit_origin: Whether to edit the original message instead of sending a new one.
-            suppress_errors: Should errors on deferring be suppressed than raised
+            suppress_error: Should errors on deferring be suppressed than raised.
 
         """
         if suppress_error:
@@ -790,7 +790,7 @@ class ComponentContext(InteractionContext, ModalMixin):
         Args:
             ephemeral: Whether the interaction response should be ephemeral.
             edit_origin: Whether to edit the original message instead of sending a new one.
-            suppress_errors: Should errors on deferring be suppressed than raised
+            suppress_error: Should errors on deferring be suppressed than raised.
 
         """
         if suppress_error:
@@ -943,7 +943,7 @@ class ModalContext(InteractionContext):
         Args:
             ephemeral: Whether the interaction response should be ephemeral.
             edit_origin: Whether to edit the original message instead of sending a new one.
-            suppress_errors: Should errors on deferring be suppressed than raised
+            suppress_error: Should errors on deferring be suppressed than raised.
 
         """
         if suppress_error:

--- a/interactions/models/internal/context.py
+++ b/interactions/models/internal/context.py
@@ -938,7 +938,7 @@ class ModalContext(InteractionContext):
 
         Args:
             ephemeral: Whether the interaction response should be ephemeral.
-            edit_origin: Whether to edit the original message instead of sending a new one.
+            edit_origin: Whether to edit the original message instead of sending a followup.
             suppress_error: Should errors on deferring be suppressed than raised.
 
         """

--- a/interactions/models/internal/context.py
+++ b/interactions/models/internal/context.py
@@ -411,8 +411,10 @@ class InteractionContext(BaseInteractionContext, SendMixin):
         Defer the interaction.
 
         Note:
-            If using this method, whether the response is ephemeral or not will be determined by this method regardless
-            of ephemeral settings in send().
+            This method's ephemeral settings override the ephemeral settings of `send()`.
+
+            For example, deferring with `ephemeral=True` will make the response ephemeral even with
+            `send(ephemeral=False)`.
 
         Args:
             ephemeral: Whether the interaction response should be ephemeral.
@@ -669,8 +671,10 @@ class ContextMenuContext(InteractionContext, ModalMixin):
         Defer the interaction.
 
         Note:
-            If using this method, whether the response is ephemeral or not will be determined by this method regardless
-            of ephemeral settings in send().
+            This method's ephemeral settings override the ephemeral settings of `send()`.
+
+            For example, deferring with `ephemeral=True` will make the response ephemeral even with
+            `send(ephemeral=False)`.
 
         Args:
             ephemeral: Whether the interaction response should be ephemeral.
@@ -775,8 +779,10 @@ class ComponentContext(InteractionContext, ModalMixin):
         Defer the interaction.
 
         Note:
-            If using this method, whether the response is ephemeral or not will be determined by this method regardless
-            of ephemeral settings in send().
+            This method's ephemeral settings override the ephemeral settings of `send()`.
+
+            For example, deferring with `ephemeral=True` will make the response ephemeral even with
+            `send(ephemeral=False)`.
 
         Args:
             ephemeral: Whether the interaction response should be ephemeral.
@@ -925,8 +931,10 @@ class ModalContext(InteractionContext):
         Defer the interaction.
 
         Note:
-            If using this method, whether the response is ephemeral or not will be determined by this method regardless
-            of ephemeral settings in send().
+            This method's ephemeral settings override the ephemeral settings of `send()`.
+
+            For example, deferring with `ephemeral=True` will make the response ephemeral even with
+            `send(ephemeral=False)`.
 
         Args:
             ephemeral: Whether the interaction response should be ephemeral.

--- a/interactions/models/internal/context.py
+++ b/interactions/models/internal/context.py
@@ -1,6 +1,7 @@
 import abc
 import datetime
 import re
+import contextlib
 import typing
 from typing_extensions import Self
 
@@ -405,14 +406,29 @@ class BaseInteractionContext(BaseContext):
 
 
 class InteractionContext(BaseInteractionContext, SendMixin):
-    async def defer(self, *, ephemeral: bool = False) -> None:
+    async def defer(self, *, ephemeral: bool = False, suppress_error: bool = False) -> None:
         """
         Defer the interaction.
 
+        Note:
+            If using this method, whether the response is ephemeral or not will be determined by this method regardless
+            of ephemeral settings in send().
+
+            If used alongside auto defer, you may want to use `suppress_error` as auto defer may defer first before
+            this method is called manually.
+
         Args:
             ephemeral: Whether the interaction response should be ephemeral.
+            suppress_errors: Should errors on deferring be suppressed than raised
 
         """
+        if suppress_error:
+            with contextlib.suppress(AlreadyDeferred, AlreadyResponded, HTTPException):
+                await self._defer(ephemeral=ephemeral)
+        else:
+            await self._defer(ephemeral=ephemeral)
+
+    async def _defer(self, *, ephemeral: bool = False) -> None:
         if self.deferred:
             raise AlreadyDeferred("Interaction has already been responded to.")
         if self.responded:
@@ -651,15 +667,30 @@ class ContextMenuContext(InteractionContext, ModalMixin):
         instance.target_type = CommandType(payload["data"]["type"])
         return instance
 
-    async def defer(self, *, ephemeral: bool = False, edit_origin: bool = False) -> None:
+    async def defer(self, *, ephemeral: bool = False, edit_origin: bool = False, suppress_error: bool = False) -> None:
         """
         Defer the interaction.
+
+        Note:
+            If using this method, whether the response is ephemeral or not will be determined by this method regardless
+            of ephemeral settings in send().
+
+            If used alongside auto defer, you may want to use `suppress_error` as auto defer may defer first before
+            this method is called manually.
 
         Args:
             ephemeral: Whether the interaction response should be ephemeral.
             edit_origin: Whether to edit the original message instead of sending a new one.
+            suppress_errors: Should errors on deferring be suppressed than raised
 
         """
+        if suppress_error:
+            with contextlib.suppress(AlreadyDeferred, AlreadyResponded, HTTPException):
+                await self._defer(ephemeral=ephemeral, edit_origin=edit_origin)
+        else:
+            await self._defer(ephemeral=ephemeral, edit_origin=edit_origin)
+
+    async def _defer(self, *, ephemeral: bool = False, edit_origin: bool = False) -> None:
         if self.deferred:
             raise AlreadyDeferred("Interaction has already been responded to.")
         if self.responded:
@@ -745,15 +776,30 @@ class ComponentContext(InteractionContext, ModalMixin):
                         instance.values[i] = channel
         return instance
 
-    async def defer(self, *, ephemeral: bool = False, edit_origin: bool = False) -> None:
+    async def defer(self, *, ephemeral: bool = False, edit_origin: bool = False, suppress_error: bool = False) -> None:
         """
         Defer the interaction.
+
+        Note:
+            If using this method, whether the response is ephemeral or not will be determined by this method regardless
+            of ephemeral settings in send().
+
+            If used alongside auto defer, you may want to use `suppress_error` as auto defer may defer first before
+            this method is called manually.
 
         Args:
             ephemeral: Whether the interaction response should be ephemeral.
             edit_origin: Whether to edit the original message instead of sending a new one.
+            suppress_errors: Should errors on deferring be suppressed than raised
 
         """
+        if suppress_error:
+            with contextlib.suppress(AlreadyDeferred, AlreadyResponded, HTTPException):
+                await self._defer(ephemeral=ephemeral, edit_origin=edit_origin)
+        else:
+            await self._defer(ephemeral=ephemeral, edit_origin=edit_origin)
+
+    async def _defer(self, *, ephemeral: bool = False, edit_origin: bool = False) -> None:
         if self.deferred:
             raise AlreadyDeferred("Interaction has already been responded to.")
         if self.responded:
@@ -883,15 +929,30 @@ class ModalContext(InteractionContext):
             await self.defer(edit_origin=True)
         return await super().edit(message, **kwargs)
 
-    async def defer(self, *, ephemeral: bool = False, edit_origin: bool = False) -> None:
+    async def defer(self, *, ephemeral: bool = False, edit_origin: bool = False, suppress_error: bool = False) -> None:
         """
         Defer the interaction.
 
+        Note:
+            If using this method, whether the response is ephemeral or not will be determined by this method regardless
+            of ephemeral settings in send().
+
+            If used alongside auto defer, you may want to use `suppress_error` as auto defer may defer first before
+            this method is called manually.
+
         Args:
             ephemeral: Whether the interaction response should be ephemeral.
-            edit_origin: Whether to edit the original message instead of sending a followup.
+            edit_origin: Whether to edit the original message instead of sending a new one.
+            suppress_errors: Should errors on deferring be suppressed than raised
 
         """
+        if suppress_error:
+            with contextlib.suppress(AlreadyDeferred, AlreadyResponded, HTTPException):
+                await self._defer(ephemeral=ephemeral, edit_origin=edit_origin)
+        else:
+            await self._defer(ephemeral=ephemeral, edit_origin=edit_origin)
+
+    async def _defer(self, *, ephemeral: bool = False, edit_origin: bool = False) -> None:
         if self.deferred:
             raise AlreadyDeferred("Interaction has already been responded to.")
         if self.responded:


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [x] Feature addition
- [ ] Bugfix
- [x] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
<!-- Provide a clear and concise description of the purpose of this PR and why it should be merged -->
<!-- If your code adds or changes features, a usage example would be helpful -->
Add a bool kwarg `suppress_error` (default `False`) to `defer()` (often `ctx.defer()`) in different instances of `InteractionContext`. If enabled, deferring an interaction response again will not raise an error, which is the current behavior of `ctx.defer()`.

One example use case of this feature, which I use in a bot of mine, is using `auto_defer(time_until_defer=...)` and `ctx.defer()` together, making the command defer after either a certain point or a set time, whichever is reached first.

### Technical Description
This feature moves/renames the current `defer()` to `_defer()` (note the underscore). The new `defer()` is a wrapper for `_defer()`, which would suppress relevant errors (`AlreadyDeferred`, `AlreadyResponded`, and `HTTPException`) using `contextlib.suppress()`. A similar method of error suppression is already used by `AutoDefer`.

## Changes
<!-- List the changes you have made in a bullet-point format -->
* Add bool kwarg `suppress_error` to `defer()`
  * Default is `False` in line with current behavior
* Add error suppression logic in `defer()`
  * Affects `InteractionContext`, `ComponentContext`, `ContextMenuContext`, `ModalContext`, and `HybridContext`
* Bonus: add docstring note in `defer()` regarding the method overriding ephemeral response settings

## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->
Use the following callback coroutine to an interaction command (slash command, component, context menu, modal, hybrid slash command). Tested on all five.
```python
async def test_cmd(ctx):
  await ctx.defer()
  try:
    await ctx.defer(suppress_error=True)
  except Exception as e:
    await ctx.send(f"Error raised: {type(e)}.")
  else:
    await ctx.send(f"No error.")
```
If `suppress_error=False` or unspecified: Command responds with "Error raised" for `AlreadyDeferred`.
If `suppress_error=True`: Command responds with "No error".

## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [x] I've added tests for my code, if applicable
- [x] I've updated / added  documentation, where applicable
