### PR TITLE
feat: improve usage of v2 components

### DIFF
--- a/interactions/models/discord/components.py
+++ b/interactions/models/discord/components.py
@@ -13,6 +13,7 @@ from interactions.models.discord.snowflake import Snowflake, Snowflake_Type
 from interactions.client.const import ACTION_ROW_MAX_ITEMS, MISSING
 from interactions.client.mixins.serialization import DictSerializationMixin
 from interactions.models.discord.base import DiscordObject
+from interactions.models.discord.color import Color, process_color
 from interactions.models.discord.emoji import PartialEmoji, process_emoji
 from interactions.models.discord.enums import (
     ButtonStyle,
@@ -861,8 +862,14 @@ class SectionComponent(BaseComponent):
     accessory: "Button | ThumbnailComponent"
 
     def __init__(
-        self, *, components: "list[TextDisplayComponent] | None" = None, accessory: "Button | ThumbnailComponent"
+        self,
+        *,
+        components: "list[TextDisplayComponent] | TextDisplayComponent | None" = None,
+        accessory: "Button | ThumbnailComponent",
     ):
+        if isinstance(components, TextDisplayComponent):
+            components = [components]
+
         self.components = components or []
         self.accessory = accessory
         self.type = ComponentType.SECTION
@@ -930,8 +937,8 @@ class ThumbnailComponent(BaseComponent):
     description: Optional[str] = None
     spoiler: bool = False
 
-    def __init__(self, media: UnfurledMediaItem, *, description: Optional[str] = None, spoiler: bool = False):
-        self.media = media
+    def __init__(self, media: UnfurledMediaItem | str, *, description: Optional[str] = None, spoiler: bool = False):
+        self.media = media if isinstance(media, UnfurledMediaItem) else UnfurledMediaItem(url=media)
         self.description = description
         self.spoiler = spoiler
         self.type = ComponentType.THUMBNAIL
@@ -972,8 +979,8 @@ class MediaGalleryItem(DictSerializationMixin):
     description: Optional[str] = None
     spoiler: bool = False
 
-    def __init__(self, media: UnfurledMediaItem, *, description: Optional[str] = None, spoiler: bool = False):
-        self.media = media
+    def __init__(self, media: UnfurledMediaItem | str, *, description: Optional[str] = None, spoiler: bool = False):
+        self.media = media if isinstance(media, UnfurledMediaItem) else UnfurledMediaItem(url=media)
         self.description = description
         self.spoiler = spoiler
 
@@ -1008,8 +1015,8 @@ class MediaGalleryComponent(BaseComponent):
 
     items: list[MediaGalleryItem]
 
-    def __init__(self, items: list[MediaGalleryItem] | None = None):
-        self.items = items or []
+    def __init__(self, items: list[MediaGalleryItem | str] | None = None):
+        self.items = [i if isinstance(i, MediaGalleryItem) else MediaGalleryItem(i) for i in items] if items else []
         self.type = ComponentType.MEDIA_GALLERY
 
     @classmethod
@@ -1040,8 +1047,8 @@ class FileComponent(BaseComponent):
     file: UnfurledMediaItem
     spoiler: bool = False
 
-    def __init__(self, file: UnfurledMediaItem, *, spoiler: bool = False):
-        self.file = file
+    def __init__(self, file: UnfurledMediaItem | str, *, spoiler: bool = False):
+        self.file = file if isinstance(file, UnfurledMediaItem) else UnfurledMediaItem(url=file)
         self.spoiler = spoiler
         self.type = ComponentType.FILE
 
@@ -1105,7 +1112,7 @@ class ContainerComponent(
 
     Attributes:
         components list[ActionRow | SectionComponent | TextDisplayComponent | MediaGalleryComponent | FileComponent | SeparatorComponent]: The components to include in this container.
-        accent_color Optional[int]: The color of the container, as a hex value, default None.
+        accent_color Optional[int]: The color of the container as an integer value, default None.
         spoiler bool: Whether the container should be marked as a spoiler, default false.
         type Union[ComponentType, int]: The type of component, as defined by discord. This cannot be modified.
 
@@ -1122,11 +1129,11 @@ class ContainerComponent(
         | MediaGalleryComponent
         | FileComponent
         | SeparatorComponent,
-        accent_color: Optional[int] = None,
+        accent_color: Optional[int | str | Color] = None,
         spoiler: bool = False,
     ):
         self.data = list(components)
-        self.accent_color = accent_color
+        self.accent_color = process_color(accent_color)
         self.spoiler = spoiler
         self.type = ComponentType.CONTAINER
 


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [x] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
This PR adds some automatic conversion of certain values when they are passed to the `__init__` of some component v2 classes. This results in a much improved usage experience when using these classes.


## Changes
- Make `ContainerComponent`'s accent color take in a `str` or `Color`.
- Make `FileComponent`, `MediaGalleryItem`, and `ThumbnailComponent` able to take in a `str` instead of requiring a `UnfurledMediaItem`.
- Make `MediaGalleryComponent` able to handle a list of `str`s, converting them to a list of `UnfurledMediaItem`.
- Make `SectionComponent`'s `components` able to take in a singular component, instead of requiring a list.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
```python
import interactions as ipy

@ipy.slash_command()
async def test(ctx: ipy.SlashContext) -> None:
    container = ipy.ContainerComponent(accent_color=ipy.BrandColors.BLURPLE)
    container.append(
        ipy.SectionComponent(
            components=ipy.TextDisplayComponent("This is a test TextDisplayComponent."),
            accessory=ipy.ThumbnailComponent(
                "https://avatars.githubusercontent.com/u/98242689?s=500&v=4"
            ),
        )
    )
    container.append(
        ipy.FileComponent(
            "attachment://test.py",
        )
    )
    container.append(
        ipy.MediaGalleryComponent(
            [
                "https://interactions-py.github.io/interactions.py/images/PrefixedCommands/OptionalConversion.png",
                ipy.MediaGalleryItem(
                    "https://interactions-py.github.io/interactions.py/images/PrefixedCommands/HelpCommand.png"
                ),
            ]
        )
    )
    await ctx.send(components=container, file=ipy.File("test.py"))
```


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [x] I've ensured my code works on Python `3.10.x`
- [ ] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [x] I've updated / added  documentation, where applicable
