### PR TITLE
feat/fix: improve typehinting of wait_fors

### DIFF
--- a/interactions/client/client.py
+++ b/interactions/client/client.py
@@ -1072,8 +1072,7 @@ class Client(
         event: type[EventT],
         checks: Absent[Callable[[EventT], bool] | Callable[[EventT], Awaitable[bool]]] = MISSING,
         timeout: Optional[float] = None,
-    ) -> "Awaitable[EventT]":
-        ...
+    ) -> "Awaitable[EventT]": ...
 
     @overload
     def wait_for(
@@ -1081,8 +1080,7 @@ class Client(
         event: str,
         checks: Callable[[EventT], bool] | Callable[[EventT], Awaitable[bool]],
         timeout: Optional[float] = None,
-    ) -> "Awaitable[EventT]":
-        ...
+    ) -> "Awaitable[EventT]": ...
 
     @overload
     def wait_for(
@@ -1090,8 +1088,7 @@ class Client(
         event: str,
         checks: Missing = MISSING,
         timeout: Optional[float] = None,
-    ) -> Awaitable[Any]:
-        ...
+    ) -> Awaitable[Any]: ...
 
     def wait_for(
         self,
@@ -1157,15 +1154,14 @@ class Client(
         self,
         messages: Union[Message, int, list],
         components: Union[
-                List[List[Union["BaseComponent", dict]]],
-                List[Union["BaseComponent", dict]],
-                "BaseComponent",
-                dict,
-            ],
+            List[List[Union["BaseComponent", dict]]],
+            List[Union["BaseComponent", dict]],
+            "BaseComponent",
+            dict,
+        ],
         check: Optional[Callable[[events.Component], bool] | Callable[[events.Component], Awaitable[bool]]] = None,
         timeout: Optional[float] = None,
-    ) -> "events.Component":
-        ...
+    ) -> "events.Component": ...
 
     @overload
     async def wait_for_component(
@@ -1179,8 +1175,7 @@ class Client(
         ],
         check: Optional[Callable[[events.Component], bool] | Callable[[events.Component], Awaitable[bool]]] = None,
         timeout: Optional[float] = None,
-    ) -> "events.Component":
-        ...
+    ) -> "events.Component": ...
 
     @overload
     async def wait_for_component(
@@ -1194,8 +1189,7 @@ class Client(
         ],
         check: Optional[Callable[[events.Component], bool] | Callable[[events.Component], Awaitable[bool]]] = None,
         timeout: Optional[float] = None,
-    ) -> "events.Component":
-        ...
+    ) -> "events.Component": ...
 
     @overload
     async def wait_for_component(
@@ -1204,8 +1198,7 @@ class Client(
         components: None = None,
         check: Optional[Callable[[events.Component], bool] | Callable[[events.Component], Awaitable[bool]]] = None,
         timeout: Optional[float] = None,
-    ) -> "events.Component":
-        ...
+    ) -> "events.Component": ...
 
     async def wait_for_component(
         self,


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [x] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
This PR improves typehintings for the `wait_for` functions, largely by using plenty of overloads. It also fixes some incorrect typehints along the way.

## Changes
- For `wait_for`, make `event: Union[str, "BaseEvent"]` > `event: Union[str, "type[BaseEvent]"]`.
- Add overloads for `wait_for` to let the typehinter return the type of event passed in if an event type is passed at any point.
- Add overloads for `wait_for_component` to enforce either passing `messages` or `components`.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [x] I've ensured my code works on Python `3.10.x`
- [ ] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [ ] I've run the `pre-commit` code linter over all edited files (I'm facing issues with this check running in certain contexts, I'll let the bot take care of it)
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
