### PR TITLE
fix: make typehinting for Extension.bot work

### DIFF
--- a/interactions/models/internal/extension.py
+++ b/interactions/models/internal/extension.py
@@ -47,7 +47,7 @@ class Extension:
 
     """
 
-    bot: "Client"
+    _bot: "Client"
     name: str
     extension_name: str
     description: str
@@ -77,8 +77,6 @@ class Extension:
     def __new__(cls, bot: "Client", *args, **kwargs) -> "Extension":
         instance = super().__new__(cls)
         instance.bot = bot
-        instance.client = bot
-
         instance.name = cls.__name__
 
         if instance.name in bot.ext:
@@ -139,6 +137,22 @@ class Extension:
     @property
     def __name__(self) -> str:
         return self.name
+
+    @property
+    def bot(self) -> "Client":
+        return self._bot
+
+    @bot.setter
+    def bot(self, value: "Client") -> None:
+        self._bot = value
+
+    @property
+    def client(self) -> "Client":
+        return self._bot
+
+    @client.setter
+    def client(self, value: "Client") -> None:
+        self._bot = value
 
     @property
     def commands(self) -> List["BaseCommand"]:


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
This PR makes the typehint for `Extension.bot` correct when using Pyright. For some reason, doing `bot: Client` doesn't typehint the variable correctly in Pyright, and so this PR works around it by making `bot` and `client` properties with setters, which both makes it act like the old variable and also makes Pyright not complain... for some reason.

Perhaps further investigation can be done to see just why the original issue occurs, but at least this PR hides the issue from the typical user.


## Changes
- Make `Extension.bot` and `Extension.client` properties with setters.
  - The ability to set these two variables is intentional, to ensure nothing relying on that breaks.
  - This technically *is* a breaking change still due to some niche stuff with Python (properties are not variables, after all), but I'm not sure if those use cases were supported in the first place.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->
#1747 


## Test Scenarios
```python
import interactions as ipy

class AnExt(ipy.Extension):
    def test(self):
        reveal_type(self.bot)  # "Unknown" before pr, "Client" after
```


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [x] I've ensured my code works on Python `3.10.x`
- [ ] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
