### PR TITLE
feat: add premium buttons

### DIFF
--- a/interactions/models/discord/enums.py
+++ b/interactions/models/discord/enums.py
@@ -721,6 +721,8 @@ class ButtonStyle(CursedIntEnum):
     """red"""
     LINK = 5
     """url button"""
+    PREMIUM = 6
+    """premium button"""
 
     # Aliases
     BLUE = 1

--- a/interactions/models/internal/context.py
+++ b/interactions/models/internal/context.py
@@ -457,6 +457,10 @@ class InteractionContext(BaseInteractionContext, SendMixin):
         """
         Send a premium required response.
 
+        !!! warn
+            This response has been deprecated by Discord and will be removed in the future.
+            Use a button with the PREMIUM type instead.
+
         When used, the user will be prompted to subscribe to premium to use this feature.
         Only available for applications with monetization enabled.
         """


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [x] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
Discord added a [premium upsell button style](https://discord.com/developers/docs/change-log#premium-apps-new-premium-button-style-deep-linking-url-schemes) for components. This PR adds them and notes the deprecation of the `PREMIUM_REQUIRED` response (noted in the changelog linked).


## Changes
- Add `PREMIUM = 6` to `ButtonStyles`.
- Added `sku_id` to `Button`.
  - Checks were also adjusted or added to note the presence of it.


## Related Issues
Resolves #1702.


## Test Scenarios
```python
import interactions as ipy

@ipy.slash_command("test", description="test!")
async def test(ctx: ipy.SlashContext):
    button = ipy.Button(style=ipy.ButtonStyle.PREMIUM, sku_id="SKU_ID")
    await ctx.send("test!", components=[button])
```

## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x` - kind of? I can't test the button sending, but I do get the correct errors, so...
- [ ] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [ ] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [x] I've updated / added  documentation, where applicable
