### PR TITLE
feat: Add poll result embed type

### DIFF
--- a/interactions/models/discord/enums.py
+++ b/interactions/models/discord/enums.py
@@ -448,6 +448,7 @@ class EmbedType(Enum):
     LINK = "link"
     AUTOMOD_MESSAGE = "auto_moderation_message"
     AUTOMOD_NOTIFICATION = "auto_moderation_notification"
+    POLL_RESULT = "poll_result"
 
 
 class MessageActivityType(CursedIntEnum):


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
<!-- Provide a clear and concise description of the purpose of this PR and why it should be merged -->
<!-- If your code adds or changes features, a usage example would be helpful -->
The new poll feature results in a new `EmbedType`, `poll_result`. Missing this will lead to error to be:
```
ValueError: 'poll_result' is not a valid EmbedType
```

## Changes
<!-- List the changes you have made in a bullet-point format -->
Add the `poll_result` to the `EmbedType` in the `enum.py`

## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->
N/A

## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->
Create a poll and end the poll.
Try to use the following code in the channel where the poll was created.
```python
@interactions.slash_command(
    "test", description="test command", scopes=[DEV_GUILD] if DEV_GUILD else None
)
async def test_cmd(self, ctx: interactions.SlashContext):
    """Register as an extension command"""
    async for msg in ctx.channel.history(10):
        ...
```
It should not generate any error

## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [ ] I've tested my changes on supported Python versions
- [x] I've added tests for my code, if applicable
- [x] I've updated / added  documentation, where applicable
