### PR TITLE
fix: fallback to empty list if entitlements is not provided

### DIFF
--- a/interactions/models/internal/context.py
+++ b/interactions/models/internal/context.py
@@ -296,7 +296,7 @@ class BaseInteractionContext(BaseContext[ClientT]):
         instance.guild_locale = payload.get("guild_locale", instance.locale)
         instance._context_type = payload.get("type", 0)
         instance.resolved = Resolved.from_dict(client, payload["data"].get("resolved", {}), payload.get("guild_id"))
-        instance.entitlements = Entitlement.from_list(payload["entitlements"], client)
+        instance.entitlements = Entitlement.from_list(payload.get("entitlements", []), client)
         instance.context = ContextType(payload["context"]) if payload.get("context") else None
         instance.authorizing_integration_owners = {
             IntegrationType(int(integration_type)): Snowflake(owner_id)


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
Bizarrely, despite the fact that entitlements [are marked as required on the docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-structure), Discord sometimes doesn't provide them, as seen in [a help thread](https://discord.com/channels/789032594456576001/1257851104809713694). This appears to be an API issue, but this PR still makes entitlements fall back to an empty list if this is the case.


## Changes
See description.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
I'm not 100% sure how this happens ~~- I personally just added a line to pop the entitlements to recreate the situation.~~ Seems like this issue happens consistently now.


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [x] I've ensured my code works on Python `3.10.x`
- [ ] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
