### PR TITLE
docs: use jump_url instead of content for getting started guide

### DIFF
--- a/docs/src/Guides/01 Getting Started.md
+++ b/docs/src/Guides/01 Getting Started.md
@@ -76,7 +76,7 @@ async def on_ready():
 @listen()
 async def on_message_create(event):
     # This event is called when a message is sent in a channel the bot can see
-    print(f"message received: {event.message.content}")
+    print(f"message received: {event.message.jump_url}")
 
 
 bot.start("Put your token here")


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [ ] Bugfix
- [x] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
This PR changes up the Getting Started guide so that the example uses `jump_url` instead of `content` when showing off the message create event. This ensures the example always works as expected with the intents (the default ones) specified in said example.


## Changes
its like a one line diff lol


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [x] I've ensured my code works on Python `3.10.x`
- [ ] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [ ] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [x] I've updated / added  documentation, where applicable
