### PR TITLE
feat:  Add client parameter for default Integration Type

### DIFF
--- a/interactions/models/internal/application_commands.py
+++ b/interactions/models/internal/application_commands.py
@@ -250,7 +250,7 @@ class InteractionCommand(BaseCommand):
     )
     nsfw: bool = attrs.field(repr=False, default=False, metadata=docs("This command should only work in NSFW channels"))
     integration_types: list[Union[IntegrationType, int]] = attrs.field(
-        factory=lambda: [IntegrationType.GUILD_INSTALL],
+        factory=list,
         repr=False,
         metadata=docs("Installation context(s) where the command is available, only for globally-scoped commands."),
     )


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [x] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
This allows you to mass-set your entire bot to work as a user-installable app.


## Changes
Rearranged defaults, added check in add_interaction to propagate client default if command didn't have a specific types set.


## Related Issues
https://discord.com/channels/789032594456576001/1219809784966942820/1329640175650734122


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
