### PR TITLE
ci: don't install mkdocs material insiders

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,6 @@ jobs:
           key: ${{ github.ref }}
           path: .cache
       - run: pip install -e .[docs]
-      - run: pip install git+https://${GH_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git
       - run: mkdocs gh-deploy
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [x] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
For a while now, the docs CI hasn't worked because it's trying to use `mkdocs-material-insider`, which we no longer have access to. We're not using anything from Insider that is critical (it's mostly the `privacy` plugin and a few tweaks to the looks), so this PR removes it altogether from our CI.

## Changes
- Remove installing Insider from the CI.

## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [ ] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
