### PR TITLE
fix: don't ignore allow_multiselect when serializing

### DIFF
--- a/interactions/models/discord/poll.py
+++ b/interactions/models/discord/poll.py
@@ -93,7 +93,7 @@ class Poll(DictSerializationMixin):
     """Each of the answers available in the poll, up to 10."""
     expiry: Timestamp = attrs.field(repr=False, default=MISSING, converter=optional(timestamp_converter))
     """Number of hours the poll is open for, up to 7 days."""
-    allow_multiselect: bool = attrs.field(repr=False, default=False, metadata=no_export_meta)
+    allow_multiselect: bool = attrs.field(repr=False, default=False)
     """Whether a user can select multiple answers."""
     layout_type: PollLayoutType = attrs.field(repr=False, default=PollLayoutType.DEFAULT, converter=PollLayoutType)
     """The layout type of the poll."""

--- a/interactions/models/discord/poll.py
+++ b/interactions/models/discord/poll.py
@@ -9,7 +9,6 @@ from interactions.client.utils.attr_converters import (
     timestamp_converter,
 )
 from interactions.client.mixins.serialization import DictSerializationMixin
-from interactions.client.utils.serializer import no_export_meta
 from interactions.models.discord.emoji import PartialEmoji, process_emoji
 from interactions.models.discord.enums import PollLayoutType
 from interactions.models.discord.timestamp import Timestamp


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
Quick bugfix to make sure `allow_multiselect` is exported when serializing. Can't test right now, but the change is simple.

## Changes
- Remove `no_export_meta` from metadata of `allow_multiselect`.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
```python
import interactions as ipy

@ipy.slash_command()
async def test(ctx: ipy.SlashContext):
    poll = Poll.create("Test?", duration=1, answers=["1!", "2."], allow_multiselect=True)
    await ctx.send(poll=poll)
```

## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [ ] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [ ] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
