### PR TITLE
fix: Use Sequence instead of List in wait_for_component hints

### DIFF
--- a/interactions/client/client.py
+++ b/interactions/client/client.py
@@ -1216,8 +1216,8 @@ class Client(
         messages: Optional[Union[Message, int, list]] = None,
         components: Optional[
             Union[
-                List[List[Union["BaseComponent", dict]]],
-                List[Union["BaseComponent", dict]],
+                Sequence[Sequence[Union["BaseComponent", dict]]],
+                Sequence[Union["BaseComponent", dict]],
                 "BaseComponent",
                 dict,
             ]

--- a/interactions/models/discord/components.py
+++ b/interactions/models/discord/components.py
@@ -1,7 +1,7 @@
 import contextlib
 import uuid
 from abc import abstractmethod
-from typing import Any, Dict, Iterator, List, Optional, Union, TYPE_CHECKING
+from typing import Any, Dict, Iterator, List, Optional, Sequence, Union, TYPE_CHECKING
 
 import attrs
 import discord_typings
@@ -840,7 +840,7 @@ def spread_to_rows(*components: Union[ActionRow, Button, StringSelectMenu], max_
     return ActionRow.split_components(*components, count_per_row=max_in_row)
 
 
-def get_components_ids(component: Union[str, dict, list, InteractiveComponent]) -> Iterator[str]:
+def get_components_ids(component: Union[str, dict, list, InteractiveComponent, Sequence]) -> Iterator[str]:
     """
     Creates a generator with the `custom_id` of a component or list of components.
 


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
Makes the function signature covariant, which fixes strict type hint errors


## Changes
<!-- List the changes you have made in a bullet-point format -->


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [x] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [ ] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
