### PR TITLE
feat: Add audioop-lts for python 3.13+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 aiohttp
 attrs>=22.1
+audioop-lts; python_version>='3.13'
 croniter
 discord-typings>=0.9.0
 emoji


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
Our voice support requires audioop, which is depreciated and being removed with python 3.13.  

This PR adds `audioop-lts` as a conditional dependency, readding the now missing module.

## Changes
* `audioop-lts; python_version>='3.13'`

## Related Issues
Fixes #1685


## Test Scenarios
I've barely tested it, but it successfully loads, and that's good enough for me

## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [ ] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [ ] I've run the `pre-commit` code linter over all edited files
- [ ] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
