### PR TITLE
fix: properly parse aliases for base commands

### DIFF
--- a/interactions/client/client.py
+++ b/interactions/client/client.py
@@ -1489,6 +1489,9 @@ class Client(
         elif not isinstance(func, BaseCommand):
             raise TypeError("Invalid command type")
 
+        for hook in self._add_command_hook:
+            hook(func)
+
         if not func.callback:
             # for group = SlashCommand(...) usage
             return
@@ -1498,9 +1501,6 @@ class Client(
             self.logger.debug(f"Added callback: {f'{ext.name}.' if ext else ''}{func.callback.func.__name__}")
         else:
             self.logger.debug(f"Added callback: {func.callback.__name__}")
-
-        for hook in self._add_command_hook:
-            hook(func)
 
         self.dispatch(CallbackAdded(callback=func, extension=func.extension if hasattr(func, "extension") else None))
 

--- a/interactions/ext/hybrid_commands/manager.py
+++ b/interactions/ext/hybrid_commands/manager.py
@@ -112,7 +112,7 @@ class HybridManager:
             if not (base := self.client.prefixed.commands.get(str(cmd.name))):
                 base = base_subcommand_generator(
                     str(cmd.name),
-                    list(_values_wrapper(cmd.name.to_locale_dict())) + cmd.aliases,
+                    list(_values_wrapper(cmd.name.to_locale_dict())),
                     str(cmd.name),
                     group=False,
                 )
@@ -123,7 +123,7 @@ class HybridManager:
                 if not (group := base.subcommands.get(str(cmd.group_name))):
                     group = base_subcommand_generator(
                         str(cmd.group_name),
-                        list(_values_wrapper(cmd.group_name.to_locale_dict())) + cmd.aliases,
+                        list(_values_wrapper(cmd.group_name.to_locale_dict())),
                         str(cmd.group_name),
                         group=True,
                     )

--- a/interactions/ext/hybrid_commands/manager.py
+++ b/interactions/ext/hybrid_commands/manager.py
@@ -81,6 +81,27 @@ class HybridManager:
             return
 
         cmd = callback
+
+        if not cmd.callback or cmd._dummy_base:
+            if cmd.group_name:
+                if not (group := self.client.prefixed.get_command(f"{cmd.name} {cmd.group_name}")):
+                    group = base_subcommand_generator(
+                        str(cmd.group_name),
+                        list(_values_wrapper(cmd.group_name.to_locale_dict())) + cmd.aliases,
+                        str(cmd.group_name),
+                        group=True,
+                    )
+                    self.client.prefixed.commands[str(cmd.name)].add_command(group)
+            elif not (base := self.client.prefixed.commands.get(str(cmd.name))):
+                base = base_subcommand_generator(
+                    str(cmd.name),
+                    list(_values_wrapper(cmd.name.to_locale_dict())) + cmd.aliases,
+                    str(cmd.name),
+                    group=False,
+                )
+                self.client.prefixed.add_command(base)
+            return
+
         prefixed_transform = slash_to_prefixed(cmd)
 
         if self.use_slash_command_msg:


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
Previously, aliases like the below wouldn't be properly registered for the prefixed command variant of hybrid commands:
```python
message = HybridSlashCommand(
    name="message",
    description="Hosts public-facing messaging commands.",
    dm_permission=False,
    aliases=["msg"],
)
```

In this case, trying to use `<prefix>msg` would not make the bot respond. The hybrid manager was just ignoring any commands without a callback or that were only meant as a jumping point for subcommands, meaning it would never read the aliases from them.

For the first part, this PR properly parses these types of commands (and makes it so it doesn't add improper aliases for base commands). However, this introduced a new problem - the command hooks were run after an empty callback check, which means that the above example would *still* not properly get parsed. That was fixed by moving the hook above the callback check.

## Changes
- Parse and use aliases from "empty" base commands.
- Don't add subcommand aliases as aliases to base command.
- Move add command hook logic above the callback check.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
See example above.


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [x] I've ensured my code works on Python `3.10.x`
- [ ] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
