### PR TITLE
docs: fix documentation build

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,7 +96,8 @@ extra_javascript:
 plugins:
   - search
   - awesome-pages
-  - autorefs
+  - autorefs:
+      resolve_closest: True
   - git-revision-date-localized:
       fallback_to_build_date: true
       enable_creation_date: true
@@ -108,14 +109,14 @@ plugins:
       enable_inventory: true
       handlers:
         python:
-          selection:
+          options:
             inherited_members: True
             filters:
               - "!^_"
-          rendering:
-            members_order: source
+            members_order: alphabetical
             show_bases: True
             show_root_toc_entry: False
+            show_symbol_type_toc: True
             group_by_category: True
             heading_level: 3
             show_if_no_docstring: True

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,5 +1,14 @@
 enum-tools[sphinx]
 furo
+mkdocs>=1.6,<2
+mkdocs-autorefs
+mkdocs-awesome-pages-plugin
+mkdocs-git-committers-plugin-2
+mkdocs-git-revision-date-localized-plugin
+mkdocs-material
+mkdocs-minify-plugin
+mkdocstrings
+mkdocstrings-python
 Sphinx
 sphinx-copybutton
 sphinx-hoverxref

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ extras_require["docs"] = extras_require["all"] + [
     "mkdocs-minify-plugin",
     "mkdocs-git-committers-plugin-2",
     "mkdocs-git-revision-date-localized-plugin",
-    "griffe==0.25",
+    "griffe",
 ]
 extras_require["tests"] = [
     "pytest",


### PR DESCRIPTION
## Pull Request Type
<!-- Check the appropriate option -->

- [ ] Feature addition
- [x] Bugfix
- [x] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
Fixes errors I encountered while building the documentation to update the docs. I suspect the errors I got (most specifically deprecated options in `mkdocs.yml`) explains why the `docs-builder` action during the release of 5.16.0 failed: `mkdocstrings` removed the config keys `selection` and `rendering`, now combining them into one `options` key. Also, the build no longer works with `griffe==0.25`.

Synchronized `requirements-docs.txt` and `setup.py` to the actual requirements (the former did not list the mkdocs requirements). The version pinning on `griffe` that was in `setup.py` is removed; `mkdocstrings-python` now requires a much later version of `griffe`.

Edited some mkdocs options to resolve some little things (detalied in Changes).

## Changes
<!-- List the changes you have made in a bullet-point format -->
* Added mkdocs and its plugins in use to `requirements-docs.txt`.
* Removed version pin on `griffe` in `setup.py`.
* Set the following mkdocs options:
  * autorefs: Set `resolve_closest` to resolve "multiple primary URL" warnings caused by the monopage.
  * mkdocstrings-python: Set `members_order` to alphabetical to match the currently live API reference.
  * mkdocstrings-python: Set `show_symbol_type_toc` to distinguish methods from attributes in Table of Contents, as the parentheses in ToC (e.g. `wait_for_component()`) are no longer present in the latest version of mkdocstrings-python.

## Related Issues
<!-- If this PR is related to any open issues, please mention them using "#ISSUENUMBER" -->


## Test Scenarios
<!-- Provide clear instructions on how to test your changes, where applicable - if no tests are required, explain why -->


## Python Compatibility
<!-- Testing 3.11 is not strictly required, but it would be nice if you could confirm that it works. -->
- [ ] I've ensured my code works on Python `3.10.x`
- [ ] I've ensured my code works on Python `3.11.x`


## Checklist
<!-- If you have not completed all of the following, there is a good chance your PR will not be merged. -->
- [x] I've run the `pre-commit` code linter over all edited files
- [ ] I've tested my changes on supported Python versions
- [ ] I've added tests for my code, if applicable
- [x] I've updated / added  documentation, where applicable