### PR TITLE
fix:  Actually place channel ids into cache.dm_channels

### DIFF
--- a/interactions/client/smart_cache.py
+++ b/interactions/client/smart_cache.py
@@ -550,6 +550,7 @@ class GlobalCache:
             data = await self._client.http.create_dm(user_id)
             channel = self.place_channel_data(data)
             channel_id = channel.id
+            self.place_dm_channel_id(user_id, channel_id)
         return channel_id
 
     async def fetch_dm_channel(self, user_id: "Snowflake_Type", *, force: bool = False) -> "DM":


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
After a lot of digging into why I was hitting "You are opening DMs too quickly" errors more than I should have been, I discovered that we never actually stored anything into the cache, and were hitting the API every single lookup.

This fixes that.


## Changes
* Adds a call to `place_dm_channel_id`

## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
