### PR TITLE
fix: adjust Timestamp.astimezone checks

### DIFF
--- a/interactions/models/discord/timestamp.py
+++ b/interactions/models/discord/timestamp.py
@@ -99,11 +99,14 @@ class Timestamp(datetime):
         if self.year > 1970 or (self.year == 1970 and (self.month > 1 or self.day > 1)):
             return super().astimezone(tz)
 
-        if self.year < 1969 or self.month < 12 or self.day < 31:
+        if self.year < 1969 or (self.year == 1969 and (self.month < 12 or self.day < 31)):
             # windows kind of breaks down for dates before unix time
             # technically this is solvable, but it's not worth the effort
             # also, again, this is a loose bound, but it's good enough for our purposes
             raise ValueError("astimezone with no arguments is not supported for dates before Unix Time on Windows.")
+
+        if tz:
+            return self.replace(tzinfo=tz)
 
         # to work around the issue to some extent, we'll use a timestamp with a date
         # that doesn't trigger the bug, and use the timezone from it to modify this


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
This PR adjusts the `Timestamp.astimezone` checks to both not error out on otherwise valid cases, and to directly use the timezone objects instead of replacing it with the local timezone if one is provided.


## Changes
- See above. The "valid" cases were a timestamp that had a month that was less than 12, or a day that was less than 31, but was a year greater than 1969. How did we not encounter this earlier?


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
```python
from datetime import Timestamp
Timestamp.fromtimestamp(9892325)
```


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [x] I've ensured my code works on Python `3.10.x`
- [ ] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
