### PR TITLE
fix: properly convert values when using ranges for hybrid commands

### DIFF
--- a/interactions/ext/hybrid_commands/hybrid_slash.py
+++ b/interactions/ext/hybrid_commands/hybrid_slash.py
@@ -134,7 +134,7 @@ class RangeConverter(Converter[float | int]):
 
     async def convert(self, ctx: BaseContext, argument: str) -> float | int:
         try:
-            converted: float | int = await maybe_coroutine(self.number_convert, ctx, argument)
+            converted: float | int = await maybe_coroutine(self.number_convert, argument)
 
             if self.min_value and converted < self.min_value:
                 raise BadArgument(f'Value "{argument}" is less than {self.min_value}.')


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
This PR fixes an issue where numeric options with `min_value` or `max_value` incorrectly errored out when using prefixed command variants of hybrid commands. Oops 😅.


## Changes
- Do not pass in `ctx` when converting a string to a number for `RangeConverter`.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
```python
@hybrid_slash_command()
@slash_option(
    "option",
    description="An integer option",
    opt_type=OptionType.INTEGER,
    required=True,
    min_value=1,
    max_value=10,
)
async def test(ctx: HybridContext, option: int):
    await ctx.send(f"Option: {option}")
```

## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
