### PR TITLE
fix: don't reconnect when http client is closed

### DIFF
--- a/interactions/api/gateway/gateway.py
+++ b/interactions/api/gateway/gateway.py
@@ -158,6 +158,10 @@ class GatewayClient(WebsocketClient):
             seq = msg.get("s")
             event = msg.get("t")
 
+            if op == MISSING:
+                # Internal no-op, ignore it.
+                continue
+
             if seq:
                 self.sequence = seq
 

--- a/interactions/api/gateway/websocket.py
+++ b/interactions/api/gateway/websocket.py
@@ -164,7 +164,7 @@ class WebsocketClient:
         serialized = FastJson.dumps(data)
         await self.send(serialized, bypass)
 
-    async def receive(self, force: bool = False) -> str:  # noqa: C901
+    async def receive(self, force: bool = False) -> dict:  # noqa: C901
         """
         Receive a full event payload from the WebSocket.
 
@@ -208,6 +208,14 @@ class WebsocketClient:
                     # is possible after all we can just wait for the event to be set.
                     await self._closed.wait()
                 else:
+                    if self.state.client.http.closed:
+                        # On aiohttp>=3.12.4, the aiohttp WebSocket client will always send a session
+                        # close message when the underlying HTTP connection is closed. We want to
+                        # ignore this to keep the behavior consistent with previous versions
+                        # of Python, so we return this to indicate that no message was received.
+                        # https://github.com/interactions-py/interactions.py/issues/1778
+                        return {"op": const.MISSING}
+
                     # This is an odd corner-case where the underlying socket connection was closed
                     # unexpectedly without communicating the WebSocket closing handshake. We'll have
                     # to reconnect ourselves.

--- a/interactions/api/http/http_client.py
+++ b/interactions/api/http/http_client.py
@@ -250,6 +250,17 @@ class HTTPClient(
             logger = constants.get_logger()
         self.logger = logger
 
+    @property
+    def closed(self) -> bool:
+        """
+        Returns whether the session is closed.
+
+        Returns:
+            True if the session is closed, False otherwise.
+
+        """
+        return self.__session is None or self.__session.closed
+
     def get_ratelimit(self, route: Route) -> BucketLock:
         """
         Get a route's rate limit bucket.


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
#1778 mentions an interesting bug that came up because of a bug fix from aiohttp. This is because, when a session closes, aiohttp will now dispatch a close event rather than abruptly ending. Our code was not expecting this possibility, and so when handling a pre-established edge case, it errored out.

This PR fixes any errors that come from such a behavior.

## Changes
- Add a new `closed` attribute to `HTTPClient`.
- Make `WebsocketClient` send an internal "no-op" op code if the websocket receives a `CLOSED` even and the HTTP client is closed.
  - Closing is already handled by other means later in the code. We have no need to implement actual behavior.
  - The internal op code may be controversial, but we should never get it under normal circumstances anyways.
- Make the no-op op code make `GatewayClient` simply ignore it.

## Related Issues
Closes #1778.

## Test Scenarios
```python
# Ensure aiohttp>=3.12.4
from interactions import Client
bot = Client()
bot.start("token") # Ctrl+C when running
```

## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
