### PR TITLE
fix: command lookup error when scope is cached

### DIFF
--- a/interactions/models/internal/context.py
+++ b/interactions/models/internal/context.py
@@ -346,7 +346,7 @@ class BaseInteractionContext(BaseContext[ClientT]):
 
     @property
     def command(self) -> InteractionCommand:
-        return self.client._interaction_lookup[self._command_name]
+        return self.client._interaction_lookup.get(self._command_name)
 
     @property
     def expires_at(self) -> Timestamp:

--- a/interactions/models/internal/context.py
+++ b/interactions/models/internal/context.py
@@ -345,7 +345,7 @@ class BaseInteractionContext(BaseContext[ClientT]):
         return Permissions(0)
 
     @property
-    def command(self) -> InteractionCommand:
+    def command(self) -> typing.Optional[InteractionCommand]:
         return self.client._interaction_lookup.get(self._command_name)
 
     @property


### PR DESCRIPTION
Fixed lookup to use .get() on the dictionary to prevent large log of error in the circumstance of a cache command showing on a changed scope

## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
Fixed lookup to use .get() on the dictionary to prevent large log of error in the circumstance of a cache command showing on a changed scope.

What happens is when no commands have been loaded to a Discord guild's scope, but they are cached, if a user tries to request one of these cached commands, an error occurs because of the way the lookup was handled (index notation)
<!-- Provide a clear and concise description of the purpose of this PR and why it should be merged -->
<!-- If your code adds or changes features, a usage example would be helpful -->


## Changes
<!-- List the changes you have made in a bullet-point format -->
- Changed index notation to `.get()` on the dictionary.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [x] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
