### PR TITLE
fix: typo in _chunk_cache on line 712 of guild.py

### DIFF
--- a/interactions/models/discord/guild.py
+++ b/interactions/models/discord/guild.py
@@ -711,7 +711,7 @@ class Guild(BaseGuild):
                 s = time.monotonic()
 
         total_time = time.perf_counter() - start_time
-        self.chunk_cache = []
+        self._chunk_cache = []
         self.logger.info(f"Cached members for {self.id} in {total_time:.2f} seconds")
         self.chunked.set()
 


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
There is typo in self._chunk_cache/self.chunk_cache in guild.py which creates a memory leak, as the cache never clears. 


## Changes

- renamed variable chunk_cache to _chunk_cache


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [x] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
