### PR TITLE
fix: Deprecation of default_permission in Application Command

### DIFF
--- a/interactions/client/utils/deserialise_app_cmds.py
+++ b/interactions/client/utils/deserialise_app_cmds.py
@@ -41,7 +41,9 @@ def deserialize_app_cmds(data: list[dict]) -> list["InteractionCommand"]:
         cmd_dict["scopes"] = [cmd_dict.pop("guild_id", const.GLOBAL_SCOPE)]
 
         del cmd_dict["version"]
-        del cmd_dict["default_permission"]
+        if hasattr(cmd_dict, "default_permission"):
+            del cmd_dict["default_permission"]
+
         cmd = command_mapping[cmd_type](**cmd_dict)  # type: ignore
 
         if options:


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
<!-- Provide a clear and concise description of the purpose of this PR and why it should be merged -->
<!-- If your code adds or changes features, a usage example would be helpful -->


## Changes
Created a check if default_permission still exist before deleting

## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [x] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [ ] I've run the `pre-commit` code linter over all edited files
- [ ] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
