### PR TITLE
fix: allow removing files and embeds by editing

### DIFF
--- a/interactions/api/http/http_client.py
+++ b/interactions/api/http/http_client.py
@@ -319,7 +319,11 @@ class HTTPClient(
         else:
             payload = [dict_filter(x) if isinstance(x, dict) else x for x in payload]
 
-        if not files:
+        if files is None:
+            return payload
+
+        if files == []:
+            payload["attachments"] = []
             return payload
 
         if not isinstance(files, list):

--- a/interactions/models/discord/message.py
+++ b/interactions/models/discord/message.py
@@ -701,7 +701,7 @@ class Message(BaseMessage):
             )
         message_payload = process_message_payload(
             content=content,
-            embeds=embeds or embed,
+            embeds=embed if embeds is None else embeds,
             components=components,
             allowed_mentions=allowed_mentions,
             attachments=attachments,

--- a/interactions/models/internal/context.py
+++ b/interactions/models/internal/context.py
@@ -633,7 +633,7 @@ class InteractionContext(BaseInteractionContext, SendMixin):
     ) -> "interactions.Message":
         message_payload = process_message_payload(
             content=content,
-            embeds=embeds or embed,
+            embeds=embed if embeds is None else embeds,
             components=components,
             allowed_mentions=allowed_mentions,
             attachments=attachments,
@@ -875,7 +875,7 @@ class ComponentContext(InteractionContext, ModalMixin):
 
         message_payload = process_message_payload(
             content=content,
-            embeds=embeds or embed,
+            embeds=embed if embeds is None else embeds,
             components=components,
             allowed_mentions=allowed_mentions,
             tts=tts,
@@ -889,13 +889,13 @@ class ComponentContext(InteractionContext, ModalMixin):
                 )
 
             message_data = await self.client.http.edit_interaction_message(
-                message_payload, self.client.app.id, self.token, files=files or file
+                message_payload, self.client.app.id, self.token, files=file if files is None else files
             )
             self.deferred = False
             self.editing_origin = False
         else:
             payload = {"type": CallbackType.UPDATE_MESSAGE, "data": message_payload}
-            await self.client.http.post_initial_response(payload, str(self.id), self.token, files=files or file)
+            await self.client.http.post_initial_response(payload, str(self.id), self.token, files=file if files is None else files)
             message_data = await self.client.http.get_interaction_message(self.client.app.id, self.token)
 
         if message_data:

--- a/interactions/models/internal/context.py
+++ b/interactions/models/internal/context.py
@@ -895,7 +895,9 @@ class ComponentContext(InteractionContext, ModalMixin):
             self.editing_origin = False
         else:
             payload = {"type": CallbackType.UPDATE_MESSAGE, "data": message_payload}
-            await self.client.http.post_initial_response(payload, str(self.id), self.token, files=file if files is None else files)
+            await self.client.http.post_initial_response(
+                payload, str(self.id), self.token, files=file if files is None else files
+            )
             message_data = await self.client.http.get_interaction_message(self.client.app.id, self.token)
 
         if message_data:


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
<!-- Provide a clear and concise description of the purpose of this PR and why it should be merged -->
<!-- If your code adds or changes features, a usage example would be helpful -->
Allow users to remove files or embeds from messages by passing an empty list into `files`/`embeds` fields in `edit` method of `Message`/`InteractionContext` or `edit_origin` method of `ComponentContext`.

## Changes
<!-- List the changes you have made in a bullet-point format -->

## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->
Not on GitHub but the related Discord thread:
https://discord.com/channels/789032594456576001/1245924804314267760

## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [x] I've ensured my code works on Python `3.10.x`
- [ ] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
