### PR TITLE
fix: use localizations for InteractionCommand

### DIFF
--- a/interactions/models/internal/application_commands.py
+++ b/interactions/models/internal/application_commands.py
@@ -288,6 +288,8 @@ class InteractionCommand(BaseCommand):
     def to_dict(self) -> dict:
         data = super().to_dict()
 
+        data["name_localizations"] = self.name.to_locale_dict()
+
         if self.default_member_permissions is not None:
             data["default_member_permissions"] = str(int(self.default_member_permissions))
         else:


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
This PR makes it so `InteractionCommand` (and so its subclasses) properly serialize localization, fixing an issue where context menu commands would not be localized (slash commands worked as they implemented a similar line on their own).


## Changes
- Add in `name_localizations` to the dict of `InteractionsCommand.to_dict()`.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
```python
@interactions.message_context_menu(ipy.LocalisedName(english_us="test_1", english_uk="test_2"))
async def a_command(ctx: interactions.ContextMenuContext):
    await ctx.respond("test")
```


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [x] I've ensured my code works on Python `3.10.x`
- [ ] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
