### PR TITLE
add deactivate_buttons() to Paginators

### DIFF
--- a/interactions/ext/paginators.py
+++ b/interactions/ext/paginators.py
@@ -259,6 +259,15 @@ class Paginator:
             pages.append(Page(page, prefix=prefix, suffix=suffix))
         return cls(client, pages=pages, timeout_interval=timeout)
 
+    def deactivate_buttons(self) -> None:
+        """
+        deactivate all control buttons for `First`, `Back`, `Next`, `Last`.
+        """
+        self.show_first_button = False
+        self.show_back_button = False
+        self.show_next_button = False
+        self.show_last_button = False
+
     def create_components(self, disable: bool = False) -> List[ActionRow]:
         """
         Create the components for the paginator message.


### PR DESCRIPTION


## Pull Request Type
<!-- Check the appropriate option -->

- [X] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
add function to deactivate Control Buttons in a Paginator. To reduce 5 Lines of Code to 2 to switch from Buttons to select.


## Changes

- add function "deactivate_buttons()" to Paginator Class


## Related Issues
#1681


## Test Scenarios
1. create Paginator
2. activate Select Menu
3. deactivate Buttons via function
4. send Paginator

## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [X] I've ensured my code works on Python `3.10.x`
- [ ] I've ensured my code works on Python `3.11.x`
not testet with 3.11, but changes should not break this.


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [ ] I've run the `pre-commit` code linter over all edited files
- [ ] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
