### PR TITLE
feat: add external apps and pin message permissions

### DIFF
--- a/interactions/models/discord/enums.py
+++ b/interactions/models/discord/enums.py
@@ -606,6 +606,10 @@ class Permissions(DiscordIntFlag):  # type: ignore
     """Allows for sending audio messages"""
     SEND_POLLS = 1 << 49
     """Allows sending polls"""
+    USE_EXTERNAL_APPS = 1 << 50
+    """Allows user-installed applications to send public responses"""
+    PIN_MESSAGES = 1 << 51
+    """Allows for pinning messages"""
 
     # Shortcuts/grouping/aliases
     REQUIRES_MFA = (


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [x] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
This is a simple PR that adds `USE_EXTERNAL_APPS` and `PIN_MESSAGES` to `Permissions`.

## Changes
See above.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
```python
Permissions.USE_EXTERNAL_APPS
# or
Permissions.PIN_MESSAGES
```


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
