### PR TITLE
ci: specify language_version to python 3.10

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,7 @@ repos:
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
+        language_version: python3.10
   - repo: https://github.com/psf/black
     rev: 24.2.0
     hooks:
@@ -41,6 +42,7 @@ repos:
         name: Black Formatting
         language: python
         types: [ file, python ]
+        language_version: python3.10
 #  - repo: https://github.com/pycqa/isort
 #    rev: 5.11.4
 #    hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
-        language_version: python3.10
+        language: python
   - repo: https://github.com/psf/black
     rev: 24.2.0
     hooks:
@@ -42,7 +42,6 @@ repos:
         name: Black Formatting
         language: python
         types: [ file, python ]
-        language_version: python3.10
 #  - repo: https://github.com/pycqa/isort
 #    rev: 5.11.4
 #    hooks:
@@ -50,6 +49,9 @@ repos:
 #        name: isort Formatting
 #        language: python
 #        types: [file, python]
+
+default_language_version:
+  python: python3.10
 ci:
   autoupdate_branch: "unstable"
   autofix_prs: true


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [x] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
This specifies a language version pre-commit so it uses Python 3.10. This is very useful if, say, your default Python installation is 3.8 (as it is on many Linux systems) and you used the 3.8 installation on the repo, as pre-commit would use that and make `black` fail on files with `match`.


## Changes
- Add `default_language_version` to pre-commit and set it to `python: python3.10`.
- Add `language: python` to Ruff.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [x] I've ensured my code works on Python `3.10.x`
- [ ] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [ ] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
