### PR TITLE
fix: Add POLL_RESULT to MessageType enum

### DIFF
--- a/interactions/models/discord/enums.py
+++ b/interactions/models/discord/enums.py
@@ -435,7 +435,7 @@ class MessageType(CursedIntEnum):
             cls.GUILD_INCIDENT_REPORT_RAID,
             cls.GUILD_INCIDENT_REPORT_FALSE_ALARM,
             cls.PURCHASE_NOTIFICATION,
-            cls.POLL_RESULT
+            cls.POLL_RESULT,
         )
 
 

--- a/interactions/models/discord/enums.py
+++ b/interactions/models/discord/enums.py
@@ -399,6 +399,7 @@ class MessageType(CursedIntEnum):
     GUILD_INCIDENT_REPORT_RAID = 38
     GUILD_INCIDENT_REPORT_FALSE_ALARM = 39
     PURCHASE_NOTIFICATION = 44
+    POLL_RESULT = 46
 
     @classmethod
     def deletable(cls) -> Tuple["MessageType", ...]:
@@ -434,6 +435,7 @@ class MessageType(CursedIntEnum):
             cls.GUILD_INCIDENT_REPORT_RAID,
             cls.GUILD_INCIDENT_REPORT_FALSE_ALARM,
             cls.PURCHASE_NOTIFICATION,
+            cls.POLL_RESULT
         )
 
 


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
This is a fix to the warning invalid/unexpected value 46 - the commit message is wrong input (accident); 

``Class `MessageType` received an invalid and unexpected value `46`, a new enum item will be created to represent this value. Please update interactions.py or report this issue on GitHub - https://github.com/interactions-py/interactions.py/issues``

## Changes
- Added 46 POLL_RESULT to MessageType enum;

## Related Issues
#1731

## Test Scenarios
When MessageCreate is called on a poll_result it will give a warning that the message type doesn't exist;

## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [x] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x ] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [x] I've added tests for my code, if applicable
- [x] I've updated / added  documentation, where applicable
