### PR TITLE
fix: don't create asset with null hash in user banner

### DIFF
--- a/interactions/models/discord/user.py
+++ b/interactions/models/discord/user.py
@@ -171,7 +171,7 @@ class User(BaseUser):
         if any(field in data for field in ("banner", "accent_color", "avatar_decoration")):
             data["_fetched"] = True
 
-        if "banner" in data:
+        if data.get("banner", None):
             data["banner"] = Asset.from_path_hash(client, f"banners/{data['id']}/{{}}", data["banner"])
 
         if data.get("premium_type", None) is None:


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
<!-- Provide a clear and concise description of the purpose of this PR and why it should be merged -->
<!-- If your code adds or changes features, a usage example would be helpful -->
The `banner` field in the Discord API `User` object is both nullable and can be missing.

When a User is fetched with `force=True` to obtain the `banner` value, due to how the data is processed, an Asset with hash=None may be erroneously created whose url points to `None.png`.

This fix makes User correctly process the null `banner` such that User.banner would become `None` in that case, rather than `Asset(hash=None)`. The similar Member object processed `banner` correctly and is not affected by this bug.

## Changes
<!-- List the changes you have made in a bullet-point format -->
* Changed the `banner` field check in `interactions.models.discord.user:User` from `if "banner" in data` to `if data.get("banner", None)`.
  * This sets the object's `banner` value to its default of `None`.

## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->
Select a user with no banner.
* Bug: `Asset(_url='https://cdn.discordapp.com/banners/<id>/None', hash=None)`
* Fixed: `None`
```python
@slash_command(name="test", description="Test command")
@slash_option(name="user", description="User to view", opt_type=OptionType.USER, required=False)
async def test_cmd(ctx: SlashContext, user: Member | User | None = None):
  user = user or ctx.author
  fetched = await ctx.bot.fetch_user(user.id, force=True)
  if fetched:
    await ctx.send(str(fetched.banner))
```

## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [x] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [x] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
