### PR TITLE
feat: add REQUIRE_TAG and make channel flags editable

### DIFF
--- a/interactions/models/discord/channel.py
+++ b/interactions/models/discord/channel.py
@@ -833,6 +833,7 @@ class BaseChannel(DiscordObject):
         rtc_region: Absent[Union["models.VoiceRegion", str]] = MISSING,
         video_quality_mode: Absent[VideoQualityMode] = MISSING,
         default_auto_archive_duration: Absent[AutoArchiveDuration] = MISSING,
+        flags: Absent[Union[int, ChannelFlags]] = MISSING,
         archived: Absent[bool] = MISSING,
         auto_archive_duration: Absent[AutoArchiveDuration] = MISSING,
         locked: Absent[bool] = MISSING,
@@ -858,6 +859,7 @@ class BaseChannel(DiscordObject):
             rtc_region: Channel voice region id, automatic when set to None.
             video_quality_mode: The camera video quality mode of the voice channel
             default_auto_archive_duration: The default duration that the clients use (not the API) for newly created threads in the channel, in minutes, to automatically archive the thread after recent activity
+            flags: Channel flags combined as a bitfield. Only REQUIRE_TAG is supported for now.
             archived: Whether the thread is archived
             auto_archive_duration: Duration in minutes to automatically archive the thread after recent activity, can be set to: 60, 1440, 4320, 10080
             locked: Whether the thread is locked; when a thread is locked, only users with MANAGE_THREADS can unarchive it
@@ -883,6 +885,7 @@ class BaseChannel(DiscordObject):
             "rtc_region": rtc_region.id if isinstance(rtc_region, models.VoiceRegion) else rtc_region,
             "video_quality_mode": video_quality_mode,
             "default_auto_archive_duration": default_auto_archive_duration,
+            "flags": flags,
             "archived": archived,
             "auto_archive_duration": auto_archive_duration,
             "locked": locked,

--- a/interactions/models/discord/enums.py
+++ b/interactions/models/discord/enums.py
@@ -825,6 +825,8 @@ class SystemChannelFlags(DiscordIntFlag):
 class ChannelFlags(DiscordIntFlag):
     PINNED = 1 << 1
     """ Thread is pinned to the top of its parent forum channel """
+    REQUIRE_TAG = 1 << 4
+    """Whether a tag is required to be specified when creating a thread in a Guild Forum or Media channel."""
     CLYDE_THREAD = 1 << 8
     """This thread was created by Clyde"""
     HIDE_MEDIA_DOWNLOAD_OPTIONS = 1 << 15


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [x] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
This PR adds the `REQUIRE_TAG` flag to `ChannelFlags`, and makes channel flags editable.

(Technically this is two features in one, but they fit together.)

## Changes
See description.


## Related Issues
Fixes #1673


## Test Scenarios
```python
import interactions as ipy

@ipy.slash_command("test", description="test!")
async def test(ctx: ipy.SlashContext):
    chan: ipy.GuildForum = await bot.fetch_channel(FORUM_CHANNEL)
    await chan.edit(flags=ipy.ChannelFlags.REQUIRE_TAG)
    await ctx.send("Done!")
```

## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [x] I've ensured my code works on Python `3.10.x`
- [ ] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [x] I've updated / added  documentation, where applicable
