### PR TITLE
fix: make ClientT covariant

### DIFF
--- a/interactions/client/const.py
+++ b/interactions/client/const.py
@@ -244,7 +244,7 @@ AsyncCallable = Callable[..., Coroutine]
 if TYPE_CHECKING:
     from interactions import Client
 
-    ClientT = typing_extensions.TypeVar("ClientT", bound=Client, default=Client)
+    ClientT = typing_extensions.TypeVar("ClientT", bound=Client, default=Client, covariant=True)
 else:
     ClientT = TypeVar("ClientT")
 


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
This PR makes `ClientT` covariant. This fixes a couple of typehinting issues I noticed, and... well, it makes sense for it to be covariant anyways, considering what it's meant for.


## Changes
See description.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
```python
import interactions as ipy
from interactions.ext import prefixed_commands as prefixed

class MyBot(ipy.Client):
    pass

class MyContext(prefixed.PrefixedContext[MyBot]):
    pass

@prefixed.prefixed_command()
async def test(ctx: MyContext):
    await ctx.reply("Hi!")

bot = MyBot(...)
prefixed.setup(bot, prefixed_context=MyContext)  # here
```


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [x] I've ensured my code works on Python `3.10.x`
- [ ] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
