### PR TITLE
fix: Hold running tasks within a Task, so the task doesn't get garbage collected before it completes

### DIFF
--- a/interactions/models/internal/tasks/task.py
+++ b/interactions/models/internal/tasks/task.py
@@ -96,6 +96,7 @@ class Task:
 
     async def _task_loop(self, *args, **kwargs) -> None:
         """The main task loop to fire the task at the specified time based on triggers configured."""
+        running = set()
         while not self._stop.is_set():
             fire_time = self.trigger.next_fire()
             if fire_time is None:
@@ -107,7 +108,9 @@ class Task:
             if future in done:
                 return None
 
-            self._fire(fire_time, *args, **kwargs)
+            task = self._fire(fire_time, *args, **kwargs)
+            running.add(task)
+            task.add_done_callback(running.discard)
 
     def start(self, *args, **kwargs) -> None:
         """Start this task."""


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
I noticed that one of my long-running tasks was never completing, and just kinda stopped silently after about an hour of execution.  Upon some digging, I found the note in https://docs.python.org/3.10/library/asyncio-task.html#asyncio.create_task that asyncio uses weak references, and that the fire-and-forget method we're using is liable to garbage collection.

## Changes
* Implemented the recommendation straight from the python documentation


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->
Currently testing in prod, will see if reliability goes up


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [x] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [ ] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
