### PR TITLE
fix: let unload_extension() pop regex pattern listeners

### DIFF
--- a/interactions/models/internal/extension.py
+++ b/interactions/models/internal/extension.py
@@ -2,6 +2,7 @@ import asyncio
 import inspect
 import typing
 from typing import Awaitable, Dict, List, TYPE_CHECKING, Callable, Coroutine, Optional
+import re
 
 import interactions.models.internal as models
 import interactions.api.events as events
@@ -154,12 +155,20 @@ class Extension:
         for func in self._commands:
             if isinstance(func, models.ModalCommand):
                 for listener in func.listeners:
-                    # noinspection PyProtectedMember
-                    self.bot._modal_callbacks.pop(listener)
+                    if isinstance(listener, re.Pattern):
+                        # noinspection PyProtectedMember
+                        self.bot._regex_modal_callbacks.pop(listener)
+                    else:
+                        # noinspection PyProtectedMember
+                        self.bot._modal_callbacks.pop(listener)
             elif isinstance(func, models.ComponentCommand):
                 for listener in func.listeners:
-                    # noinspection PyProtectedMember
-                    self.bot._component_callbacks.pop(listener)
+                    if isinstance(listener, re.Pattern):
+                        # noinspection PyProtectedMember
+                        self.bot._regex_component_callbacks.pop(listener)
+                    else:
+                        # noinspection PyProtectedMember
+                        self.bot._component_callbacks.pop(listener)
             elif isinstance(func, models.InteractionCommand):
                 for scope in func.scopes:
                     if self.bot.interactions_by_scope.get(scope):


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
<!-- Provide a clear and concise description of the purpose of this PR and why it should be merged -->
<!-- If your code adds or changes features, a usage example would be helpful -->
This PR fixes an error while calling `Client.unload_extension()` due to the extension containing a callback (component or modal) that uses a regex pattern (`re.Pattern`) listener.

## Changes
<!-- List the changes you have made in a bullet-point format -->
* Edited `Extension.drop()` to allow for dropping `re.Pattern` listeners, which are stored in a different dict inside `Client`

## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->
interactions.py Discord server help thread: https://discord.com/channels/789032594456576001/1240745583636119562

## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->
The command `/test-unload` should run without errors with the extension's command `/test-a` unloaded. You may need to reload your Discord client (hotkey `^R`) to refresh the list of commands.
### `test.py` (main)
```python
from interactions import Client, Intents, slash_command, SlashContext
bot = Client(intents=Intents.DEFAULT)

@slash_command(name="test-unload", description="Unload test extension")
async def unload_cmd(ctx: SlashContext):
  bot.unload_extension("test_ext")
  await ctx.send("Extension is unloaded")

bot.load_extension("test_ext")
bot.start("token")
```

### `test_ext.py` (extension)
The command in this extension has two different component callbacks: a `str` one and a `re.Pattern` one.
```python
from interactions import (
  Extension,
  slash_command,
  SlashContext,
  Button,
  ButtonStyle,
  component_callback,
  ComponentContext,
)
import re

regex_callback = re.compile(r"button-[0-9]+")

class TestExtension(Extension):
  @slash_command(name="test-a", description="Test command")
  async def test_cmd_a(self, ctx: SlashContext):
    btn_1 = Button(label="1", style=ButtonStyle.BLURPLE, custom_id="button-0001")
    btn_2 = Button(label="2", style=ButtonStyle.BLURPLE, custom_id="button-0002")
    btn_a = Button(label="A", style=ButtonStyle.BLURPLE, custom_id="button-a")
    await ctx.send(components=[btn_1, btn_2, btn_a])

  @component_callback(regex_callback)
  async def re_btn(self, ctx: ComponentContext):
    await ctx.send(f"Clicked button with id `{ctx.custom_id}`")

  @component_callback("button-a")
  async def str_btn(self, ctx: ComponentContext):
    await ctx.send(f"Clicked button with id `button-a`")
```

## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [x] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
