### PR TITLE
feat: add support for nsfw for ThreadChannel

### DIFF
--- a/interactions/models/discord/channel.py
+++ b/interactions/models/discord/channel.py
@@ -1901,6 +1901,10 @@ class ThreadChannel(BaseChannel, MessageableMixin, WebhookMixin):
         return self._client.cache.get_channel(self.parent_id)
 
     @property
+    def nsfw(self) -> bool:
+        return self.parent_channel.nsfw
+
+    @property
     def parent_message(self) -> Optional["Message"]:
         """The message this thread is a child of."""
         return self._client.cache.get_message(self.parent_id, self.id)


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [x] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
<!-- Provide a clear and concise description of the purpose of this PR and why it should be merged -->
<!-- If your code adds or changes features, a usage example would be helpful -->
 - added support for accessing the .nsfw property on channels inheriting from ThreadChannel
 - Discord doesn't let you change the "age restricted" setting on threads, they always inherit this setting from their parent channel.

## Changes
<!-- List the changes you have made in a bullet-point format -->
- add .nsfw property to ThreadChannel, inheriting from its parent Text Channel 

## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->

```
@slash_command(name="show", description="display this channels nsfw setting")
async def show(ctx: SlashContext):
    await ctx.send(str(ctx.channel.nsfw))
```
- Without this patch, running this command in a thread will raise `AttributeError: 'GuildPublicThread' object has no attribute 'nsfw'`

## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [x] I've ensured my code works on Python `3.10.x`
- [ ] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
