### PR TITLE
fix: VoiceGateway connection is closed with code 4020

### DIFF
--- a/interactions/api/voice/voice_gateway.py
+++ b/interactions/api/voice/voice_gateway.py
@@ -350,7 +350,7 @@ class VoiceGateway(WebsocketClient):
         self.timestamp += encoder.samples_per_frame
 
     async def send_heartbeat(self) -> None:
-        await self.send_json({"op": OP.HEARTBEAT, "d": random.uniform(0.0, 1.0)})
+        await self.send_json({"op": OP.HEARTBEAT, "d": random.getrandbits(64)})
         self.logger.debug("❤ Voice Connection is sending Heartbeat")
 
     async def _identify(self) -> None:


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
The heartbeat sent to the VoiceGateway used `random.uniform(0.0, 1.0)`  to generate a nonce. A recent change in the Discord backend causes it to reject a float value and close the connection with code 4020.  The backend now expects an uint64.


## Changes
<!-- List the changes you have made in a bullet-point format -->
- changed `random.uniform(0.0, 1.0)` to `random.getrandbits(64)` in `send_heartbeat` to generate an uint64 instead of a float.

## Related Issues
Fixes #1726


## Test Scenarios
None.

## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [x] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`
- [x] I've ensured my code works on Python `3.12.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files (_ran manually_)
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
