### PR TITLE
fix: Use raw `message_id` instead of ctx.message.id in wait_for_component

### DIFF
--- a/interactions/client/client.py
+++ b/interactions/client/client.py
@@ -1256,7 +1256,7 @@ class Client(
         async def _check(event: events.Component) -> bool:
             ctx: ComponentContext = event.ctx
             # if custom_ids is empty or there is a match
-            wanted_message = not message_ids or ctx.message.id in (
+            wanted_message = not message_ids or ctx.message_id in (
                 [message_ids] if isinstance(message_ids, int) else message_ids
             )
             wanted_component = not custom_ids or ctx.custom_id in custom_ids


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
<!-- Provide a clear and concise description of the purpose of this PR and why it should be merged -->
<!-- If your code adds or changes features, a usage example would be helpful -->

I've noticed that sometimes the Message will be None, throwing an error.  This usually happens when using wait_for_component on Ephemeral messages with a long or non-existent timeout.

This switches the ID check to directly reference the message_id, rather than going through a cache lookup that may fail.

## Changes
<!-- List the changes you have made in a bullet-point format -->
* Changed a dot to an underscore.

## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
