### PR TITLE
feat:  Add support for Application Emoji

### DIFF
--- a/interactions/api/http/http_requests/emojis.py
+++ b/interactions/api/http/http_requests/emojis.py
@@ -110,3 +110,88 @@ class EmojiRequests(CanRequest):
             Route("DELETE", "/guilds/{guild_id}/emojis/{emoji_id}", guild_id=guild_id, emoji_id=emoji_id),
             reason=reason,
         )
+
+    async def get_application_emojis(self, application_id: "Snowflake_Type") -> list[discord_typings.EmojiData]:
+        """
+        Fetch all emojis for this application
+
+        Args:
+            application_id: The id of the application
+
+        Returns:
+            List of emojis
+
+        """
+        result = await self.request(Route("GET", f"/applications/{application_id}/emojis"))
+        result = cast(dict, result)
+        return cast(list[discord_typings.EmojiData], result["items"])
+
+    async def get_application_emoji(
+        self, application_id: "Snowflake_Type", emoji_id: "Snowflake_Type"
+    ) -> discord_typings.EmojiData:
+        """
+        Fetch an emoji for this application
+
+        Args:
+            application_id: The id of the application
+            emoji_id: The id of the emoji
+
+        Returns:
+            Emoji object
+
+        """
+        result = await self.request(Route("GET", f"/applications/{application_id}/emojis/{emoji_id}"))
+        return cast(discord_typings.EmojiData, result)
+
+    async def create_application_emoji(
+        self, payload: dict, application_id: "Snowflake_Type", reason: str | None = None
+    ) -> discord_typings.EmojiData:
+        """
+        Create an emoji for this application
+
+        Args:
+            application_id: The id of the application
+            name: The name of the emoji
+            imagefile: The image file to use for the emoji
+
+        Returns:
+            Emoji object
+
+        """
+        result = await self.request(
+            Route("POST", f"/applications/{application_id}/emojis"), payload=payload, reason=reason
+        )
+        return cast(discord_typings.EmojiData, result)
+
+    async def edit_application_emoji(
+        self, application_id: "Snowflake_Type", emoji_id: "Snowflake_Type", name: str
+    ) -> discord_typings.EmojiData:
+        """
+        Edit an emoji for this application
+
+        Args:
+            application_id: The id of the application
+            emoji_id: The id of the emoji
+            name: The new name for the emoji
+
+        Returns:
+            Emoji object
+
+        """
+        result = await self.request(
+            Route("PATCH", f"/applications/{application_id}/emojis/{emoji_id}"), payload={"name": name}
+        )
+        return cast(discord_typings.EmojiData, result)
+
+    async def delete_application_emoji(
+        self, application_id: discord_typings.Snowflake, emoji_id: discord_typings.Snowflake
+    ) -> None:
+        """
+        Delete an emoji for this application
+
+        Args:
+            application_id: The id of the application
+            emoji_id: The id of the emoji
+
+        """
+        await self.request(Route("DELETE", f"/applications/{application_id}/emojis/{emoji_id}"))

--- a/interactions/client/smart_cache.py
+++ b/interactions/client/smart_cache.py
@@ -642,7 +642,7 @@ class GlobalCache:
 
         """
         guild_id = to_snowflake(data["id"])
-        guild: Guild = self.guild_cache.get(guild_id)
+        guild: Guild | None = self.guild_cache.get(guild_id)
         if guild is None:
             guild = Guild.from_dict(data, self._client)
             self.guild_cache[guild_id] = guild
@@ -929,7 +929,7 @@ class GlobalCache:
         with suppress(KeyError):
             del data["guild_id"]  # discord sometimes packages a guild_id - this will cause an exception
 
-        emoji = CustomEmoji.from_dict(data, self._client, to_snowflake(guild_id))
+        emoji = CustomEmoji.from_dict(data, self._client, to_optional_snowflake(guild_id))
         if self.emoji_cache is not None:
             self.emoji_cache[emoji.id] = emoji
 

--- a/interactions/client/smart_cache.py
+++ b/interactions/client/smart_cache.py
@@ -914,7 +914,7 @@ class GlobalCache:
         """
         return self.emoji_cache.get(to_optional_snowflake(emoji_id)) if self.emoji_cache is not None else None
 
-    def place_emoji_data(self, guild_id: "Snowflake_Type", data: discord_typings.EmojiData) -> "CustomEmoji":
+    def place_emoji_data(self, guild_id: "Snowflake_Type | None", data: discord_typings.EmojiData) -> "CustomEmoji":
         """
         Take json data representing an emoji, process it, and cache it. This cache is disabled by default, start your bot with `Client(enable_emoji_cache=True)` to enable it.
 

--- a/interactions/models/discord/application.py
+++ b/interactions/models/discord/application.py
@@ -6,7 +6,7 @@ from interactions.client.const import MISSING
 from interactions.client.utils.attr_converters import optional
 from interactions.client.utils.serializer import to_image_data
 from interactions.models.discord.asset import Asset
-from interactions.models.discord.emoji import PartialEmoji
+from interactions.models.discord.emoji import CustomEmoji
 from interactions.models.discord.enums import ApplicationFlags
 from interactions.models.discord.file import UPLOADABLE_TYPE
 from interactions.models.discord.snowflake import Snowflake_Type, to_snowflake
@@ -92,17 +92,17 @@ class Application(DiscordObject):
         """The user object for the owner of this application"""
         return self._client.cache.get_user(self.owner_id)
 
-    async def fetch_all_emoji(self) -> List[PartialEmoji]:
+    async def fetch_all_emoji(self) -> List[CustomEmoji]:
         """Fetch all emojis for this application"""
-        response = await self._client.http.get_application_emojis(self.id)
-        return [self._client.cache.place_emoji_data(None, emoji) for emoji in response]
+        response = await self.client.http.get_application_emojis(self.id)
+        return [self.client.cache.place_emoji_data(None, emoji) for emoji in response]
 
-    async def fetch_emoji(self, emoji_id: Snowflake_Type) -> PartialEmoji:
+    async def fetch_emoji(self, emoji_id: Snowflake_Type) -> CustomEmoji:
         """Fetch an emoji for this application"""
-        response = await self._client.http.get_application_emoji(self.id, emoji_id)
-        return await self._client.cache.place_emoji_data(None, response)
+        response = await self.client.http.get_application_emoji(self.id, emoji_id)
+        return self.client.cache.place_emoji_data(None, response)
 
-    async def create_emoji(self, name: str, imagefile: UPLOADABLE_TYPE) -> PartialEmoji:
+    async def create_emoji(self, name: str, imagefile: UPLOADABLE_TYPE) -> CustomEmoji:
         """Create an emoji for this application"""
         data_payload = {
             "name": name,
@@ -110,16 +110,16 @@ class Application(DiscordObject):
             "roles": MISSING,
         }
 
-        return self._client.cache.place_emoji_data(
-            None, await self._client.http.create_application_emoji(data_payload, self.id)
+        return self.client.cache.place_emoji_data(
+            None, await self.client.http.create_application_emoji(data_payload, self.id)
         )
 
-    async def edit_emoji(self, emoji_id: Snowflake_Type, name: str) -> PartialEmoji:
+    async def edit_emoji(self, emoji_id: Snowflake_Type, name: str) -> CustomEmoji:
         """Edit an emoji for this application"""
-        return await self._client.cache.place_emoji_data(
-            None, self._client.http.edit_application_emoji(self.id, emoji_id, name)
+        return self.client.cache.place_emoji_data(
+            None, await self.client.http.edit_application_emoji(self.id, emoji_id, name)
         )
 
     async def delete_emoji(self, emoji_id: Snowflake_Type) -> None:
         """Delete an emoji for this application"""
-        return await self._client.http.delete_application_emoji(self.id, emoji_id)
+        await self.client.http.delete_application_emoji(self.id, emoji_id)

--- a/interactions/models/discord/application.py
+++ b/interactions/models/discord/application.py
@@ -99,9 +99,8 @@ class Application(DiscordObject):
 
     async def fetch_emoji(self, emoji_id: Snowflake_Type) -> PartialEmoji:
         """Fetch an emoji for this application"""
-        return await self._client.cache.place_emoji_data(
-            None, self._client.http.get_application_emoji(self.id, emoji_id)
-        )
+        response = await self._client.http.get_application_emoji(self.id, emoji_id)
+        return await self._client.cache.place_emoji_data(None, response)
 
     async def create_emoji(self, name: str, imagefile: UPLOADABLE_TYPE) -> PartialEmoji:
         """Create an emoji for this application"""

--- a/interactions/models/discord/application.py
+++ b/interactions/models/discord/application.py
@@ -4,8 +4,11 @@ import attrs
 
 from interactions.client.const import MISSING
 from interactions.client.utils.attr_converters import optional
+from interactions.client.utils.serializer import to_image_data
 from interactions.models.discord.asset import Asset
+from interactions.models.discord.emoji import PartialEmoji
 from interactions.models.discord.enums import ApplicationFlags
+from interactions.models.discord.file import UPLOADABLE_TYPE
 from interactions.models.discord.snowflake import Snowflake_Type, to_snowflake
 from interactions.models.discord.team import Team
 from .base import DiscordObject
@@ -88,3 +91,36 @@ class Application(DiscordObject):
     def owner(self) -> "User":
         """The user object for the owner of this application"""
         return self._client.cache.get_user(self.owner_id)
+
+    async def fetch_all_emoji(self) -> List[PartialEmoji]:
+        """Fetch all emojis for this application"""
+        response = await self._client.http.get_application_emojis(self.id)
+        return [self._client.cache.place_emoji_data(None, emoji) for emoji in response]
+
+    async def fetch_emoji(self, emoji_id: Snowflake_Type) -> PartialEmoji:
+        """Fetch an emoji for this application"""
+        return await self._client.cache.place_emoji_data(
+            None, self._client.http.get_application_emoji(self.id, emoji_id)
+        )
+
+    async def create_emoji(self, name: str, imagefile: UPLOADABLE_TYPE) -> PartialEmoji:
+        """Create an emoji for this application"""
+        data_payload = {
+            "name": name,
+            "image": to_image_data(imagefile),
+            "roles": MISSING,
+        }
+
+        return self._client.cache.place_emoji_data(
+            None, await self._client.http.create_application_emoji(data_payload, self.id)
+        )
+
+    async def edit_emoji(self, emoji_id: Snowflake_Type, name: str) -> PartialEmoji:
+        """Edit an emoji for this application"""
+        return await self._client.cache.place_emoji_data(
+            None, self._client.http.edit_application_emoji(self.id, emoji_id, name)
+        )
+
+    async def delete_emoji(self, emoji_id: Snowflake_Type) -> None:
+        """Delete an emoji for this application"""
+        return await self._client.http.delete_application_emoji(self.id, emoji_id)

--- a/interactions/models/discord/emoji.py
+++ b/interactions/models/discord/emoji.py
@@ -38,6 +38,8 @@ class PartialEmoji(SnowflakeObject, DictSerializationMixin):
     """The custom emoji name, or standard unicode emoji in string"""
     animated: bool = attrs.field(repr=True, default=False)
     """Whether this emoji is animated"""
+    available: bool = attrs.field(repr=False, default=True)
+    """whether this emoji can be used, may be false due to loss of Server Boosts"""
 
     @classmethod
     def from_str(cls, emoji_str: str, *, language: str = "alias") -> Optional["PartialEmoji"]:
@@ -120,7 +122,7 @@ class CustomEmoji(PartialEmoji, ClientObject):
     _role_ids: List["Snowflake_Type"] = attrs.field(
         repr=False, factory=list, converter=optional(list_converter(to_snowflake))
     )
-    _guild_id: "Snowflake_Type" = attrs.field(repr=False, default=None, converter=to_snowflake)
+    _guild_id: "Snowflake_Type" = attrs.field(repr=False, default=None, converter=optional(to_snowflake))
 
     @classmethod
     def _process_dict(cls, data: Dict[str, Any], client: "Client") -> Dict[str, Any]:

--- a/interactions/models/discord/emoji.py
+++ b/interactions/models/discord/emoji.py
@@ -135,7 +135,7 @@ class CustomEmoji(PartialEmoji, ClientObject):
         return data
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any], client: "Client", guild_id: int) -> "CustomEmoji":
+    def from_dict(cls, data: Dict[str, Any], client: "Client", guild_id: "Optional[Snowflake_Type]") -> "CustomEmoji":
         data = cls._process_dict(data, client)
         return cls(client=client, guild_id=guild_id, **cls._filter_kwargs(data, cls._get_init_keys()))
 
@@ -216,6 +216,9 @@ class CustomEmoji(PartialEmoji, ClientObject):
 
         """
         if not self._guild_id:
+            if reason:
+                raise ValueError("Cannot specify reason for application emoji.")
+
             await self.client.http.delete_application_emoji(self._client.app.id, self.id)
         else:
             await self._client.http.delete_guild_emoji(self._guild_id, self.id, reason=reason)

--- a/tests/test_emoji.py
+++ b/tests/test_emoji.py
@@ -34,7 +34,7 @@ def test_emoji_formatting() -> None:
 
 def test_emoji_processing() -> None:
     raw_sample = "<:sparklesnek:910496037708374016>"
-    dict_sample = {"id": 910496037708374016, "name": "sparklesnek", "animated": False}
+    dict_sample = {"id": 910496037708374016, "name": "sparklesnek", "animated": False, "available": True}
     unicode_sample = "👍"
     target = "sparklesnek:910496037708374016"
 
@@ -48,7 +48,7 @@ def test_emoji_processing() -> None:
 
     assert isinstance(raw_emoji, dict) and raw_emoji == dict_sample
     assert isinstance(dict_emoji, dict) and dict_emoji == dict_sample
-    assert isinstance(unicode_emoji, dict) and unicode_emoji == {"name": "👍", "animated": False}
+    assert isinstance(unicode_emoji, dict) and unicode_emoji == {"name": "👍", "animated": False, "available": True}
 
     from_str = PartialEmoji.from_str(raw_sample)
     assert from_str.req_format == target


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [x] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
New discord feature, applications can host emoji, rather than storing them in guilds.


## Changes
- Added methods to Application for interacting with App Emoji
- Modifed PartialEmoji to allow for emoji without a guild_id
- Added missing `available` flag to PartialEmoji (This is technically unrelated, but I was in there)


## Related Issues
Closes #1723


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
