### PR TITLE
refactor: replace asyncio.iscoroutinefunction()

### DIFF
--- a/interactions/client/client.py
+++ b/interactions/client/client.py
@@ -451,7 +451,7 @@ class Client(
 
         # callbacks
         if global_pre_run_callback:
-            if asyncio.iscoroutinefunction(global_pre_run_callback):
+            if inspect.iscoroutinefunction(global_pre_run_callback):
                 self.pre_run_callback: Callable[..., Coroutine] = global_pre_run_callback
             else:
                 raise TypeError("Callback must be a coroutine")
@@ -459,7 +459,7 @@ class Client(
             self.pre_run_callback = MISSING
 
         if global_post_run_callback:
-            if asyncio.iscoroutinefunction(global_post_run_callback):
+            if inspect.iscoroutinefunction(global_post_run_callback):
                 self.post_run_callback: Callable[..., Coroutine] = global_post_run_callback
             else:
                 raise TypeError("Callback must be a coroutine")
@@ -1267,7 +1267,7 @@ class Client(
             )
             wanted_component = not custom_ids or ctx.custom_id in custom_ids
             if wanted_message and wanted_component:
-                if asyncio.iscoroutinefunction(check):
+                if inspect.iscoroutinefunction(check):
                     return bool(check is None or await check(event))
                 return bool(check is None or check(event))
             return False

--- a/interactions/ext/hybrid_commands/hybrid_slash.py
+++ b/interactions/ext/hybrid_commands/hybrid_slash.py
@@ -1,4 +1,3 @@
-import asyncio
 import inspect
 from typing import Any, Callable, List, Optional, Union, TYPE_CHECKING, Awaitable, Annotated, get_origin, get_args
 
@@ -291,7 +290,7 @@ class HybridSlashCommand(SlashCommand):
         def wrapper(call: AsyncCallable) -> "HybridSlashCommand":
             nonlocal sub_cmd_name, sub_cmd_description
 
-            if not asyncio.iscoroutinefunction(call):
+            if not inspect.iscoroutinefunction(call):
                 raise TypeError("Subcommand must be coroutine")
 
             if sub_cmd_description is MISSING:
@@ -518,7 +517,7 @@ def hybrid_slash_command(
     """
 
     def wrapper(func: AsyncCallable) -> HybridSlashCommand:
-        if not asyncio.iscoroutinefunction(func):
+        if not inspect.iscoroutinefunction(func):
             raise ValueError("Commands must be coroutines")
 
         perm = default_member_permissions
@@ -608,7 +607,7 @@ def hybrid_slash_subcommand(
     """
 
     def wrapper(func: AsyncCallable) -> HybridSlashCommand:
-        if not asyncio.iscoroutinefunction(func):
+        if not inspect.iscoroutinefunction(func):
             raise ValueError("Commands must be coroutines")
 
         _name = name

--- a/interactions/models/internal/application_commands.py
+++ b/interactions/models/internal/application_commands.py
@@ -1,4 +1,3 @@
-import asyncio
 from collections import defaultdict
 import inspect
 import re
@@ -765,7 +764,7 @@ class SlashCommand(InteractionCommand):
         """A decorator to declare a coroutine as an option autocomplete."""
 
         def wrapper(call: Callable[..., Coroutine]) -> Callable[..., Coroutine]:
-            if not asyncio.iscoroutinefunction(call):
+            if not inspect.iscoroutinefunction(call):
                 raise TypeError("autocomplete must be coroutine")
             self.autocomplete_callbacks[option_name] = call
 
@@ -811,7 +810,7 @@ class SlashCommand(InteractionCommand):
         def wrapper(call: Callable[..., Coroutine]) -> "SlashCommand":
             nonlocal sub_cmd_name, sub_cmd_description
 
-            if not asyncio.iscoroutinefunction(call):
+            if not inspect.iscoroutinefunction(call):
                 raise TypeError("Subcommand must be coroutine")
 
             if sub_cmd_description is MISSING:
@@ -940,7 +939,7 @@ def global_autocomplete(option_name: str) -> Callable[[AsyncCallable], GlobalAut
     """
 
     def decorator(func: Callable) -> GlobalAutoComplete:
-        if not asyncio.iscoroutinefunction(func):
+        if not inspect.iscoroutinefunction(func):
             raise TypeError("Autocomplete functions must be coroutines")
         return GlobalAutoComplete(option_name, func)
 
@@ -992,7 +991,7 @@ def slash_command(
     """
 
     def wrapper(func: AsyncCallable) -> SlashCommand:
-        if not asyncio.iscoroutinefunction(func):
+        if not inspect.iscoroutinefunction(func):
             raise ValueError("Commands must be coroutines")
 
         perm = default_member_permissions
@@ -1076,7 +1075,7 @@ def subcommand(
     """
 
     def wrapper(func: AsyncCallable) -> SlashCommand:
-        if not asyncio.iscoroutinefunction(func):
+        if not inspect.iscoroutinefunction(func):
             raise ValueError("Commands must be coroutines")
 
         _name = name
@@ -1136,7 +1135,7 @@ def context_menu(
     """
 
     def wrapper(func: AsyncCallable) -> ContextMenu:
-        if not asyncio.iscoroutinefunction(func):
+        if not inspect.iscoroutinefunction(func):
             raise ValueError("Commands must be coroutines")
 
         perm = default_member_permissions
@@ -1255,7 +1254,7 @@ def component_callback(*custom_id: str | re.Pattern) -> Callable[[AsyncCallable]
     def wrapper(func: AsyncCallable) -> ComponentCommand:
         resolved_custom_id = custom_id or [func.__name__]
 
-        if not asyncio.iscoroutinefunction(func):
+        if not inspect.iscoroutinefunction(func):
             raise ValueError("Commands must be coroutines")
 
         return ComponentCommand(
@@ -1288,7 +1287,7 @@ def modal_callback(*custom_id: str | re.Pattern) -> Callable[[AsyncCallable], Mo
     def wrapper(func: AsyncCallable) -> ModalCommand:
         resolved_custom_id = custom_id or [func.__name__]
 
-        if not asyncio.iscoroutinefunction(func):
+        if not inspect.iscoroutinefunction(func):
             raise ValueError("Commands must be coroutines")
 
         return ModalCommand(name=f"ModalCallback::{resolved_custom_id}", callback=func, listeners=resolved_custom_id)

--- a/interactions/models/internal/command.py
+++ b/interactions/models/internal/command.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import asyncio
+import inspect
 import typing
 from typing import (
     Annotated,
@@ -239,21 +239,21 @@ class BaseCommand(DictSerializationMixin, CallbackObject):
 
     def error(self, call: Callable[..., Coroutine]) -> Callable[..., Coroutine]:
         """A decorator to declare a coroutine as one that will be run upon an error."""
-        if not asyncio.iscoroutinefunction(call):
+        if not inspect.iscoroutinefunction(call):
             raise TypeError("Error handler must be coroutine")
         self.error_callback = call
         return call
 
     def pre_run(self, call: Callable[..., Coroutine]) -> Callable[..., Coroutine]:
         """A decorator to declare a coroutine as one that will be run before the command."""
-        if not asyncio.iscoroutinefunction(call):
+        if not inspect.iscoroutinefunction(call):
             raise TypeError("pre_run must be coroutine")
         self.pre_run_callback = call
         return call
 
     def post_run(self, call: Callable[..., Coroutine]) -> Callable[..., Coroutine]:
         """A decorator to declare a coroutine as one that will be run after the command has."""
-        if not asyncio.iscoroutinefunction(call):
+        if not inspect.iscoroutinefunction(call):
             raise TypeError("post_run must be coroutine")
         self.post_run_callback = call
         return call

--- a/interactions/models/internal/extension.py
+++ b/interactions/models/internal/extension.py
@@ -1,4 +1,3 @@
-import asyncio
 import inspect
 import typing
 from typing import Awaitable, Dict, List, TYPE_CHECKING, Callable, Coroutine, Optional
@@ -225,7 +224,7 @@ class Extension:
             coroutine: The coroutine to use as a check
 
         """
-        if not asyncio.iscoroutinefunction(coroutine):
+        if not inspect.iscoroutinefunction(coroutine):
             raise TypeError("Check must be a coroutine")
 
         if not self.extension_checks:
@@ -253,7 +252,7 @@ class Extension:
             coroutine: The coroutine to run
 
         """
-        if not asyncio.iscoroutinefunction(coroutine):
+        if not inspect.iscoroutinefunction(coroutine):
             raise TypeError("Callback must be a coroutine")
 
         if not self.extension_prerun:
@@ -277,7 +276,7 @@ class Extension:
             coroutine: The coroutine to run
 
         """
-        if not asyncio.iscoroutinefunction(coroutine):
+        if not inspect.iscoroutinefunction(coroutine):
             raise TypeError("Callback must be a coroutine")
 
         if not self.extension_postrun:
@@ -297,7 +296,7 @@ class Extension:
             coroutine: The coroutine to run
 
         """
-        if not asyncio.iscoroutinefunction(coroutine):
+        if not inspect.iscoroutinefunction(coroutine):
             raise TypeError("Callback must be a coroutine")
 
         if self.extension_error:

--- a/interactions/models/internal/listener.py
+++ b/interactions/models/internal/listener.py
@@ -1,4 +1,3 @@
-import asyncio
 import inspect
 from typing import Callable
 
@@ -75,7 +74,7 @@ class Listener(CallbackObject):
         """
 
         def wrapper(coro: AsyncCallable) -> "Listener":
-            if not asyncio.iscoroutinefunction(coro):
+            if not inspect.iscoroutinefunction(coro):
                 raise TypeError("Listener must be a coroutine")
 
             name = event_name

--- a/interactions/models/internal/wait.py
+++ b/interactions/models/internal/wait.py
@@ -1,4 +1,5 @@
-from asyncio import Future, iscoroutinefunction
+from asyncio import Future
+from inspect import iscoroutinefunction
 from typing import Callable, Optional, Union, Awaitable
 
 __all__ = ("Wait",)


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [ ] Bugfix
- [ ] Documentation update
- [x] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
Replaces all instances of `asyncio.iscoroutinefunction()` with the equivalent `inspect.iscoroutinefunction()`. The asyncio counterpart is deprecated in 3.14.


## Changes
<!-- List the changes you have made in a bullet-point format -->
* Changed `asyncio.iscoroutinefunction()` to `inspect.iscoroutinefunction()`, affecting 7 files.


## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [x] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [ ] I've updated / added  documentation, where applicable
