### PR TITLE
fix: correctly serialize slash cmd with same names from different scope

### DIFF
--- a/interactions/models/internal/application_commands.py
+++ b/interactions/models/internal/application_commands.py
@@ -1,4 +1,5 @@
 import asyncio
+from collections import defaultdict
 import inspect
 import re
 import typing
@@ -1466,9 +1467,9 @@ def application_commands_to_dict(  # noqa: C901
     `Client.interactions` should be the variable passed to this
 
     """
-    cmd_bases = {}  # {cmd_base: [commands]}
+    cmd_bases: defaultdict[str, list[InteractionCommand]] = defaultdict(list)  # {cmd_base: [commands]}
     """A store of commands organised by their base command"""
-    output = {}
+    output: defaultdict["Snowflake_Type", list[dict]] = defaultdict(list)
     """The output dictionary"""
 
     def squash_subcommand(subcommands: List) -> Dict:
@@ -1514,9 +1515,6 @@ def application_commands_to_dict(  # noqa: C901
     for _scope, cmds in commands.items():
         for cmd in cmds.values():
             cmd_name = str(cmd.name)
-            if cmd_name not in cmd_bases:
-                cmd_bases[cmd_name] = [cmd]
-                continue
             if cmd not in cmd_bases[cmd_name]:
                 cmd_bases[cmd_name].append(cmd)
 
@@ -1556,15 +1554,14 @@ def application_commands_to_dict(  # noqa: C901
                 cmd.nsfw = nsfw
             # end validation of attributes
             cmd_data = squash_subcommand(cmd_list)
+
+            for s in scopes:
+                output[s].append(cmd_data)
         else:
-            scopes = cmd_list[0].scopes
-            cmd_data = cmd_list[0].to_dict()
-        for s in scopes:
-            if s not in output:
-                output[s] = [cmd_data]
-                continue
-            output[s].append(cmd_data)
-    return output
+            for cmd in cmd_list:
+                for s in cmd.scopes:
+                    output[s].append(cmd.to_dict())
+    return dict(output)
 
 
 def _compare_commands(local_cmd: dict, remote_cmd: dict) -> bool:


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
Trying to make two non-sub slash commands with the same name but a different `scopes` results in an error message when trying to sync these slash commands.

This is because our `application_commands_to_dict`, if multiple slash commands under the same name were found, only used the scope of the first command in the list for serialization purposes.

This later causes issues between the dict generated by this command and `bot.interactions_by_scope` since `interactions_by_scope` now has a command in a scope that `application_commands_to_dict` did not account for, causing an error when syncing.

This PR fixes all of that by making sure all slash commands with the same name are properly serialized. Because I was there already, this PR also refactors `application_commands_to_dict` a tiny bit to be nicer.

## Changes
- Include all commands in `cmd_list` (a list representing slash commands with the same name) in the final, serialized result instead of only taking the scope of the first command and ignoring other commands.
- Did a little refactoring to `application_commands_to_dict` since I was here anyways.

## Related Issues
N/A


## Test Scenarios
```python
import interactions as ipy

bot = ipy.Client(sync_interactions=True, delete_unused_application_cmds=True, ...)

@ipy.slash_command(name="test", scopes=[GUILD_1])
async def test(ctx: ipy.SlashContext):
    await ctx.send("Hello, world!")

@ipy.slash_command(name="test", scopes=[GUILD_2])
async def test2(ctx: ipy.SlashContext):
    await ctx.send("Hello, world!")

bot.start()
```


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [x] I've ensured my code works on Python `3.10.x`
- [ ] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
