### PR TITLE
fix: add extension name before loading in callbacks

### DIFF
--- a/interactions/models/internal/extension.py
+++ b/interactions/models/internal/extension.py
@@ -83,6 +83,7 @@ class Extension:
         if instance.name in bot.ext:
             raise ValueError(f"An extension with the name {instance.name} is already loaded!")
 
+        instance.extension_name = inspect.getmodule(instance).__name__
         instance.extension_checks = []
         instance.extension_prerun = []
         instance.extension_postrun = []
@@ -123,7 +124,6 @@ class Extension:
                 bot.add_global_autocomplete(val)
         bot.dispatch(events.ExtensionCommandParse(extension=instance, callables=callables))
 
-        instance.extension_name = inspect.getmodule(instance).__name__
         instance.bot.ext[instance.name] = instance
 
         if hasattr(instance, "async_start"):


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
This one's on me - I probably should have done more testing.

Anyways, while making #1678, I did not account for, when adding prefixed commands in extensions, that the extension's `extension_name` does not exist yet. This variable is used when registering prefixed commands, and so an error appears:

```python
Traceback (most recent call last):
  File "/home/astrea/Documents/dis-snek-testing-ground/interactions-py-library/interactions/client/client.py", line 1995, in __load_module
    setup(self, **load_kwargs)
  File "/home/astrea/Documents/dis-snek-testing-ground/bot/ipy5ext.py", line 10, in setup
    AExt(bot)
  File "/home/astrea/Documents/dis-snek-testing-ground/interactions-py-library/interactions/models/internal/extension.py", line 109, in __new__
    bot.add_command(val)
  File "/home/astrea/Documents/dis-snek-testing-ground/interactions-py-library/interactions/client/client.py", line 1422, in add_command
    hook(func)
  File "/home/astrea/Documents/dis-snek-testing-ground/interactions-py-library/interactions/ext/prefixed_commands/manager.py", line 237, in _register_command
    self.add_command(callback)
  File "/home/astrea/Documents/dis-snek-testing-ground/interactions-py-library/interactions/ext/prefixed_commands/manager.py", line 138, in add_command
    self._ext_command_list[command.extension.extension_name].add(command.name)
AttributeError: 'AExt' object has no attribute 'extension_name'. Did you mean: 'extension_error'?
```

I... don't know how prefixed command registering before #1678 worked, since the old version still should register prefixed commands before `extension_name` exists, but async funkiness, I suppose. Regardless, this PR fixes `extension_name` not existing by adding it in earlier.

## Changes
- Move `extension_name` assignment to before adding callbacks, instead of after.

## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
```python
import interactions as ipy
from interactions.ext.prefixed_commands import prefixed_command, PrefixedContext


class AExt(ipy.Extension):
    @prefixed_command()
    async def test2(self, ctx: PrefixedContext):
        await ctx.send("Woo!")


def setup(bot):
    AExt(bot)
```

## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [x] I've ensured my code works on Python `3.10.x`
- [ ] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
