### PR TITLE
fix: Invite._process_dict incorrectly passed all data

### DIFF
--- a/interactions/models/discord/invite.py
+++ b/interactions/models/discord/invite.py
@@ -95,7 +95,8 @@ class Invite(ClientObject):
             data["stage_instance"] = StageInstance.from_dict(data, client)
 
         if "target_application" in data:
-            data["target_application"] = Application.from_dict(data, client)
+            app_data = data['target_application']
+            data["target_application"] = Application.from_dict(app_data, client)
 
         if "target_event_id" in data:
             data["scheduled_event"] = data["target_event_id"]

--- a/interactions/models/discord/invite.py
+++ b/interactions/models/discord/invite.py
@@ -95,7 +95,7 @@ class Invite(ClientObject):
             data["stage_instance"] = StageInstance.from_dict(data, client)
 
         if "target_application" in data:
-            app_data = data['target_application']
+            app_data = data["target_application"]
             data["target_application"] = Application.from_dict(app_data, client)
 
         if "target_event_id" in data:


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
<!-- Provide a clear and concise description of the purpose of this PR and why it should be merged -->
<!-- If your code adds or changes features, a usage example would be helpful -->


## Changes
<!-- List the changes you have made in a bullet-point format -->
- For invites of type "target_application" (activity invites), pass data['target_application'] into Application.from_dict() instead of the entire data dict

## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->
#1755 

## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->
Steps to Reproduce

 -   setup a @listen for a on_raw_gateway_event
 -   create a new voice channel (to ensure no invite has been created for it yet) in a guild with the bot
 -   give the bot admin perms (i dont know the specific perm that enables bots to view invites, but admin provides all)
 -   start a voice chat activity and right click on the voice chat in the sidebar and choose 'invite to join '
 -   view the error appear when this patch isn't applied!


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [x] I've ensured my code works on Python `3.10.x`
- [ ] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
