### PR TITLE
feat: allow list operations on ContainerComponent

### DIFF
--- a/interactions/models/discord/components.py
+++ b/interactions/models/discord/components.py
@@ -1,7 +1,9 @@
+from collections import UserList
 import contextlib
 import uuid
 from abc import abstractmethod
-from typing import Any, Dict, Iterator, List, Optional, Sequence, Union, TYPE_CHECKING
+from typing import Any, Dict, Iterator, List, Optional, Sequence, Union, TYPE_CHECKING, overload
+from typing_extensions import Self
 
 import attrs
 import discord_typings
@@ -1092,7 +1094,12 @@ class SeparatorComponent(BaseComponent):
         }
 
 
-class ContainerComponent(BaseComponent):
+class ContainerComponent(
+    BaseComponent,
+    UserList[
+        ActionRow | SectionComponent | TextDisplayComponent | MediaGalleryComponent | FileComponent | SeparatorComponent
+    ],
+):
     """
     A top-level layout component. Containers are visually distinct from surrounding components and have an optional customizable color bar.
 
@@ -1103,10 +1110,6 @@ class ContainerComponent(BaseComponent):
         type Union[ComponentType, int]: The type of component, as defined by discord. This cannot be modified.
 
     """
-
-    components: list[
-        ActionRow | SectionComponent | TextDisplayComponent | MediaGalleryComponent | FileComponent | SeparatorComponent
-    ]
     accent_color: Optional[int] = None
     spoiler: bool = False
 
@@ -1121,13 +1124,86 @@ class ContainerComponent(BaseComponent):
         accent_color: Optional[int] = None,
         spoiler: bool = False,
     ):
-        self.components = list(components)
+        self.data = list(components)
         self.accent_color = accent_color
         self.spoiler = spoiler
         self.type = ComponentType.CONTAINER
 
+    @property
+    def components(
+        self,
+    ) -> list[
+        ActionRow | SectionComponent | TextDisplayComponent | MediaGalleryComponent | FileComponent | SeparatorComponent
+    ]:
+        return self.data
+
+    @components.setter
+    def components(
+        self,
+        value: list[
+            ActionRow
+            | SectionComponent
+            | TextDisplayComponent
+            | MediaGalleryComponent
+            | FileComponent
+            | SeparatorComponent
+        ],
+    ) -> None:
+        self.data = value
+
+    @overload
+    def __getitem__(
+        self, i: int
+    ) -> (
+        ActionRow | SectionComponent | TextDisplayComponent | MediaGalleryComponent | FileComponent | SeparatorComponent
+    ): ...
+
+    @overload
+    def __getitem__(self, i: slice) -> Self: ...
+
+    def __getitem__(
+        self, i: int | slice
+    ) -> (
+        Self
+        | ActionRow
+        | SectionComponent
+        | TextDisplayComponent
+        | MediaGalleryComponent
+        | FileComponent
+        | SeparatorComponent
+    ):
+        if isinstance(i, slice):
+            return self.__class__(*self.data[i], accent_color=self.accent_color, spoiler=self.spoiler)
+        return self.data[i]
+
+    def __add__(self, other: Any) -> Self:
+        if isinstance(other, ContainerComponent):
+            return self.__class__(*(self.data + other.data), accent_color=self.accent_color, spoiler=self.spoiler)
+        if isinstance(other, UserList):
+            return self.__class__(*(self.data + other.data), accent_color=self.accent_color, spoiler=self.spoiler)
+        if isinstance(other, type(self.data)):
+            return self.__class__(*(self.data + other), accent_color=self.accent_color, spoiler=self.spoiler)
+        return self.__class__(*(self.data + list(other)), accent_color=self.accent_color, spoiler=self.spoiler)
+
+    def __radd__(self, other: Any) -> Self:
+        if isinstance(other, ContainerComponent):
+            return self.__class__(*(self.data + other.data), accent_color=other.accent_color, spoiler=other.spoiler)
+        if isinstance(other, UserList):
+            return self.__class__(*(other.data + self.data), accent_color=self.accent_color, spoiler=self.spoiler)
+        if isinstance(other, type(self.data)):
+            return self.__class__(*(other + self.data), accent_color=self.accent_color, spoiler=self.spoiler)
+        return self.__class__(*(list(other) + self.data), accent_color=self.accent_color, spoiler=self.spoiler)
+
+    def __mul__(self, n: int) -> Self:
+        return self.__class__(*(self.data * n), accent_color=self.accent_color, spoiler=self.spoiler)
+
+    __rmul__ = __mul__
+
+    def copy(self) -> Self:
+        return self.__class__(*self.data, accent_color=self.accent_color, spoiler=self.spoiler)
+
     @classmethod
-    def from_dict(cls, data: dict) -> "ContainerComponent":
+    def from_dict(cls, data: dict) -> Self:
         return cls(
             *[BaseComponent.from_dict_factory(component) for component in data["components"]],
             accent_color=data.get("accent_color"),

--- a/interactions/models/discord/components.py
+++ b/interactions/models/discord/components.py
@@ -1110,6 +1110,7 @@ class ContainerComponent(
         type Union[ComponentType, int]: The type of component, as defined by discord. This cannot be modified.
 
     """
+
     accent_color: Optional[int] = None
     spoiler: bool = False
 


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [x] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
This PR allows using `ContainerComponent` similarly to a list.

Previously, if someone wanted to edit the components in a container after it was created, they would have to do something like:
```python
container = ContainerComponent(...)
container.components.append(...)
```

This is cumbersome for a common operation. This PR makes it so a shorthand can be used instead:
```python
container = ContainerComponent(...)
container.append(...)
```

The old method is still able to be used.

## Changes
- Make `ContainerComponent` into a subtype of `collections.UserList`.
  - To keep the `__init__` the same, `UserList` requires some function overriding have to be done to handle the multi-argument init.
  - `ContainerComponent` now has a `data` field because `UserList` uses that under the hood for list operations. `components` is now an alias of `data`.


## Test Scenarios
```python
container = ContainerComponent(...)
container.append(...)
```


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
