### PR TITLE
fix: hook onto add_command to propagate errors correctly

### DIFF
--- a/interactions/client/client.py
+++ b/interactions/client/client.py
@@ -435,6 +435,8 @@ class Client(
         self.async_startup_tasks: list[tuple[Callable[..., Coroutine], Iterable[Any], dict[str, Any]]] = []
         """A list of coroutines to run during startup"""
 
+        self._add_command_hook: list[Callable[[Callable], Any]] = []
+
         # callbacks
         if global_pre_run_callback:
             if asyncio.iscoroutinefunction(global_pre_run_callback):
@@ -1415,6 +1417,9 @@ class Client(
             self.logger.debug(f"Added callback: {f'{ext.name}.' if ext else ''}{func.callback.func.__name__}")
         else:
             self.logger.debug(f"Added callback: {func.callback.__name__}")
+
+        for hook in self._add_command_hook:
+            hook(func)
 
         self.dispatch(CallbackAdded(callback=func, extension=func.extension if hasattr(func, "extension") else None))
 

--- a/interactions/ext/hybrid_commands/manager.py
+++ b/interactions/ext/hybrid_commands/manager.py
@@ -71,6 +71,7 @@ class HybridManager:
 
         self.client.hybrid = self
 
+    @listen("on_callback_added")
     async def add_hybrid_command(self, event: CallbackAdded) -> None:
         # just here for backwards compatability since it was accidentially public, don't rely on it
         self._add_hybrid_command(event.callback)

--- a/interactions/ext/hybrid_commands/manager.py
+++ b/interactions/ext/hybrid_commands/manager.py
@@ -65,21 +65,21 @@ class HybridManager:
         self.client = cast(prefixed.PrefixedInjectedClient, client)
         self.ext_command_list: dict[str, list[str]] = {}
 
-        self.client.add_listener(self.add_hybrid_command.copy_with_binding(self))
         self.client.add_listener(self.handle_ext_unload.copy_with_binding(self))
+
+        self.client._add_command_hook.append(self._add_hybrid_command)
 
         self.client.hybrid = self
 
-    @listen("on_callback_added")
-    async def add_hybrid_command(self, event: CallbackAdded):
-        if (
-            not isinstance(event.callback, HybridSlashCommand)
-            or not event.callback.callback
-            or event.callback._dummy_base
-        ):
+    async def add_hybrid_command(self, event: CallbackAdded) -> None:
+        # just here for backwards compatability since it was accidentially public, don't rely on it
+        self._add_hybrid_command(event.callback)
+
+    def _add_hybrid_command(self, callback: Callable):
+        if not isinstance(callback, HybridSlashCommand) or not callback.callback or callback._dummy_base:
             return
 
-        cmd = event.callback
+        cmd = callback
         prefixed_transform = slash_to_prefixed(cmd)
 
         if self.use_slash_command_msg:


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
Errors generated when adding prefixed and hybrid commands were not being propagated as they should, as due to being a separated extension, they would error out like a listener instead of like `add_command`. This caused some fun situations, like the one noted in #1668.

This PR fixes that by adding a way of adding "hooks" onto `add_command` directly, and then making prefixed and hybrid commands use that hook for its register command logic.

## Changes
- Add `Client._add_command_hook`, which is a list of functions to run during `add_command`.
- Make prefixed commands and hybrid commands use the hook.
  - This required modifying the register command logic a bit to make the function not async. This would be *technically* breaking for hybrid commands due to me not using an underscore, so the old function was kept as a wrapper for the new one.

## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
```python
@hybrid_slash_command()
@slash_option(
    "test", "The test option", OptionType.STRING, required=True, autocomplete=True
)
async def test(ctx: HybridContext, test: str):
    await ctx.send(f"Test: {test}")
```

```python
@prefixed_command()
async def test(ctx: PrefixedContext):
    await ctx.send("Hello!")

@prefixed_command(name="test")
async def test2(ctx: PrefixedContext):
    await ctx.send("Hello!")
```


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
