### PR TITLE
fix: add permission checks before fetching messages in reaction events

### DIFF
--- a/interactions/api/events/processors/reaction_events.py
+++ b/interactions/api/events/processors/reaction_events.py
@@ -12,6 +12,29 @@ __all__ = ("ReactionEvents",)
 
 
 class ReactionEvents(EventMixinTemplate):
+    async def _check_message_fetch_permissions(self, channel_id: str, guild_id: str | None) -> bool:
+        """
+        Check if the bot has permissions to fetch a message in the given channel.
+
+        Args:
+            channel_id: The ID of the channel to check
+            guild_id: The ID of the guild, if any
+
+        Returns:
+            bool: True if the bot has permission to fetch messages, False otherwise
+
+        """
+        if not guild_id:  # DMs always have permission
+            return True
+
+        channel = await self.cache.fetch_channel(channel_id)
+        if not channel:
+            return False
+
+        bot_member = channel.guild.me
+        ctx_perms = channel.permissions_for(bot_member)
+        return Permissions.READ_MESSAGE_HISTORY in ctx_perms
+
     async def _handle_message_reaction_change(self, event: "RawGatewayEvent", add: bool) -> None:
         if member := event.data.get("member"):
             author = self.cache.place_member_data(event.data.get("guild_id"), member)
@@ -56,26 +79,23 @@ class ReactionEvents(EventMixinTemplate):
             guild_id = event.data.get("guild_id")
             channel_id = event.data.get("channel_id")
 
-            if guild_id:  # if this is in a guild
-                channel = await self.cache.fetch_channel(channel_id)
-                if channel:
-                    bot_member = channel.guild.me
-                    ctx_perms = channel.permissions_for(bot_member)
-                    # only fetch if we have the required permissions
-                    if Permissions.READ_MESSAGE_HISTORY in ctx_perms:
-                        message = await self.cache.fetch_message(channel_id, event.data.get("message_id"))
-                        for r in message.reactions:
-                            if r.emoji == emoji:
-                                reaction = r
-                                break
+            if await self._check_message_fetch_permissions(channel_id, guild_id):
+                message = await self.cache.fetch_message(channel_id, event.data.get("message_id"))
+                for r in message.reactions:
+                    if r.emoji == emoji:
+                        reaction = r
+                        break
 
             if not message:  # otherwise construct skeleton message with no reactions
-                message = Message.from_dict({
-                    "id": event.data.get("message_id"),
-                    "channel_id": event.data.get("channel_id"),
-                    "guild_id": event.data.get("guild_id"),
-                    "reactions": []
-                }, self)
+                message = Message.from_dict(
+                    {
+                        "id": event.data.get("message_id"),
+                        "channel_id": channel_id,
+                        "guild_id": guild_id,
+                        "reactions": [],
+                    },
+                    self,
+                )
 
         if add:
             self.dispatch(events.MessageReactionAdd(message=message, emoji=emoji, author=author, reaction=reaction))


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
<!-- Provide a clear and concise description of the purpose of this PR and why it should be merged -->
<!-- If your code adds or changes features, a usage example would be helpful -->


## Changes
<!-- List the changes you have made in a bullet-point format -->

- Updated `ReactionEvents._handle_message_reaction_change()` to check for correct channel permissions before attempting to fetch a message from Discord.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->
#1753 


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->

### Test the updated code thru a bot's handling of reaction changes:

- Create a channel in a discord server with your test bot, and disable the bot's "Read Message History" permission in it.
- Add the OS environment variables BOT_TOKEN and BOT_TEST_CHANNEL_ID (the id of your new channel)
- Run tests/test_bot.py
- In `test_reaction_events()`, you will need to react with the ✅ emoji to the bot's newly sent message.
- The test will work with the updated code, but throws an error `403 missing access` with the old code.

## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [x] I've ensured my code works on Python `3.10.x`
- [ ] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [x] I've added tests for my code, if applicable
- [x] I've updated / added  documentation, where applicable
