### PR TITLE
fix: Don't throw confusing error when using unsuppressed autocomplete in Hybrid Commands

### DIFF
--- a/interactions/ext/hybrid_commands/hybrid_slash.py
+++ b/interactions/ext/hybrid_commands/hybrid_slash.py
@@ -31,6 +31,7 @@ from interactions.client.const import AsyncCallable, GLOBAL_SCOPE
 from interactions.client.utils.serializer import no_export_meta
 from interactions.client.utils.misc_utils import maybe_coroutine, get_object_name
 from interactions.client.errors import BadArgument
+from interactions.client import get_logger
 from interactions.ext.prefixed_commands import PrefixedCommand, PrefixedContext
 from interactions.models.internal.converters import _LiteralConverter, CONSUME_REST_MARKER
 from interactions.models.internal.checks import guild_only
@@ -355,7 +356,7 @@ def slash_to_prefixed(cmd: HybridSlashCommand) -> _HybridToPrefixedCommand:  # n
 
         if option.autocomplete and not cmd._silence_autocomplete_errors:
             # there isn't much we can do here
-            raise ValueError("Autocomplete is unsupported in hybrid commands.")
+            get_logger().warning("Autocomplete is unsupported in hybrid commands.")
 
         name = option.argument_name or str(option.name)
         annotation = inspect.Parameter.empty


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
I wasted far too much time trying to figure out why my hybrid commands didn't have any options defined, and ignored the "Autocomplete doesn't work on text commands" message because I wasn't even getting as far as having options to autocomplete.

It was only when I dug far too much into the code that I realized that the "warning" there was effectively removing all parameters from my command (in both Slash and Prefixed modes), that I figured out that I needed to pass `_silence_autocomplete_errors=True`, something that A) is a private parameter, and B) implies that it hides the message but otherwise doesn't change behaviour. 

This PR makes the combination of `autocomplete=True, _silence_autocomplete_errors=False` behave the way I expected it to.

## Changes
* Changed `throw "Autocomplete is unsupported in hybrid commands."` into a warning.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [x] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
