### PR TITLE
Forgot await

### DIFF
--- a/interactions/models/discord/application.py
+++ b/interactions/models/discord/application.py
@@ -99,9 +99,8 @@ class Application(DiscordObject):
 
     async def fetch_emoji(self, emoji_id: Snowflake_Type) -> PartialEmoji:
         """Fetch an emoji for this application"""
-        return await self._client.cache.place_emoji_data(
-            None, self._client.http.get_application_emoji(self.id, emoji_id)
-        )
+        response = await self._client.http.get_application_emoji(self.id, emoji_id)
+        return await self._client.cache.place_emoji_data(None, response)
 
     async def create_emoji(self, name: str, imagefile: UPLOADABLE_TYPE) -> PartialEmoji:
         """Create an emoji for this application"""


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
Simple typo where you missed an await when fetching the application emoji.

## Changes
- Added await to `self._client.http.get_application_emoji(self.id, emoji_id)`


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->
`Emoji = await ctx.bot.app.fetch_emoji(your_id)` is the simplest way to test.  

## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [x] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [ ] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
