### PR TITLE
Fix timeout for ephemeral paginators and hybrid commands

### DIFF
--- a/interactions/ext/paginators.py
+++ b/interactions/ext/paginators.py
@@ -381,9 +381,11 @@ class Paginator:
         self._message = await ctx.send(**self.to_dict(), **kwargs)
         self._author_id = ctx.author.id
 
-        if hasattr(ctx, "_prefixed_ctx"): # HybridContext
+        if hasattr(ctx, "token"):  # SlashContext
+            edit = ctx.edit
+        elif hasattr(ctx, "_prefixed_ctx"):  # HybridContext
             edit = partial(ctx.edit, message=self._message)
-        else:
+        else:  # PrefixedContext
             edit = self._message.edit
 
         if self.timeout_interval > 1:
@@ -407,10 +409,12 @@ class Paginator:
         self._message = await ctx.reply(**self.to_dict(), **kwargs)
         self._author_id = ctx.author.id
 
-        if hasattr(ctx, "_prefixed_ctx"): # HybridContext
+        if hasattr(ctx, "token"):  # SlashContext
+            edit = ctx.edit
+        elif hasattr(ctx, "_prefixed_ctx"):  # HybridContext
             edit = partial(ctx.edit, message=self._message)
-        else:
-            edit= self._message.edit
+        else:  # PrefixedContext
+            edit = self._message.edit
 
         if self.timeout_interval > 1:
             self._timeout_task = Timeout(self, edit)

--- a/interactions/ext/paginators.py
+++ b/interactions/ext/paginators.py
@@ -1,6 +1,7 @@
 import asyncio
 import textwrap
 import uuid
+from functools import partial
 from typing import Callable, Coroutine, List, Optional, Sequence, TYPE_CHECKING, Union
 
 import attrs
@@ -38,6 +39,8 @@ class Timeout:
         repr=False,
     )
     """The paginator that this timeout is associated with."""
+    edit: Callable[..., Coroutine] = attrs.field(repr=False, default=None)
+    """A coroutine that edits the current paginator message."""
     run: bool = attrs.field(repr=False, default=True)
     """Whether or not this timeout is currently running."""
     ping: asyncio.Event = asyncio.Event()
@@ -49,7 +52,7 @@ class Timeout:
                 await asyncio.wait_for(self.ping.wait(), timeout=self.paginator.timeout_interval)
             except asyncio.TimeoutError:
                 if self.paginator.message:
-                    await self.paginator.message.edit(components=self.paginator.create_components(True))
+                    await self.edit(components=self.paginator.create_components(True))
                 return
             else:
                 self.ping.clear()
@@ -378,8 +381,13 @@ class Paginator:
         self._message = await ctx.send(**self.to_dict(), **kwargs)
         self._author_id = ctx.author.id
 
+        if hasattr(ctx, "_prefixed_ctx"): # HybridContext
+            edit = partial(ctx.edit, message=self._message)
+        else:
+            edit = self._message.edit
+
         if self.timeout_interval > 1:
-            self._timeout_task = Timeout(self)
+            self._timeout_task = Timeout(self, edit)
             _ = asyncio.create_task(self._timeout_task())  # noqa: RUF006
 
         return self._message
@@ -399,8 +407,13 @@ class Paginator:
         self._message = await ctx.reply(**self.to_dict(), **kwargs)
         self._author_id = ctx.author.id
 
+        if hasattr(ctx, "_prefixed_ctx"): # HybridContext
+            edit = partial(ctx.edit, message=self._message)
+        else:
+            edit= self._message.edit
+
         if self.timeout_interval > 1:
-            self._timeout_task = Timeout(self)
+            self._timeout_task = Timeout(self, edit)
             _ = asyncio.create_task(self._timeout_task())  # noqa: RUF006
 
         return self._message


### PR DESCRIPTION
## Pull Request Type
- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
While I was writing a command that uses ephemeral paginators, I noticed the timeout resulted in a 404 NotFound. While looking for ways to resolve this, I noticed that HybridContext required a `message` object in it's `edit()` function, so I used `_prefixed_ctx` to determine HybridContext. Probably not the best way to handle this, but I did what I could.


## Changes
- Added `edit` field to `Timeout` class to store the message edit coroutine
- Updated `send()` and `reply()` to use the appropriate edit method based on command type


## Test Scenarios
I tested with ephemeral, non-ephemeral, send, reply, slash, hybrid, and prefixed. Now works in all cases without errors.


## Python Compatibility
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
- [ ] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
